### PR TITLE
TT-17321 REST-as-MCP gateway runtime and admin lifecycle

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1543,6 +1543,12 @@ func (gw *Gateway) handleDeleteAPI(apiID string) (interface{}, int) {
 		return resp, code
 	}
 
+	if !spec.IsMCPManaged() {
+		if pairedProxyIDs := gw.pairedMCPProxyIDsReferencingRESTSource(apiID); len(pairedProxyIDs) > 0 {
+			return apiError("API is referenced by paired MCP proxies: " + strings.Join(pairedProxyIDs, ", ")), http.StatusConflict
+		}
+	}
+
 	fs := afero.NewOsFs()
 
 	if spec.IsOAS {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -719,6 +719,36 @@ func (a APIDefinitionLoader) GetMCPFilepath(path string) string {
 	return strings.TrimSuffix(path, ".json") + "-mcp.json"
 }
 
+func (a APIDefinitionLoader) isOASCompanionFile(path string) bool {
+	var apiDefPath string
+	switch {
+	case strings.HasSuffix(path, "-oas.json"):
+		apiDefPath = strings.TrimSuffix(path, "-oas.json") + ".json"
+	case strings.HasSuffix(path, "-mcp.json"):
+		apiDefPath = strings.TrimSuffix(path, "-mcp.json") + ".json"
+	default:
+		return false
+	}
+
+	if _, err := os.Stat(apiDefPath); err != nil {
+		return false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+
+	var marker struct {
+		OpenAPI string `json:"openapi"`
+		Swagger string `json:"swagger"`
+	}
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return false
+	}
+	return marker.OpenAPI != "" || marker.Swagger != ""
+}
+
 // FromDir will load APIDefinitions from a directory on the filesystem. Definitions need
 // to be the JSON representation of APIDefinition object
 func (a APIDefinitionLoader) FromDir(dir string) []*APISpec {
@@ -727,7 +757,7 @@ func (a APIDefinitionLoader) FromDir(dir string) []*APISpec {
 	paths, _ := filepath.Glob(filepath.Join(dir, "*.json"))
 	for _, path := range paths {
 		// Skip companion files (loaded separately)
-		if strings.HasSuffix(path, "-oas.json") || strings.HasSuffix(path, "-mcp.json") {
+		if a.isOASCompanionFile(path) {
 			continue
 		}
 

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -3052,3 +3052,47 @@ func TestLoadDefFromFilePath(t *testing.T) {
 		assert.Nil(t, spec)
 	})
 }
+
+func TestAPIDefinitionLoaderFromDir_LoadsAPIDefinitionEndingWithCompanionSuffix(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "api_def_suffix_test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	apiID := "proxy-over-mcp"
+	def := apidef.APIDefinition{
+		Name:  apiID,
+		APIID: apiID,
+		IsOAS: true,
+		Proxy: apidef.ProxyConfig{
+			ListenPath: "/proxy-over-mcp/",
+			TargetURL:  "https://example.org/mcp",
+		},
+	}
+	def.MarkAsMCP()
+
+	apiData, err := json.Marshal(def)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, apiID+".json"), apiData, 0644)
+	assert.NoError(t, err)
+
+	oasDoc := &oas.OAS{T: openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: apiID, Version: "1.0.0"},
+		Paths:   openapi3.NewPaths(),
+	}}
+	oasData, err := json.Marshal(oasDoc)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, apiID+"-mcp.json"), oasData, 0644)
+	assert.NoError(t, err)
+
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.SetConfig(config.Config{})
+	loader := APIDefinitionLoader{Gw: gw}
+	specs := loader.FromDir(tmpDir)
+
+	assert.Len(t, specs, 1)
+	if assert.NotEmpty(t, specs) {
+		assert.Equal(t, apiID, specs[0].APIID)
+		assert.NotNil(t, specs[0].OAS)
+	}
+}

--- a/gateway/api_healthcheck.go
+++ b/gateway/api_healthcheck.go
@@ -39,6 +39,9 @@ type DefaultHealthChecker struct {
 }
 
 func (h *DefaultHealthChecker) Init(storeType storage.Handler) {
+	if h.Gw == nil {
+		return
+	}
 	if !h.Gw.GetConfig().HealthCheck.EnableHealthChecks {
 		return
 	}

--- a/gateway/api_helpers.go
+++ b/gateway/api_helpers.go
@@ -20,7 +20,7 @@ type apiFilterFunc func(*APISpec) bool
 type apiTypeCheck func(*APISpec) error
 
 func isOASNotMCP(spec *APISpec) bool {
-	return spec != nil && spec.IsOAS && !mcpManaged(spec)
+	return spec != nil && spec.IsOAS && !spec.IsSyntheticMCPAdapter() && !mcpManaged(spec)
 }
 
 func typeCheckFunc(name string, predicate apiFilterFunc) apiTypeCheck {
@@ -40,7 +40,7 @@ func mcpManaged(spec *APISpec) bool {
 	if spec == nil || spec.APIDefinition == nil {
 		return false
 	}
-	return spec.IsMCPManaged()
+	return !spec.IsSyntheticMCPAdapter() && spec.IsMCPManaged()
 }
 
 func (gw *Gateway) setBaseAPIIDHeader(w http.ResponseWriter, oasObj *oas.OAS) {

--- a/gateway/api_helpers.go
+++ b/gateway/api_helpers.go
@@ -20,7 +20,7 @@ type apiFilterFunc func(*APISpec) bool
 type apiTypeCheck func(*APISpec) error
 
 func isOASNotMCP(spec *APISpec) bool {
-	return spec != nil && spec.IsOAS && !spec.IsSyntheticMCPAdapter() && !mcpManaged(spec)
+	return spec != nil && spec.IsOAS && !spec.IsSyntheticMCPAdapter() && !mcpProxy(spec)
 }
 
 func typeCheckFunc(name string, predicate apiFilterFunc) apiTypeCheck {
@@ -33,10 +33,13 @@ func typeCheckFunc(name string, predicate apiFilterFunc) apiTypeCheck {
 }
 
 var (
-	mcpTypeCheck = typeCheckFunc("MCP Proxy", mcpManaged)
+	mcpTypeCheck = typeCheckFunc("MCP Proxy", mcpProxy)
 )
 
-func mcpManaged(spec *APISpec) bool {
+// mcpProxy reports whether spec is a caller-facing MCP-managed API. Synthetic
+// REST-as-MCP adapters are MCP internals and must not be exposed as MCP proxies
+// in admin/public API listings.
+func mcpProxy(spec *APISpec) bool {
 	if spec == nil || spec.APIDefinition == nil {
 		return false
 	}

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/httputil"
+	"github.com/TykTechnologies/tyk/internal/mcp/pairing"
 	"github.com/TykTechnologies/tyk/internal/otel"
 	"github.com/TykTechnologies/tyk/internal/service/newrelic"
 )
@@ -358,6 +359,7 @@ func (gw *Gateway) processSpec(
 	gw.mwAppendEnabled(&chainArray, &MiddlewareContextVars{BaseMiddleware: baseMid.Copy()})
 	gw.mwAppendEnabled(&chainArray, &TrackEndpointMiddleware{baseMid.Copy()})
 	gw.mwAppendEnabled(&chainArray, &PRMMiddleware{BaseMiddleware: baseMid.Copy()})
+	gw.mwAppendEnabled(&chainArray, &MCPLoopAuthBypassMiddleware{BaseMiddleware: baseMid.Copy()})
 
 	// Track auth middlewares for OR wrapper
 	var authMiddlewares []TykMiddleware
@@ -527,6 +529,7 @@ func (gw *Gateway) processSpec(
 
 	gw.mwAppendEnabled(&chainArray, &OAuth2Middleware{BaseMiddleware: baseMid.Copy()})
 	gw.mwAppendEnabled(&chainArray, getOAuth2ExchangeMw(baseMid.Copy()))
+	gw.mwAppendEnabled(&chainArray, &MCPLoopAuthRestoreMiddleware{BaseMiddleware: baseMid.Copy()})
 
 	gw.mwAppendEnabled(&chainArray, &RateLimitForAPI{BaseMiddleware: baseMid.Copy(), quotaKey: options.quotaKey})
 	gw.mwAppendEnabled(&chainArray, &GraphQLMiddleware{BaseMiddleware: baseMid.Copy()})
@@ -764,7 +767,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if d.SH.Spec.target.Scheme == "tyk" {
-		handler, _, found := d.Gw.findInternalHttpHandlerByNameOrID(d.SH.Spec.target.Host)
+		handler, _, found := d.Gw.findInternalHTTPHandlerForLoop(d.SH.Spec.target.Host, d.SH.Spec, r)
 
 		if !found {
 			handler := ErrorHandler{d.SH.Base()}
@@ -1213,6 +1216,15 @@ func listenPathLength(listenPath string) int {
 // Create the individual API (app) specs based on live configurations and assign middleware
 func (gw *Gateway) loadApps(specs []*APISpec) {
 	mainLog.Info("Loading API configurations.")
+
+	synthesizedSpecs, mcpPairingSnapshot, err := synthesizeMCPAdapterSpecs(specs, gw.currentSyntheticMCPAdapterSpecs())
+	if err != nil {
+		mainLog.WithError(err).Error("failed to synthesize REST-as-MCP adapters")
+		gw.mcpPairingIndex.Set(pairing.Snapshot{})
+	} else {
+		specs = synthesizedSpecs
+		gw.mcpPairingIndex.Set(mcpPairingSnapshot)
+	}
 
 	// Only build usage map in RPC mode (when tracker exists)
 	if gw.certUsageTracker != nil {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -14,7 +14,10 @@ func (gw *Gateway) GetLoadedAPIIDs() []model.LoadedAPIInfo {
 	defer gw.apisMu.RUnlock()
 
 	apis := make([]model.LoadedAPIInfo, 0, len(gw.apisByID))
-	for apiID := range gw.apisByID {
+	for apiID, spec := range gw.apisByID {
+		if spec != nil && spec.IsSyntheticMCPAdapter() {
+			continue
+		}
 		apis = append(apis, model.LoadedAPIInfo{
 			APIID: apiID,
 		})

--- a/gateway/mcp_api.go
+++ b/gateway/mcp_api.go
@@ -245,6 +245,37 @@ func derivedToolSourceIdentity(tool oas.DerivedTool) string {
 	return tool.CanonicalName
 }
 
+func (gw *Gateway) alignPairedMCPProxyGatewayTags(apiDef *apidef.APIDefinition, oasObj *oas.OAS) error {
+	if apiDef == nil || oasObj == nil {
+		return nil
+	}
+
+	_, restAPIID, ok := pairedMCPAdapterTarget(apiDef.Proxy.TargetURL)
+	if !ok {
+		return nil
+	}
+
+	rest := gw.getApiSpec(restAPIID)
+	if rest == nil || rest.APIDefinition == nil {
+		return fmt.Errorf("paired REST API %s is not loaded; create it first", restAPIID)
+	}
+
+	apiDef.TagsDisabled = rest.TagsDisabled
+	apiDef.Tags = append([]string(nil), rest.Tags...)
+
+	ext := oasObj.GetTykExtension()
+	if ext == nil {
+		return nil
+	}
+	if ext.Server.GatewayTags == nil {
+		ext.Server.GatewayTags = &oas.GatewayTags{}
+	}
+	ext.Server.GatewayTags.Enabled = !apiDef.TagsDisabled
+	ext.Server.GatewayTags.Tags = append([]string(nil), apiDef.Tags...)
+
+	return nil
+}
+
 func (gw *Gateway) handleAddMCP(r *http.Request, fs afero.Fs) (interface{}, int) {
 	versionParams := lib.NewVersionQueryParameters(r.URL.Query())
 	err := versionParams.Validate(func() (bool, string) {
@@ -284,6 +315,10 @@ func (gw *Gateway) handleAddMCP(r *http.Request, fs afero.Fs) (interface{}, int)
 	)
 
 	if err := gw.handleOASServersForNewAPI(newDef, oasObj, versioningParams); err != nil {
+		return apiError(err.Error()), http.StatusBadRequest
+	}
+
+	if err := gw.alignPairedMCPProxyGatewayTags(newDef, oasObj); err != nil {
 		return apiError(err.Error()), http.StatusBadRequest
 	}
 
@@ -332,6 +367,10 @@ func (gw *Gateway) handleUpdateMCP(apiID string, r *http.Request, fs afero.Fs) (
 	}
 
 	if err := gw.handleOASServersForUpdate(spec, newDef, oasObj); err != nil {
+		return apiError(err.Error()), http.StatusBadRequest
+	}
+
+	if err := gw.alignPairedMCPProxyGatewayTags(newDef, oasObj); err != nil {
 		return apiError(err.Error()), http.StatusBadRequest
 	}
 

--- a/gateway/mcp_api.go
+++ b/gateway/mcp_api.go
@@ -345,7 +345,7 @@ func (gw *Gateway) handleUpdateMCP(apiID string, r *http.Request, fs afero.Fs) (
 }
 
 func (gw *Gateway) handleGetMCPListOAS() (interface{}, int) {
-	return gw.handleGetOASList(mcpManaged, false)
+	return gw.handleGetOASList(mcpProxy, false)
 }
 
 func (gw *Gateway) mcpListHandler(w http.ResponseWriter, _ *http.Request) {

--- a/gateway/mcp_api_test.go
+++ b/gateway/mcp_api_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -22,6 +23,31 @@ import (
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/config"
 )
+
+func newMCPTestGateway(t *testing.T, appPath ...string) *Gateway {
+	t.Helper()
+
+	var path string
+	if len(appPath) > 0 {
+		path = appPath[0]
+	} else {
+		path = t.TempDir()
+	}
+
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.SetConfig(config.Config{
+		AppPath:    path,
+		HostName:   "localhost",
+		ListenPort: 8080,
+	})
+	return gw
+}
+
+func newValidateMCPHandler(t *testing.T, next http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+
+	return newMCPTestGateway(t).validateMCP(next)
+}
 
 func TestExtractMCPObjFromReq(t *testing.T) {
 	t.Parallel()
@@ -158,16 +184,13 @@ func TestValidateMCP(t *testing.T) {
 	}`
 
 	t.Run("valid MCP object passes validation", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(validMCPDefinition))
 		req.Header.Set("Content-Type", "application/json")
@@ -180,16 +203,13 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("PUT request with valid MCP object", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPut, "/test", strings.NewReader(validMCPDefinition))
 		req.Header.Set("Content-Type", "application/json")
@@ -202,15 +222,12 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("malformed request body", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"invalid": json}`))
 		req.Header.Set("Content-Type", "application/json")
@@ -224,15 +241,12 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("POST without Tyk extension returns error", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithoutExtension := `{
 			"openapi": "3.0.3",
@@ -252,15 +266,12 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("PUT without Tyk extension returns error", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithoutExtension := `{
 			"openapi": "3.0.3",
@@ -280,16 +291,13 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("GET request without Tyk extension passes", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithoutExtension := `{
 			"openapi": "3.0.3",
@@ -309,15 +317,12 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("missing required Tyk fields returns error", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		invalidMCP := `{
 			"openapi": "3.0.3",
@@ -341,9 +346,6 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("request body is preserved for next handler", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		var capturedBody []byte
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var err error
@@ -352,7 +354,7 @@ func TestValidateMCP(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(validMCPDefinition))
 		req.Header.Set("Content-Type", "application/json")
@@ -366,9 +368,6 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("context is passed through", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		type contextKey string
 		testKey := contextKey("test-key")
 		testValue := "test-value"
@@ -381,7 +380,7 @@ func TestValidateMCP(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		ctx := context.WithValue(context.Background(), testKey, testValue)
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(validMCPDefinition))
@@ -396,11 +395,8 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("response headers are set correctly on error", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`invalid`))
 		req.Header.Set("Content-Type", "application/json")
@@ -415,15 +411,12 @@ func TestValidateMCP(t *testing.T) {
 
 func TestValidateMCP_EdgeCases(t *testing.T) {
 	t.Run("empty request body reader", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", &bytes.Buffer{})
 		req.Header.Set("Content-Type", "application/json")
@@ -436,9 +429,6 @@ func TestValidateMCP_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("MCP object with multiple tools", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		mcpWithMultipleTools := `{
 			"openapi": "3.0.3",
 			"info": {"title": "Multi-Tool MCP API", "version": "1.0.0"},
@@ -470,7 +460,7 @@ func TestValidateMCP_EdgeCases(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(mcpWithMultipleTools))
 		req.Header.Set("Content-Type", "application/json")
@@ -483,16 +473,13 @@ func TestValidateMCP_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("DELETE request behavior", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithoutExtension := `{
 			"openapi": "3.0.3",
@@ -550,6 +537,28 @@ func restSourceSpec(apiID, orgID string, isOAS bool) *APISpec {
 			IsOAS: isOAS,
 		},
 		OAS: doc,
+	}
+}
+
+func mcpManagedTestSpec(apiID string) *APISpec {
+	apiDef := &apidef.APIDefinition{
+		APIID: apiID,
+		Name:  apiID,
+		IsOAS: true,
+		Proxy: apidef.ProxyConfig{
+			ListenPath: "/" + apiID + "/",
+			TargetURL:  "http://upstream.url",
+		},
+	}
+	apiDef.MarkAsMCP()
+
+	return &APISpec{
+		APIDefinition: apiDef,
+		OAS: oas.OAS{T: openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: apiID, Version: "1.0.0"},
+			Paths:   openapi3.NewPaths(),
+		}},
 	}
 }
 
@@ -843,6 +852,108 @@ func TestHandleAddApiOAS_ValidatesPairedMCPAdapterUpstream(t *testing.T) {
 	assert.Contains(t, msg.Message, "missing-rest")
 }
 
+func TestHandleMCP_AlignsSourceRESTGatewayTagsToPairedProxy(t *testing.T) {
+	cases := []struct {
+		name      string
+		handler   func(*Gateway, *http.Request, afero.Fs) (interface{}, int)
+		method    string
+		path      string
+		loadProxy bool
+	}{
+		{
+			name: "add",
+			handler: func(gw *Gateway, req *http.Request, fs afero.Fs) (interface{}, int) {
+				return gw.handleAddMCP(req, fs)
+			},
+			method: http.MethodPost,
+			path:   "/tyk/mcps",
+		},
+		{
+			name: "update",
+			handler: func(gw *Gateway, req *http.Request, fs afero.Fs) (interface{}, int) {
+				return gw.handleUpdateMCP("proxy-1", req, fs)
+			},
+			method:    http.MethodPut,
+			path:      "/tyk/mcps/proxy-1",
+			loadProxy: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" copies source tags", func(t *testing.T) {
+			gw := pairedMCPGatewayForTagAlignment(tc.loadProxy, true)
+			fs := afero.NewMemMapFs()
+			require.NoError(t, fs.MkdirAll("/apps", 0755))
+
+			body, err := json.Marshal(pairedMCPProxyOAS("proxy-1", "org-1", "rest-1"))
+			require.NoError(t, err)
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader(body))
+
+			obj, code := tc.handler(gw, req, fs)
+
+			require.Equal(t, http.StatusOK, code)
+			resp, ok := obj.(apiModifyKeySuccess)
+			require.True(t, ok)
+			assert.Equal(t, "proxy-1", resp.Key)
+			assertWrittenPairedMCPGatewayTags(t, gw, fs, false, []string{"edge-a", "edge-b"})
+		})
+
+		t.Run(tc.name+" rejects missing source", func(t *testing.T) {
+			gw := pairedMCPGatewayForTagAlignment(tc.loadProxy, false)
+			fs := afero.NewMemMapFs()
+			require.NoError(t, fs.MkdirAll("/apps", 0755))
+
+			body, err := json.Marshal(pairedMCPProxyOAS("proxy-1", "org-1", "rest-1"))
+			require.NoError(t, err)
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader(body))
+
+			obj, code := tc.handler(gw, req, fs)
+
+			require.Equal(t, http.StatusBadRequest, code)
+			msg, ok := obj.(apiStatusMessage)
+			require.True(t, ok)
+			assert.Contains(t, msg.Message, "paired REST API rest-1 is not loaded")
+		})
+	}
+}
+
+func pairedMCPGatewayForTagAlignment(loadProxy, loadSource bool) *Gateway {
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.SetConfig(config.Config{
+		AppPath:    "/apps",
+		HostName:   "localhost",
+		ListenPort: 8080,
+	})
+	if loadSource {
+		gw.apisByID["rest-1"] = restSourceSpec("rest-1", "org-1", true)
+		gw.apisByID["rest-1"].TagsDisabled = false
+		gw.apisByID["rest-1"].Tags = []string{"edge-a", "edge-b"}
+	}
+	if loadProxy {
+		gw.apisByID["proxy-1"] = pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+	}
+	return gw
+}
+
+func assertWrittenPairedMCPGatewayTags(t *testing.T, gw *Gateway, fs afero.Fs, tagsDisabled bool, tags []string) {
+	t.Helper()
+
+	apiDefBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1.json")
+	require.NoError(t, err)
+	var apiDef apidef.APIDefinition
+	require.NoError(t, json.Unmarshal(apiDefBody, &apiDef))
+	assert.Equal(t, tagsDisabled, apiDef.TagsDisabled)
+	assert.Equal(t, tags, apiDef.Tags)
+
+	oasBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1-mcp.json")
+	require.NoError(t, err)
+	var proxyOAS oas.OAS
+	require.NoError(t, json.Unmarshal(oasBody, &proxyOAS))
+	require.NotNil(t, proxyOAS.GetTykExtension().Server.GatewayTags)
+	assert.Equal(t, !tagsDisabled, proxyOAS.GetTykExtension().Server.GatewayTags.Enabled)
+	assert.Equal(t, tags, proxyOAS.GetTykExtension().Server.GatewayTags.Tags)
+}
+
 func TestHandleGetMCPListOAS(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
@@ -923,17 +1034,9 @@ func TestMCPListHandler(t *testing.T) {
 }
 
 func TestMCPUpdateHandler(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-
-	// Create a test MCP Proxy
-	ts.Gw.BuildAndLoadAPI(
-		func(spec *APISpec) {
-			spec.APIID = "mcp-update-test"
-			spec.Name = "MCP Update Test"
-			spec.MarkAsMCP()
-		},
-	)
+	appPath := t.TempDir()
+	gw := newMCPTestGateway(t, appPath)
+	gw.apisByID["mcp-update-test"] = mcpManagedTestSpec("mcp-update-test")
 
 	validMCPUpdate := `{
 		"openapi": "3.0.3",
@@ -974,13 +1077,14 @@ func TestMCPUpdateHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "/tyk/mcps/mcp-update-test", strings.NewReader(validMCPUpdate))
 		w := httptest.NewRecorder()
 
-		// Mock mux.Vars
 		req = mux.SetURLVars(req, map[string]string{"apiID": "mcp-update-test"})
 
-		ts.Gw.mcpUpdateHandler(w, req)
+		gw.mcpUpdateHandler(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), "modified")
+		assert.FileExists(t, filepath.Join(appPath, "mcp-update-test.json"))
+		assert.FileExists(t, filepath.Join(appPath, "mcp-update-test-mcp.json"))
 	})
 
 	t.Run("returns 400 for invalid API ID", func(t *testing.T) {
@@ -989,7 +1093,7 @@ func TestMCPUpdateHandler(t *testing.T) {
 
 		req = mux.SetURLVars(req, map[string]string{"apiID": "../../../etc/passwd"})
 
-		ts.Gw.mcpUpdateHandler(w, req)
+		gw.mcpUpdateHandler(w, req)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "Invalid API ID")
@@ -997,8 +1101,13 @@ func TestMCPUpdateHandler(t *testing.T) {
 }
 
 func TestMCPDeleteHandler(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
+	appPath := t.TempDir()
+	gw := newMCPTestGateway(t, appPath)
+	gw.apisByID["test-api"] = mcpManagedTestSpec("test-api")
+
+	fs := afero.NewOsFs()
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(appPath, "test-api.json"), []byte("{}"), 0644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(appPath, "test-api-mcp.json"), []byte("{}"), 0644))
 
 	t.Run("deletes MCP Proxy successfully", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, "/tyk/mcps/test-api", nil)
@@ -1006,9 +1115,12 @@ func TestMCPDeleteHandler(t *testing.T) {
 
 		req = mux.SetURLVars(req, map[string]string{"apiID": "test-api"})
 
-		ts.Gw.mcpDeleteHandler(w, req)
+		gw.mcpDeleteHandler(w, req)
 
-		assert.NotEqual(t, http.StatusInternalServerError, w.Code)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "deleted")
+		assert.NoFileExists(t, filepath.Join(appPath, "test-api.json"))
+		assert.NoFileExists(t, filepath.Join(appPath, "test-api-mcp.json"))
 	})
 
 	t.Run("rejects invalid API ID", func(t *testing.T) {
@@ -1017,7 +1129,7 @@ func TestMCPDeleteHandler(t *testing.T) {
 
 		req = mux.SetURLVars(req, map[string]string{"apiID": "../../etc/passwd"})
 
-		ts.Gw.mcpDeleteHandler(w, req)
+		gw.mcpDeleteHandler(w, req)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "Invalid API ID")
@@ -1026,15 +1138,12 @@ func TestMCPDeleteHandler(t *testing.T) {
 
 func TestValidateMCP_PRM(t *testing.T) {
 	t.Run("rejects PRM without resource", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithBadPRM := `{
 			"openapi": "3.0.3",
@@ -1076,15 +1185,12 @@ func TestValidateMCP_PRM(t *testing.T) {
 	})
 
 	t.Run("rejects PRM without authorizationServers for MCP", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithBadPRM := `{
 			"openapi": "3.0.3",
@@ -1126,16 +1232,13 @@ func TestValidateMCP_PRM(t *testing.T) {
 	})
 
 	t.Run("accepts valid PRM", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithGoodPRM := `{
 			"openapi": "3.0.3",

--- a/gateway/mcp_context.go
+++ b/gateway/mcp_context.go
@@ -1,0 +1,96 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+)
+
+type mcpContextKey string
+
+const (
+	mcpAdapterCallerProxyIDKey mcpContextKey = "mcp_adapter_caller_proxy_id"
+	mcpAdapterGatewayKey       mcpContextKey = "mcp_adapter_gateway"
+	mcpAdapterSpecKey          mcpContextKey = "mcp_adapter_spec"
+	mcpAdapterParentRequestKey mcpContextKey = "mcp_adapter_parent_request"
+	mcpAdapterLoopTrustKey     mcpContextKey = "mcp_adapter_loop_trust"
+	mcpAdapterLoopBypassKey    mcpContextKey = "mcp_adapter_loop_bypass"
+)
+
+type mcpAdapterLoopTrust struct {
+	SourceRESTAPIID  string
+	AdapterAPIID     string
+	CallerProxyAPIID string
+}
+
+func ctxSetMCPAdapterCallerProxyID(r *http.Request, proxyAPIID string) {
+	setCtxValue(r, mcpAdapterCallerProxyIDKey, proxyAPIID)
+}
+
+func ctxGetMCPAdapterCallerProxyID(r *http.Request) string {
+	if v := r.Context().Value(mcpAdapterCallerProxyIDKey); v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func ctxSetMCPAdapterLoopTrust(r *http.Request, trust mcpAdapterLoopTrust) {
+	setCtxValue(r, mcpAdapterLoopTrustKey, trust)
+}
+
+func ctxGetMCPAdapterLoopTrust(r *http.Request) (mcpAdapterLoopTrust, bool) {
+	if v := r.Context().Value(mcpAdapterLoopTrustKey); v != nil {
+		if trust, ok := v.(mcpAdapterLoopTrust); ok {
+			return trust, true
+		}
+	}
+	return mcpAdapterLoopTrust{}, false
+}
+
+func ctxSetMCPAdapterLoopAuthBypassed(r *http.Request, bypassed bool) {
+	setCtxValue(r, mcpAdapterLoopBypassKey, bypassed)
+}
+
+func ctxMCPAdapterLoopAuthBypassed(r *http.Request) bool {
+	if v := r.Context().Value(mcpAdapterLoopBypassKey); v != nil {
+		if bypassed, ok := v.(bool); ok {
+			return bypassed
+		}
+	}
+	return false
+}
+
+func installMCPAdapterCallContext(r *http.Request, gw *Gateway, spec *APISpec) {
+	ctx := context.WithValue(r.Context(), mcpAdapterGatewayKey, gw)
+	ctx = context.WithValue(ctx, mcpAdapterSpecKey, spec)
+	ctx = context.WithValue(ctx, mcpAdapterParentRequestKey, r)
+	*r = *r.WithContext(ctx)
+}
+
+func mcpAdapterGatewayFromContext(ctx context.Context) *Gateway {
+	if v := ctx.Value(mcpAdapterGatewayKey); v != nil {
+		if gw, ok := v.(*Gateway); ok {
+			return gw
+		}
+	}
+	return nil
+}
+
+func mcpAdapterSpecFromContext(ctx context.Context) *APISpec {
+	if v := ctx.Value(mcpAdapterSpecKey); v != nil {
+		if spec, ok := v.(*APISpec); ok {
+			return spec
+		}
+	}
+	return nil
+}
+
+func mcpAdapterParentRequestFromContext(ctx context.Context) *http.Request {
+	if v := ctx.Value(mcpAdapterParentRequestKey); v != nil {
+		if req, ok := v.(*http.Request); ok {
+			return req
+		}
+	}
+	return nil
+}

--- a/gateway/mcp_lifecycle_test.go
+++ b/gateway/mcp_lifecycle_test.go
@@ -1,0 +1,73 @@
+package gateway
+
+import (
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/config"
+)
+
+func TestHandleDeleteAPI_RefusesRESTSourceWithPairedMCPProxy(t *testing.T) {
+	gw := &Gateway{
+		apisByID: map[string]*APISpec{},
+	}
+	gw.SetConfig(config.Config{AppPath: t.TempDir()})
+
+	rest := restSourceSpec("rest-delete", "org-1", true)
+	proxy1 := pairedMCPProxySpec("proxy-delete-1", "org-1", "rest-delete", nil)
+	proxy2 := pairedMCPProxySpec("proxy-delete-2", "org-1", "rest-delete", nil)
+
+	gw.apisByID[rest.APIID] = rest
+	gw.apisByID[proxy1.APIID] = proxy1
+	gw.apisByID[proxy2.APIID] = proxy2
+
+	obj, code := gw.handleDeleteAPI("rest-delete")
+	require.Equal(t, http.StatusConflict, code)
+
+	msg, ok := obj.(apiStatusMessage)
+	require.True(t, ok)
+	assert.Equal(t, "error", msg.Status)
+	assert.Contains(t, msg.Message, "paired MCP proxies")
+	assert.Contains(t, msg.Message, "proxy-delete-1")
+	assert.Contains(t, msg.Message, "proxy-delete-2")
+}
+
+func TestHandleDeleteMCP_DeletesPairedProxyPersistedWithOASSuffix(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	appPath := "/app"
+	require.NoError(t, fs.MkdirAll(appPath, 0755))
+
+	gw := &Gateway{
+		apisByID: map[string]*APISpec{},
+	}
+	gw.SetConfig(config.Config{AppPath: appPath})
+
+	proxy := pairedMCPProxySpec("proxy-delete", "org-1", "rest-1", nil)
+	gw.apisByID[proxy.APIID] = proxy
+
+	mainFile := filepath.Join(appPath, "proxy-delete.json")
+	mcpFile := filepath.Join(appPath, "proxy-delete-mcp.json")
+	require.NoError(t, afero.WriteFile(fs, mainFile, []byte("{}"), 0644))
+	require.NoError(t, afero.WriteFile(fs, mcpFile, []byte("{}"), 0644))
+
+	obj, code := gw.handleDeleteMCP("proxy-delete", fs)
+	require.Equal(t, http.StatusOK, code)
+
+	success, ok := obj.(apiModifyKeySuccess)
+	require.True(t, ok)
+	assert.Equal(t, "proxy-delete", success.Key)
+	assert.Equal(t, "deleted", success.Action)
+
+	exists, err := afero.Exists(fs, mainFile)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	exists, err = afero.Exists(fs, mcpFile)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}

--- a/gateway/mcp_lifecycle_test.go
+++ b/gateway/mcp_lifecycle_test.go
@@ -25,6 +25,9 @@ func TestHandleDeleteAPI_RefusesRESTSourceWithPairedMCPProxy(t *testing.T) {
 	gw.apisByID[rest.APIID] = rest
 	gw.apisByID[proxy1.APIID] = proxy1
 	gw.apisByID[proxy2.APIID] = proxy2
+	snapshot, err := computeMCPPairing([]*APISpec{rest, proxy1, proxy2})
+	require.NoError(t, err)
+	gw.mcpPairingIndex.Set(snapshot)
 
 	obj, code := gw.handleDeleteAPI("rest-delete")
 	require.Equal(t, http.StatusConflict, code)

--- a/gateway/mcp_pairing.go
+++ b/gateway/mcp_pairing.go
@@ -1,0 +1,389 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/mcp"
+	restmcpadapter "github.com/TykTechnologies/tyk/internal/mcp/adapter"
+	"github.com/TykTechnologies/tyk/internal/mcp/pairing"
+)
+
+type mcpAdapterCatalogue struct {
+	unionTools []oas.DerivedTool
+	toolViews  map[string]oas.MCPToolView
+}
+
+func synthesizeMCPAdapterSpecs(specs []*APISpec, existing map[string]*APISpec) ([]*APISpec, pairing.Snapshot, error) {
+	snapshot, err := computeMCPPairing(specs)
+	if err != nil {
+		return specs, pairing.Snapshot{}, err
+	}
+
+	proxiesByRESTID := pairedMCPProxiesByRESTID(specs)
+	sourcesByID := apiSpecsByID(specs)
+
+	out := append([]*APISpec(nil), specs...)
+	for _, restID := range snapshot.ReferencedRESTAPIIDs() {
+		source := sourcesByID[restID]
+		if source == nil {
+			return specs, pairing.Snapshot{}, fmt.Errorf("paired REST API %q is not loaded", restID)
+		}
+
+		adapterID := pairing.CanonicalAdapterAPIID(restID)
+		var existingAdapter *APISpec
+		if existing != nil {
+			existingAdapter = existing[adapterID]
+		}
+
+		adapterSpec, err := buildMCPAdapterSpec(source, proxiesByRESTID[restID], existingAdapter)
+		if err != nil {
+			return specs, pairing.Snapshot{}, err
+		}
+		out = append(out, adapterSpec)
+	}
+
+	return out, snapshot, nil
+}
+
+func (gw *Gateway) currentSyntheticMCPAdapterSpecs() map[string]*APISpec {
+	out := map[string]*APISpec{}
+	if gw == nil {
+		return out
+	}
+
+	gw.apisMu.RLock()
+	defer gw.apisMu.RUnlock()
+
+	for apiID, spec := range gw.apisByID {
+		if spec != nil && spec.IsSyntheticMCPAdapter() {
+			out[apiID] = spec
+		}
+	}
+	return out
+}
+
+func (gw *Gateway) findInternalHTTPHandlerForLoop(apiNameOrID string, caller *APISpec, r *http.Request) (handler http.Handler, targetAPI *APISpec, ok bool) {
+	targetName := apiNameOrID
+	if caller != nil && caller.APIDefinition != nil && caller.IsPairedMCPAdapterProxy() {
+		if _, restAPIID, paired := pairedMCPAdapterTarget(caller.Proxy.TargetURL); paired {
+			targetName = pairing.CanonicalAdapterAPIID(restAPIID)
+			if r != nil {
+				ctxSetMCPAdapterCallerProxyID(r, caller.APIID)
+			}
+		}
+	}
+	return gw.findInternalHttpHandlerByNameOrID(targetName)
+}
+
+func computeMCPPairing(specs []*APISpec) (pairing.Snapshot, error) {
+	sourcesByID := apiSpecsByID(specs)
+	records := make([]pairing.Record, 0)
+
+	for _, spec := range specs {
+		if spec == nil || spec.APIDefinition == nil || spec.IsSyntheticMCPAdapter() || !spec.IsPairedMCPAdapterProxy() {
+			continue
+		}
+
+		_, restAPIID, ok := pairedMCPAdapterTarget(spec.Proxy.TargetURL)
+		if !ok {
+			continue
+		}
+
+		source := sourcesByID[restAPIID]
+		if source == nil || source.APIDefinition == nil {
+			return pairing.Snapshot{}, fmt.Errorf("paired REST API %q is not loaded", restAPIID)
+		}
+		if !source.IsOAS {
+			return pairing.Snapshot{}, fmt.Errorf("paired REST API %q is a Classic API; REST-as-MCP sources must be Tyk OAS APIs", restAPIID)
+		}
+
+		records = append(records, pairing.Record{
+			SourceRESTAPIID:  restAPIID,
+			SourceOrgID:      source.OrgID,
+			CallerProxyAPIID: spec.APIID,
+			CallerProxyOrgID: spec.OrgID,
+		})
+	}
+
+	return pairing.NewSnapshot(records)
+}
+
+func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (*APISpec, error) {
+	if rest == nil || rest.APIDefinition == nil {
+		return nil, fmt.Errorf("REST-as-MCP source spec is nil")
+	}
+
+	catalogue, err := deriveMCPAdapterCatalogue(rest, proxies)
+	if err != nil {
+		return nil, err
+	}
+
+	adapterID := pairing.CanonicalAdapterAPIID(rest.APIID)
+	sdkAdapter := (*restmcpadapter.SDKAdapter)(nil)
+	if existing != nil {
+		sdkAdapter = existing.MCPSDKAdapter
+	}
+	if sdkAdapter == nil {
+		sdkAdapter, err = restmcpadapter.NewSDKAdapter(restmcpadapter.SDKServerConfig{
+			Name:     adapterID,
+			Version:  "1.0",
+			Tools:    catalogue.unionTools,
+			CallTool: defaultMCPAdapterCallTool,
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if err := sdkAdapter.UpdateCallTool(defaultMCPAdapterCallTool); err != nil {
+			return nil, err
+		}
+		if err := sdkAdapter.UpdateTools(catalogue.unionTools); err != nil {
+			return nil, err
+		}
+	}
+
+	allowedCallers := callerProxyIDs(proxies)
+	adapterDef := &apidef.APIDefinition{
+		APIID:    adapterID,
+		Name:     adapterID,
+		OrgID:    rest.OrgID,
+		Active:   true,
+		IsOAS:    true,
+		Internal: true,
+		Proxy: apidef.ProxyConfig{
+			ListenPath: "/" + adapterID + "/",
+			TargetURL:  "http://127.0.0.1",
+		},
+	}
+	adapterDef.MarkAsMCP()
+
+	doc := oas.OAS{T: openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: adapterID, Version: "1.0.0"},
+		Paths: openapi3.NewPaths(
+			openapi3.WithPath(oas.AdapterLoopPath, &openapi3.PathItem{
+				Post: &openapi3.Operation{OperationID: "mcp"},
+			}),
+		),
+	}}
+	doc.SetTykExtension(&oas.XTykAPIGateway{
+		Info: oas.Info{
+			ID:    adapterID,
+			OrgID: rest.OrgID,
+			Name:  adapterID,
+			State: oas.State{Active: true},
+		},
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{Value: "/" + adapterID + "/"},
+		},
+		Upstream: oas.Upstream{URL: "http://127.0.0.1"},
+	})
+
+	return &APISpec{
+		APIDefinition:                 adapterDef,
+		OAS:                           doc,
+		MCPAdapterSynthetic:           true,
+		MCPAdapterSourceRESTAPIID:     rest.APIID,
+		MCPSDKAdapter:                 sdkAdapter,
+		MCPAllowedCallerProxyAPIIDs:   allowedCallers,
+		MCPAllowedCallerProxyAPIIDSet: stringSet(allowedCallers),
+		MCPToolViews:                  catalogue.toolViews,
+		MCPAdapterUnionTools:          append([]oas.DerivedTool(nil), catalogue.unionTools...),
+		JSONRPCRouter:                 mcp.NewRouter(),
+	}, nil
+}
+
+func deriveMCPAdapterCatalogue(rest *APISpec, proxies []*APISpec) (mcpAdapterCatalogue, error) {
+	if rest == nil {
+		return mcpAdapterCatalogue{}, fmt.Errorf("REST-as-MCP source spec is nil")
+	}
+
+	unionByName := map[string]oas.DerivedTool{}
+	toolViews := make(map[string]oas.MCPToolView, len(proxies))
+
+	for _, proxy := range proxies {
+		if proxy == nil || proxy.APIDefinition == nil {
+			continue
+		}
+		view, warnings, err := oas.DeriveMCPToolView(&rest.OAS, proxy.OAS.GetTykMCPServerExtension())
+		logMCPDeriveWarnings(proxy.APIID, rest.APIID, warnings)
+		if err != nil {
+			return mcpAdapterCatalogue{}, fmt.Errorf("build MCP tool view for proxy %q: %w", proxy.APIID, err)
+		}
+
+		toolViews[proxy.APIID] = view
+		for _, tool := range view.Tools {
+			existing, duplicate := unionByName[tool.Name]
+			if duplicate && derivedToolSourceIdentity(existing) != derivedToolSourceIdentity(tool) {
+				return mcpAdapterCatalogue{}, fmt.Errorf("MCP tool alias conflict for %q: sources %q and %q", tool.Name, derivedToolSourceIdentity(existing), derivedToolSourceIdentity(tool))
+			}
+			unionByName[tool.Name] = tool
+		}
+	}
+
+	unionTools := make([]oas.DerivedTool, 0, len(unionByName))
+	for _, tool := range unionByName {
+		unionTools = append(unionTools, tool)
+	}
+	sort.Slice(unionTools, func(i, j int) bool { return unionTools[i].Name < unionTools[j].Name })
+
+	return mcpAdapterCatalogue{
+		unionTools: unionTools,
+		toolViews:  toolViews,
+	}, nil
+}
+
+func pairedMCPProxiesByRESTID(specs []*APISpec) map[string][]*APISpec {
+	out := map[string][]*APISpec{}
+	for _, spec := range specs {
+		if spec == nil || spec.APIDefinition == nil || spec.IsSyntheticMCPAdapter() || !spec.IsPairedMCPAdapterProxy() {
+			continue
+		}
+		_, restAPIID, ok := pairedMCPAdapterTarget(spec.Proxy.TargetURL)
+		if !ok {
+			continue
+		}
+		out[restAPIID] = append(out[restAPIID], spec)
+	}
+	for _, proxies := range out {
+		sort.Slice(proxies, func(i, j int) bool { return proxies[i].APIID < proxies[j].APIID })
+	}
+	return out
+}
+
+func (gw *Gateway) pairedMCPProxyIDsReferencingRESTSource(restAPIID string) []string {
+	if gw == nil || restAPIID == "" {
+		return nil
+	}
+
+	gw.apisMu.RLock()
+	defer gw.apisMu.RUnlock()
+
+	var proxyIDs []string
+	for _, spec := range gw.apisByID {
+		if spec == nil || spec.APIDefinition == nil || spec.APIID == restAPIID || spec.IsSyntheticMCPAdapter() || !spec.IsPairedMCPAdapterProxy() {
+			continue
+		}
+		_, sourceRESTAPIID, ok := pairedMCPAdapterTarget(spec.Proxy.TargetURL)
+		if ok && sourceRESTAPIID == restAPIID {
+			proxyIDs = append(proxyIDs, spec.APIID)
+		}
+	}
+	sort.Strings(proxyIDs)
+	return proxyIDs
+}
+
+func apiSpecsByID(specs []*APISpec) map[string]*APISpec {
+	out := make(map[string]*APISpec, len(specs))
+	for _, spec := range specs {
+		if spec == nil || spec.APIDefinition == nil || spec.IsSyntheticMCPAdapter() {
+			continue
+		}
+		out[spec.APIID] = spec
+	}
+	return out
+}
+
+func callerProxyIDs(proxies []*APISpec) []string {
+	ids := make([]string, 0, len(proxies))
+	for _, proxy := range proxies {
+		if proxy != nil && proxy.APIID != "" {
+			ids = append(ids, proxy.APIID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func defaultMCPAdapterCallTool(ctx context.Context, tool *oas.DerivedTool, args map[string]any) (*restmcpadapter.Recorder, error) {
+	gw := mcpAdapterGatewayFromContext(ctx)
+	adapterSpec := mcpAdapterSpecFromContext(ctx)
+	parentReq := mcpAdapterParentRequestFromContext(ctx)
+	if gw == nil || adapterSpec == nil || parentReq == nil {
+		return nil, fmt.Errorf("REST-as-MCP adapter callback is not installed")
+	}
+	return gw.callMCPAdapterTool(parentReq, adapterSpec, tool, args)
+}
+
+func (gw *Gateway) callMCPAdapterTool(parentReq *http.Request, adapterSpec *APISpec, tool *oas.DerivedTool, args map[string]any) (*restmcpadapter.Recorder, error) {
+	if gw == nil {
+		return nil, fmt.Errorf("gateway is nil")
+	}
+	if parentReq == nil {
+		return nil, fmt.Errorf("REST-as-MCP parent request is nil")
+	}
+	if adapterSpec == nil || !adapterSpec.IsSyntheticMCPAdapter() {
+		return nil, fmt.Errorf("REST-as-MCP adapter spec is invalid")
+	}
+	if tool == nil {
+		return nil, fmt.Errorf("REST-as-MCP tool is nil")
+	}
+
+	callerProxyID := ctxGetMCPAdapterCallerProxyID(parentReq)
+	if callerProxyID == "" {
+		return nil, fmt.Errorf("caller proxy is required")
+	}
+	if !gw.mcpPairingIndex.AllowsCaller(adapterSpec.APIID, callerProxyID) {
+		return nil, fmt.Errorf("caller proxy is not allowed for REST-as-MCP adapter")
+	}
+
+	view, ok := adapterSpec.MCPToolViews[callerProxyID]
+	if !ok {
+		return nil, fmt.Errorf("caller proxy has no REST-as-MCP tool view")
+	}
+	callerTool, ok := view.ToolByName(tool.Name)
+	if !ok {
+		logMCPToolHiddenFromCaller(parentReq, adapterSpec, callerProxyID, tool.Name)
+		return nil, fmt.Errorf("tool not found")
+	}
+
+	sourceRESTAPIID := adapterSpec.MCPAdapterSourceRESTAPIID
+	upstreamReq, err := restmcpadapter.BuildUpstreamRequest(parentReq, &callerTool, sourceRESTAPIID, args)
+	if err != nil {
+		return nil, err
+	}
+	ctxSetMCPAdapterLoopTrust(upstreamReq, mcpAdapterLoopTrust{
+		SourceRESTAPIID:  sourceRESTAPIID,
+		AdapterAPIID:     adapterSpec.APIID,
+		CallerProxyAPIID: callerProxyID,
+	})
+
+	handler, _, ok := gw.findInternalHttpHandlerByNameOrID(sourceRESTAPIID)
+	if !ok {
+		return nil, fmt.Errorf("source REST API %q handler not found", sourceRESTAPIID)
+	}
+
+	rec := restmcpadapter.NewRecorder()
+	handler.ServeHTTP(rec, upstreamReq)
+	return rec, nil
+}
+
+func logMCPToolHiddenFromCaller(parentReq *http.Request, adapterSpec *APISpec, callerProxyID, toolName string) {
+	sessionKey := ""
+	if ses := ctxGetSession(parentReq); ses != nil {
+		sessionKey = ses.KeyID
+	}
+	log.WithFields(logrus.Fields{
+		"tool_name":          toolName,
+		"proxy_api_id":       callerProxyID,
+		"source_rest_api_id": adapterSpec.MCPAdapterSourceRESTAPIID,
+		"adapter_api_id":     adapterSpec.APIID,
+		"session_key":        sessionKey,
+	}).Warn("MCP tool is not exposed for caller proxy")
+}

--- a/gateway/mcp_pairing.go
+++ b/gateway/mcp_pairing.go
@@ -264,21 +264,11 @@ func (gw *Gateway) pairedMCPProxyIDsReferencingRESTSource(restAPIID string) []st
 		return nil
 	}
 
-	gw.apisMu.RLock()
-	defer gw.apisMu.RUnlock()
-
-	var proxyIDs []string
-	for _, spec := range gw.apisByID {
-		if spec == nil || spec.APIDefinition == nil || spec.APIID == restAPIID || spec.IsSyntheticMCPAdapter() || !spec.IsPairedMCPAdapterProxy() {
-			continue
-		}
-		_, sourceRESTAPIID, ok := pairedMCPAdapterTarget(spec.Proxy.TargetURL)
-		if ok && sourceRESTAPIID == restAPIID {
-			proxyIDs = append(proxyIDs, spec.APIID)
-		}
+	source, ok := gw.mcpPairingIndex.LookupSource(restAPIID)
+	if !ok {
+		return nil
 	}
-	sort.Strings(proxyIDs)
-	return proxyIDs
+	return source.CallerProxyAPIIDs
 }
 
 func apiSpecsByID(specs []*APISpec) map[string]*APISpec {

--- a/gateway/mcp_pairing.go
+++ b/gateway/mcp_pairing.go
@@ -21,18 +21,26 @@ type mcpAdapterCatalogue struct {
 	toolViews  map[string]oas.MCPToolView
 }
 
+type mcpPairingSynthesisAnalysis struct {
+	snapshot        pairing.Snapshot
+	sourcesByID     map[string]*APISpec
+	proxiesByRESTID map[string][]*APISpec
+}
+
+type pendingMCPProxyPairing struct {
+	spec      *APISpec
+	restAPIID string
+}
+
 func synthesizeMCPAdapterSpecs(specs []*APISpec, existing map[string]*APISpec) ([]*APISpec, pairing.Snapshot, error) {
-	snapshot, err := computeMCPPairing(specs)
+	analysis, err := analyzeMCPPairingsForSynthesis(specs)
 	if err != nil {
 		return specs, pairing.Snapshot{}, err
 	}
 
-	proxiesByRESTID := pairedMCPProxiesByRESTID(specs)
-	sourcesByID := apiSpecsByID(specs)
-
 	out := append([]*APISpec(nil), specs...)
-	for _, restID := range snapshot.ReferencedRESTAPIIDs() {
-		source := sourcesByID[restID]
+	for _, restID := range analysis.snapshot.ReferencedRESTAPIIDs() {
+		source := analysis.sourcesByID[restID]
 		if source == nil {
 			return specs, pairing.Snapshot{}, fmt.Errorf("paired REST API %q is not loaded", restID)
 		}
@@ -43,14 +51,14 @@ func synthesizeMCPAdapterSpecs(specs []*APISpec, existing map[string]*APISpec) (
 			existingAdapter = existing[adapterID]
 		}
 
-		adapterSpec, err := buildMCPAdapterSpec(source, proxiesByRESTID[restID], existingAdapter)
+		adapterSpec, err := buildMCPAdapterSpec(source, analysis.proxiesByRESTID[restID], existingAdapter)
 		if err != nil {
 			return specs, pairing.Snapshot{}, err
 		}
 		out = append(out, adapterSpec)
 	}
 
-	return out, snapshot, nil
+	return out, analysis.snapshot, nil
 }
 
 func (gw *Gateway) currentSyntheticMCPAdapterSpecs() map[string]*APISpec {
@@ -84,43 +92,70 @@ func (gw *Gateway) findInternalHTTPHandlerForLoop(apiNameOrID string, caller *AP
 }
 
 func computeMCPPairing(specs []*APISpec) (pairing.Snapshot, error) {
-	sourcesByID := apiSpecsByID(specs)
-	records := make([]pairing.Record, 0)
+	analysis, err := analyzeMCPPairingsForSynthesis(specs)
+	if err != nil {
+		return pairing.Snapshot{}, err
+	}
+	return analysis.snapshot, nil
+}
+
+func analyzeMCPPairingsForSynthesis(specs []*APISpec) (mcpPairingSynthesisAnalysis, error) {
+	analysis := mcpPairingSynthesisAnalysis{
+		sourcesByID:     make(map[string]*APISpec, len(specs)),
+		proxiesByRESTID: map[string][]*APISpec{},
+	}
+	pairedProxies := make([]pendingMCPProxyPairing, 0)
 
 	for _, spec := range specs {
-		if spec == nil || spec.APIDefinition == nil || spec.IsSyntheticMCPAdapter() || !spec.IsPairedMCPAdapterProxy() {
+		if spec == nil || spec.APIDefinition == nil || spec.IsSyntheticMCPAdapter() {
 			continue
 		}
+		analysis.sourcesByID[spec.APIID] = spec
 
+		if !spec.IsPairedMCPAdapterProxy() {
+			continue
+		}
 		_, restAPIID, ok := pairedMCPAdapterTarget(spec.Proxy.TargetURL)
-		if !ok {
-			continue
+		if ok {
+			pairedProxies = append(pairedProxies, pendingMCPProxyPairing{spec: spec, restAPIID: restAPIID})
+			analysis.proxiesByRESTID[restAPIID] = append(analysis.proxiesByRESTID[restAPIID], spec)
 		}
+	}
 
-		source := sourcesByID[restAPIID]
+	records := make([]pairing.Record, 0, len(pairedProxies))
+	for _, paired := range pairedProxies {
+		source := analysis.sourcesByID[paired.restAPIID]
 		if source == nil || source.APIDefinition == nil {
-			return pairing.Snapshot{}, fmt.Errorf("paired REST API %q is not loaded", restAPIID)
+			return mcpPairingSynthesisAnalysis{}, fmt.Errorf("paired REST API %q is not loaded", paired.restAPIID)
 		}
 		if !source.IsOAS {
-			return pairing.Snapshot{}, fmt.Errorf("paired REST API %q is a Classic API; REST-as-MCP sources must be Tyk OAS APIs", restAPIID)
+			return mcpPairingSynthesisAnalysis{}, fmt.Errorf("paired REST API %q is a Classic API; REST-as-MCP sources must be Tyk OAS APIs", paired.restAPIID)
 		}
 
 		records = append(records, pairing.Record{
-			SourceRESTAPIID:  restAPIID,
+			SourceRESTAPIID:  paired.restAPIID,
 			SourceOrgID:      source.OrgID,
-			CallerProxyAPIID: spec.APIID,
-			CallerProxyOrgID: spec.OrgID,
+			CallerProxyAPIID: paired.spec.APIID,
+			CallerProxyOrgID: paired.spec.OrgID,
 		})
 	}
 
-	return pairing.NewSnapshot(records)
+	for _, proxies := range analysis.proxiesByRESTID {
+		sort.Slice(proxies, func(i, j int) bool { return proxies[i].APIID < proxies[j].APIID })
+	}
+
+	snapshot, err := pairing.NewSnapshot(records)
+	if err != nil {
+		return mcpPairingSynthesisAnalysis{}, err
+	}
+	analysis.snapshot = snapshot
+	return analysis, nil
 }
 
 func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (*APISpec, error) {
 	if rest == nil || rest.APIDefinition == nil {
 		return nil, fmt.Errorf("REST-as-MCP source spec is nil")
 	}
-
 	catalogue, err := deriveMCPAdapterCatalogue(rest, proxies)
 	if err != nil {
 		return nil, err
@@ -241,24 +276,6 @@ func deriveMCPAdapterCatalogue(rest *APISpec, proxies []*APISpec) (mcpAdapterCat
 	}, nil
 }
 
-func pairedMCPProxiesByRESTID(specs []*APISpec) map[string][]*APISpec {
-	out := map[string][]*APISpec{}
-	for _, spec := range specs {
-		if spec == nil || spec.APIDefinition == nil || spec.IsSyntheticMCPAdapter() || !spec.IsPairedMCPAdapterProxy() {
-			continue
-		}
-		_, restAPIID, ok := pairedMCPAdapterTarget(spec.Proxy.TargetURL)
-		if !ok {
-			continue
-		}
-		out[restAPIID] = append(out[restAPIID], spec)
-	}
-	for _, proxies := range out {
-		sort.Slice(proxies, func(i, j int) bool { return proxies[i].APIID < proxies[j].APIID })
-	}
-	return out
-}
-
 func (gw *Gateway) pairedMCPProxyIDsReferencingRESTSource(restAPIID string) []string {
 	if gw == nil || restAPIID == "" {
 		return nil
@@ -269,17 +286,6 @@ func (gw *Gateway) pairedMCPProxyIDsReferencingRESTSource(restAPIID string) []st
 		return nil
 	}
 	return source.CallerProxyAPIIDs
-}
-
-func apiSpecsByID(specs []*APISpec) map[string]*APISpec {
-	out := make(map[string]*APISpec, len(specs))
-	for _, spec := range specs {
-		if spec == nil || spec.APIDefinition == nil || spec.IsSyntheticMCPAdapter() {
-			continue
-		}
-		out[spec.APIID] = spec
-	}
-	return out
 }
 
 func callerProxyIDs(proxies []*APISpec) []string {

--- a/gateway/mcp_pairing.go
+++ b/gateway/mcp_pairing.go
@@ -162,6 +162,7 @@ func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (
 	}
 
 	adapterID := pairing.CanonicalAdapterAPIID(rest.APIID)
+	gw := gatewayForSyntheticAdapter(rest, existing)
 	sdkAdapter := (*restmcpadapter.SDKAdapter)(nil)
 	if existing != nil {
 		sdkAdapter = existing.MCPAdapter.SDKAdapter
@@ -225,6 +226,16 @@ func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (
 	return &APISpec{
 		APIDefinition: adapterDef,
 		OAS:           doc,
+		Health: &DefaultHealthChecker{
+			Gw:    gw,
+			APIID: adapterID,
+		},
+		AuthManager: &DefaultSessionManager{Gw: gw},
+		OrgSessionManager: &DefaultSessionManager{
+			orgID: rest.OrgID,
+			Gw:    gw,
+		},
+		GlobalConfig: rest.GlobalConfig,
 		MCPAdapter: MCPAdapterRuntime{
 			Synthetic:                true,
 			SourceRESTAPIID:          rest.APIID,
@@ -235,6 +246,24 @@ func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (
 		},
 		JSONRPCRouter: mcp.NewRouter(),
 	}, nil
+}
+
+func gatewayForSyntheticAdapter(specs ...*APISpec) *Gateway {
+	for _, spec := range specs {
+		if spec == nil {
+			continue
+		}
+		if manager, ok := spec.AuthManager.(*DefaultSessionManager); ok && manager.Gw != nil {
+			return manager.Gw
+		}
+		if manager, ok := spec.OrgSessionManager.(*DefaultSessionManager); ok && manager.Gw != nil {
+			return manager.Gw
+		}
+		if health, ok := spec.Health.(*DefaultHealthChecker); ok && health.Gw != nil {
+			return health.Gw
+		}
+	}
+	return nil
 }
 
 func deriveMCPAdapterCatalogue(rest *APISpec, proxies []*APISpec) (mcpAdapterCatalogue, error) {

--- a/gateway/mcp_pairing.go
+++ b/gateway/mcp_pairing.go
@@ -164,7 +164,7 @@ func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (
 	adapterID := pairing.CanonicalAdapterAPIID(rest.APIID)
 	sdkAdapter := (*restmcpadapter.SDKAdapter)(nil)
 	if existing != nil {
-		sdkAdapter = existing.MCPSDKAdapter
+		sdkAdapter = existing.MCPAdapter.SDKAdapter
 	}
 	if sdkAdapter == nil {
 		sdkAdapter, err = restmcpadapter.NewSDKAdapter(restmcpadapter.SDKServerConfig{
@@ -223,16 +223,17 @@ func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (
 	})
 
 	return &APISpec{
-		APIDefinition:                 adapterDef,
-		OAS:                           doc,
-		MCPAdapterSynthetic:           true,
-		MCPAdapterSourceRESTAPIID:     rest.APIID,
-		MCPSDKAdapter:                 sdkAdapter,
-		MCPAllowedCallerProxyAPIIDs:   allowedCallers,
-		MCPAllowedCallerProxyAPIIDSet: stringSet(allowedCallers),
-		MCPToolViews:                  catalogue.toolViews,
-		MCPAdapterUnionTools:          append([]oas.DerivedTool(nil), catalogue.unionTools...),
-		JSONRPCRouter:                 mcp.NewRouter(),
+		APIDefinition: adapterDef,
+		OAS:           doc,
+		MCPAdapter: MCPAdapterRuntime{
+			Synthetic:                true,
+			SourceRESTAPIID:          rest.APIID,
+			SDKAdapter:               sdkAdapter,
+			AllowedCallerProxyAPIIDs: allowedCallers,
+			ToolViews:                catalogue.toolViews,
+			UnionTools:               append([]oas.DerivedTool(nil), catalogue.unionTools...),
+		},
+		JSONRPCRouter: mcp.NewRouter(),
 	}, nil
 }
 
@@ -299,14 +300,6 @@ func callerProxyIDs(proxies []*APISpec) []string {
 	return ids
 }
 
-func stringSet(values []string) map[string]struct{} {
-	out := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		out[value] = struct{}{}
-	}
-	return out
-}
-
 func defaultMCPAdapterCallTool(ctx context.Context, tool *oas.DerivedTool, args map[string]any) (*restmcpadapter.Recorder, error) {
 	gw := mcpAdapterGatewayFromContext(ctx)
 	adapterSpec := mcpAdapterSpecFromContext(ctx)
@@ -339,7 +332,7 @@ func (gw *Gateway) callMCPAdapterTool(parentReq *http.Request, adapterSpec *APIS
 		return nil, fmt.Errorf("caller proxy is not allowed for REST-as-MCP adapter")
 	}
 
-	view, ok := adapterSpec.MCPToolViews[callerProxyID]
+	view, ok := adapterSpec.MCPAdapter.ToolViews[callerProxyID]
 	if !ok {
 		return nil, fmt.Errorf("caller proxy has no REST-as-MCP tool view")
 	}
@@ -349,7 +342,7 @@ func (gw *Gateway) callMCPAdapterTool(parentReq *http.Request, adapterSpec *APIS
 		return nil, fmt.Errorf("tool not found")
 	}
 
-	sourceRESTAPIID := adapterSpec.MCPAdapterSourceRESTAPIID
+	sourceRESTAPIID := adapterSpec.MCPAdapter.SourceRESTAPIID
 	upstreamReq, err := restmcpadapter.BuildUpstreamRequest(parentReq, &callerTool, sourceRESTAPIID, args)
 	if err != nil {
 		return nil, err
@@ -374,7 +367,7 @@ func logMCPToolHiddenFromCaller(adapterSpec *APISpec, callerProxyID, toolName st
 	log.WithFields(logrus.Fields{
 		"tool_name":          toolName,
 		"proxy_api_id":       callerProxyID,
-		"source_rest_api_id": adapterSpec.MCPAdapterSourceRESTAPIID,
+		"source_rest_api_id": adapterSpec.MCPAdapter.SourceRESTAPIID,
 		"adapter_api_id":     adapterSpec.APIID,
 	}).Warn("MCP tool is not exposed for caller proxy")
 }

--- a/gateway/mcp_pairing.go
+++ b/gateway/mcp_pairing.go
@@ -349,7 +349,7 @@ func (gw *Gateway) callMCPAdapterTool(parentReq *http.Request, adapterSpec *APIS
 	}
 	callerTool, ok := view.ToolByName(tool.Name)
 	if !ok {
-		logMCPToolHiddenFromCaller(parentReq, adapterSpec, callerProxyID, tool.Name)
+		logMCPToolHiddenFromCaller(adapterSpec, callerProxyID, tool.Name)
 		return nil, fmt.Errorf("tool not found")
 	}
 
@@ -374,16 +374,11 @@ func (gw *Gateway) callMCPAdapterTool(parentReq *http.Request, adapterSpec *APIS
 	return rec, nil
 }
 
-func logMCPToolHiddenFromCaller(parentReq *http.Request, adapterSpec *APISpec, callerProxyID, toolName string) {
-	sessionKey := ""
-	if ses := ctxGetSession(parentReq); ses != nil {
-		sessionKey = ses.KeyID
-	}
+func logMCPToolHiddenFromCaller(adapterSpec *APISpec, callerProxyID, toolName string) {
 	log.WithFields(logrus.Fields{
 		"tool_name":          toolName,
 		"proxy_api_id":       callerProxyID,
 		"source_rest_api_id": adapterSpec.MCPAdapterSourceRESTAPIID,
 		"adapter_api_id":     adapterSpec.APIID,
-		"session_key":        sessionKey,
 	}).Warn("MCP tool is not exposed for caller proxy")
 }

--- a/gateway/mcp_pairing_test.go
+++ b/gateway/mcp_pairing_test.go
@@ -149,7 +149,7 @@ func TestSynthesizeMCPAdapterSpecs_AppendsHiddenInternalAdapters(t *testing.T) {
 	assert.True(t, adapterSpec.IsSyntheticMCPAdapter())
 	assert.True(t, adapterSpec.Internal)
 	assert.Equal(t, "rest-1__mcp-server", adapterSpec.APIID)
-	assert.False(t, mcpManaged(adapterSpec))
+	assert.False(t, mcpProxy(adapterSpec))
 	assert.True(t, snapshot.AllowsCaller("rest-1__mcp-server", "proxy-1"))
 }
 

--- a/gateway/mcp_pairing_test.go
+++ b/gateway/mcp_pairing_test.go
@@ -6,10 +6,12 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/internal/mcp/pairing"
+	mockstorage "github.com/TykTechnologies/tyk/storage/mock"
 )
 
 func TestComputeMCPPairing(t *testing.T) {
@@ -135,6 +137,22 @@ func TestBuildAdapterSpec_ReusesSDKAdapterAndUpdatesTools(t *testing.T) {
 	tool, ok := reused.MCPAdapter.ToolViews["proxy-1"].ToolByName("list_orders")
 	require.True(t, ok)
 	assert.Equal(t, "updated list orders", tool.Description)
+}
+
+func TestBuildAdapterSpec_InitializesManagerFields(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+
+	adapterSpec, err := buildMCPAdapterSpec(rest, []*APISpec{proxy}, nil)
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	store := mockstorage.NewMockHandler(ctrl)
+	store.EXPECT().Connect().Return(true).Times(2)
+
+	require.NotPanics(t, func() {
+		adapterSpec.Init(store, store, store)
+	})
 }
 
 func TestSynthesizeMCPAdapterSpecs_AppendsHiddenInternalAdapters(t *testing.T) {

--- a/gateway/mcp_pairing_test.go
+++ b/gateway/mcp_pairing_test.go
@@ -134,6 +134,19 @@ func TestSynthesizeMCPAdapterSpecs_AppendsHiddenInternalAdapters(t *testing.T) {
 	assert.True(t, snapshot.AllowsCaller("rest-1__mcp-server", "proxy-1"))
 }
 
+func TestPairedMCPProxyIDsReferencingRESTSource_UsesPairingIndex(t *testing.T) {
+	snapshot, err := pairing.NewSnapshot([]pairing.Record{
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-2", CallerProxyOrgID: "org-1"},
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-1", CallerProxyOrgID: "org-1"},
+	})
+	require.NoError(t, err)
+
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.mcpPairingIndex.Set(snapshot)
+
+	assert.Equal(t, []string{"proxy-1", "proxy-2"}, gw.pairedMCPProxyIDsReferencingRESTSource("rest-1"))
+}
+
 func pairedMCPProxySpec(proxyID, orgID, restID string, ext *oas.TykMCPServer) *APISpec {
 	doc := pairedMCPProxyOAS(proxyID, orgID, restID)
 	if ext != nil {

--- a/gateway/mcp_pairing_test.go
+++ b/gateway/mcp_pairing_test.go
@@ -71,6 +71,25 @@ func TestComputeMCPPairing_DuplicateProxyTargetsAllowed(t *testing.T) {
 	assert.Equal(t, []string{"proxy-1", "proxy-2"}, source.CallerProxyAPIIDs)
 }
 
+func TestAnalyzeMCPPairingsForSynthesis_BuildsLookupsAndSnapshot(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	unreferenced := restSourceSpec("rest-2", "org-1", true)
+	proxy2 := pairedMCPProxySpec("proxy-2", "org-1", "rest-1", nil)
+	proxy1 := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+
+	analysis, err := analyzeMCPPairingsForSynthesis([]*APISpec{rest, unreferenced, proxy2, proxy1})
+	require.NoError(t, err)
+
+	assert.Same(t, rest, analysis.sourcesByID["rest-1"])
+	assert.Same(t, unreferenced, analysis.sourcesByID["rest-2"])
+	assert.Equal(t, []string{"proxy-1", "proxy-2"}, callerProxyIDs(analysis.proxiesByRESTID["rest-1"]))
+	assert.Equal(t, []string{"rest-1"}, analysis.snapshot.ReferencedRESTAPIIDs())
+
+	source, ok := analysis.snapshot.LookupSource("rest-1")
+	require.True(t, ok)
+	assert.Equal(t, []string{"proxy-1", "proxy-2"}, source.CallerProxyAPIIDs)
+}
+
 func TestDeriveMCPAdapterCatalogue_BuildsProxySpecificToolViewsAndUnion(t *testing.T) {
 	rest := restSourceSpec("rest-1", "org-1", true)
 	proxy1 := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", &oas.TykMCPServer{

--- a/gateway/mcp_pairing_test.go
+++ b/gateway/mcp_pairing_test.go
@@ -120,10 +120,10 @@ func TestBuildAdapterSpec_ReusesSDKAdapterAndUpdatesTools(t *testing.T) {
 	first, err := buildMCPAdapterSpec(rest, []*APISpec{proxy}, nil)
 	require.NoError(t, err)
 	require.True(t, first.IsSyntheticMCPAdapter())
-	require.NotNil(t, first.MCPSDKAdapter)
+	require.NotNil(t, first.MCPAdapter.SDKAdapter)
 	assert.Equal(t, "rest-1__mcp-server", first.APIID)
-	assert.Equal(t, "rest-1", first.MCPAdapterSourceRESTAPIID)
-	assert.Equal(t, []string{"proxy-1"}, first.MCPAllowedCallerProxyAPIIDs)
+	assert.Equal(t, "rest-1", first.MCPAdapter.SourceRESTAPIID)
+	assert.Equal(t, []string{"proxy-1"}, first.MCPAdapter.AllowedCallerProxyAPIIDs)
 
 	rest.OAS.Paths.Set("/orders", &openapi3.PathItem{
 		Get: &openapi3.Operation{OperationID: "list_orders", Summary: "updated list orders"},
@@ -131,8 +131,8 @@ func TestBuildAdapterSpec_ReusesSDKAdapterAndUpdatesTools(t *testing.T) {
 
 	reused, err := buildMCPAdapterSpec(rest, []*APISpec{proxy}, first)
 	require.NoError(t, err)
-	assert.Same(t, first.MCPSDKAdapter, reused.MCPSDKAdapter)
-	tool, ok := reused.MCPToolViews["proxy-1"].ToolByName("list_orders")
+	assert.Same(t, first.MCPAdapter.SDKAdapter, reused.MCPAdapter.SDKAdapter)
+	tool, ok := reused.MCPAdapter.ToolViews["proxy-1"].ToolByName("list_orders")
 	require.True(t, ok)
 	assert.Equal(t, "updated list orders", tool.Description)
 }

--- a/gateway/mcp_pairing_test.go
+++ b/gateway/mcp_pairing_test.go
@@ -1,0 +1,160 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/mcp/pairing"
+)
+
+func TestComputeMCPPairing(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+
+	snapshot, err := computeMCPPairing([]*APISpec{rest, proxy})
+	require.NoError(t, err)
+
+	source, ok := snapshot.LookupSource("rest-1")
+	require.True(t, ok)
+	assert.Equal(t, "rest-1__mcp-server", source.AdapterAPIID)
+	assert.Equal(t, []string{"proxy-1"}, source.CallerProxyAPIIDs)
+}
+
+func TestComputeMCPPairing_CrossOrgRefused(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-rest", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-proxy", "rest-1", nil)
+
+	_, err := computeMCPPairing([]*APISpec{rest, proxy})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-org")
+}
+
+func TestReferencedMCPAdapterRESTIDs_AreProxyDriven(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	unreferenced := restSourceSpec("rest-2", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+
+	snapshot, err := computeMCPPairing([]*APISpec{rest, unreferenced, proxy})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"rest-1"}, snapshot.ReferencedRESTAPIIDs())
+}
+
+func TestReferencedMCPAdapterRESTIDs_RemainsAfterOneProxyRemoved(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-remaining", "org-1", "rest-1", nil)
+
+	snapshot, err := computeMCPPairing([]*APISpec{rest, proxy})
+	require.NoError(t, err)
+
+	source, ok := snapshot.LookupSource("rest-1")
+	require.True(t, ok)
+	assert.Equal(t, []string{"proxy-remaining"}, source.CallerProxyAPIIDs)
+	assert.False(t, snapshot.AllowsCaller(pairing.CanonicalAdapterAPIID("rest-1"), "proxy-removed"))
+}
+
+func TestComputeMCPPairing_DuplicateProxyTargetsAllowed(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy1 := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+	proxy2 := pairedMCPProxySpec("proxy-2", "org-1", "rest-1", nil)
+
+	snapshot, err := computeMCPPairing([]*APISpec{rest, proxy1, proxy2})
+	require.NoError(t, err)
+
+	source, ok := snapshot.LookupSource("rest-1")
+	require.True(t, ok)
+	assert.Equal(t, []string{"proxy-1", "proxy-2"}, source.CallerProxyAPIIDs)
+}
+
+func TestDeriveMCPAdapterCatalogue_BuildsProxySpecificToolViewsAndUnion(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy1 := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "list_orders"}, Name: "orders", Description: "orders visible to proxy one", Allow: boolPtr(true)},
+		},
+	})
+	proxy2 := pairedMCPProxySpec("proxy-2", "org-1", "rest-1", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "create_order"}, Name: "make_order", Description: "orders visible to proxy two", Allow: boolPtr(true)},
+		},
+	})
+
+	catalogue, err := deriveMCPAdapterCatalogue(rest, []*APISpec{proxy1, proxy2})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"make_order", "orders"}, derivedToolNames(catalogue.unionTools))
+	assert.Equal(t, []string{"orders"}, catalogue.toolViews["proxy-1"].ToolNames())
+	assert.Equal(t, []string{"make_order"}, catalogue.toolViews["proxy-2"].ToolNames())
+	assert.Equal(t, "orders visible to proxy one", catalogue.toolViews["proxy-1"].Tools[0].Description)
+	assert.Equal(t, "orders visible to proxy two", catalogue.toolViews["proxy-2"].Tools[0].Description)
+}
+
+func TestBuildAdapterSpec_ReusesSDKAdapterAndUpdatesTools(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+
+	first, err := buildMCPAdapterSpec(rest, []*APISpec{proxy}, nil)
+	require.NoError(t, err)
+	require.True(t, first.IsSyntheticMCPAdapter())
+	require.NotNil(t, first.MCPSDKAdapter)
+	assert.Equal(t, "rest-1__mcp-server", first.APIID)
+	assert.Equal(t, "rest-1", first.MCPAdapterSourceRESTAPIID)
+	assert.Equal(t, []string{"proxy-1"}, first.MCPAllowedCallerProxyAPIIDs)
+
+	rest.OAS.Paths.Set("/orders", &openapi3.PathItem{
+		Get: &openapi3.Operation{OperationID: "list_orders", Summary: "updated list orders"},
+	})
+
+	reused, err := buildMCPAdapterSpec(rest, []*APISpec{proxy}, first)
+	require.NoError(t, err)
+	assert.Same(t, first.MCPSDKAdapter, reused.MCPSDKAdapter)
+	tool, ok := reused.MCPToolViews["proxy-1"].ToolByName("list_orders")
+	require.True(t, ok)
+	assert.Equal(t, "updated list orders", tool.Description)
+}
+
+func TestSynthesizeMCPAdapterSpecs_AppendsHiddenInternalAdapters(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+
+	specs, snapshot, err := synthesizeMCPAdapterSpecs([]*APISpec{rest, proxy}, nil)
+	require.NoError(t, err)
+
+	require.Len(t, specs, 3)
+	adapterSpec := specs[2]
+	assert.True(t, adapterSpec.IsSyntheticMCPAdapter())
+	assert.True(t, adapterSpec.Internal)
+	assert.Equal(t, "rest-1__mcp-server", adapterSpec.APIID)
+	assert.False(t, mcpManaged(adapterSpec))
+	assert.True(t, snapshot.AllowsCaller("rest-1__mcp-server", "proxy-1"))
+}
+
+func pairedMCPProxySpec(proxyID, orgID, restID string, ext *oas.TykMCPServer) *APISpec {
+	doc := pairedMCPProxyOAS(proxyID, orgID, restID)
+	if ext != nil {
+		doc.SetTykMCPServerExtension(ext)
+	}
+	api := &apidef.APIDefinition{}
+	doc.ExtractTo(api)
+	api.APIID = proxyID
+	api.OrgID = orgID
+	api.IsOAS = true
+
+	return &APISpec{
+		APIDefinition: api,
+		OAS:           *doc,
+	}
+}
+
+func derivedToolNames(tools []oas.DerivedTool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}

--- a/gateway/mcp_synthetic_runtime_test.go
+++ b/gateway/mcp_synthetic_runtime_test.go
@@ -288,7 +288,7 @@ func TestCallMCPAdapterTool_LogsToolHiddenFromCallerProxy(t *testing.T) {
 	assert.Equal(t, "proxy-1", warningEntry.Data["proxy_api_id"])
 	assert.Equal(t, "rest-1", warningEntry.Data["source_rest_api_id"])
 	assert.Equal(t, adapterSpec.APIID, warningEntry.Data["adapter_api_id"])
-	assert.Equal(t, "session-key-1", warningEntry.Data["session_key"])
+	assert.NotContains(t, warningEntry.Data, "session_key")
 }
 
 func TestCallMCPAdapterTool_RunsSourceRESTMiddlewareChain(t *testing.T) {

--- a/gateway/mcp_synthetic_runtime_test.go
+++ b/gateway/mcp_synthetic_runtime_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -131,6 +132,34 @@ func TestRESTAsMCPToolView_RewritesToolsListForCallerProxy(t *testing.T) {
 	tool := tools[0].(map[string]any)
 	assert.Equal(t, "orders", tool["name"])
 	assert.Equal(t, "proxy one list", tool["description"])
+}
+
+func TestWriteSyntheticMCPToolsListResponse_FailsClosedWhenRewriteFails(t *testing.T) {
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{}}
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+
+	sdkResponse := newBufferedResponseWriter()
+	sdkResponse.Header().Set("Content-Type", "application/json")
+	sdkResponse.WriteHeader(http.StatusOK)
+	_, err := sdkResponse.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"hidden"}]`))
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	mw.writeSyntheticMCPToolsListResponse(rec, req, sdkResponse, oas.MCPToolView{
+		Tools: []oas.DerivedTool{{
+			Name:        "visible",
+			InputSchema: map[string]any{"type": "object"},
+		}},
+	}, true)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "hidden")
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.NotContains(t, body, "result")
+	rpcErr := body["error"].(map[string]any)
+	assert.EqualValues(t, mcp.JSONRPCInternalError, rpcErr["code"])
 }
 
 func TestBuildAdapterSpec_ReusedSDKAdapterUsesUpdatedToolViewsForCalls(t *testing.T) {

--- a/gateway/mcp_synthetic_runtime_test.go
+++ b/gateway/mcp_synthetic_runtime_test.go
@@ -150,7 +150,7 @@ func TestWriteSyntheticMCPToolsListResponse_FailsClosedWhenRewriteFails(t *testi
 			Name:        "visible",
 			InputSchema: map[string]any{"type": "object"},
 		}},
-	}, true)
+	}, true, nil)
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.NotContains(t, rec.Body.String(), "hidden")

--- a/gateway/mcp_synthetic_runtime_test.go
+++ b/gateway/mcp_synthetic_runtime_test.go
@@ -179,7 +179,7 @@ func TestBuildAdapterSpec_ReusedSDKAdapterUsesUpdatedToolViewsForCalls(t *testin
 	})
 	reused, err := buildMCPAdapterSpec(rest, []*APISpec{updatedProxy}, first)
 	require.NoError(t, err)
-	require.Same(t, first.MCPSDKAdapter, reused.MCPSDKAdapter)
+	require.Same(t, first.MCPAdapter.SDKAdapter, reused.MCPAdapter.SDKAdapter)
 
 	gw := &Gateway{
 		apisByID: map[string]*APISpec{
@@ -534,7 +534,7 @@ func mcpAdapterCallContext(t *testing.T, gw *Gateway, adapterSpec *APISpec, call
 func mustAdapterTool(t *testing.T, adapterSpec *APISpec, name string) oas.DerivedTool {
 	t.Helper()
 
-	for _, tool := range adapterSpec.MCPAdapterUnionTools {
+	for _, tool := range adapterSpec.MCPAdapter.UnionTools {
 		if tool.Name == name {
 			return tool
 		}

--- a/gateway/mcp_synthetic_runtime_test.go
+++ b/gateway/mcp_synthetic_runtime_test.go
@@ -1,0 +1,515 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+func TestResolveInternalHTTPHandlerForMCPAdapterLoop_StampsCallerAndUsesCanonicalAdapter(t *testing.T) {
+	gw := &Gateway{
+		apisByID:        map[string]*APISpec{},
+		apisHandlesByID: &sync.Map{},
+	}
+	adapterSpec := buildSyntheticAdapterForRuntimeTest(t)
+	caller := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+	gw.apisByID[adapterSpec.APIID] = adapterSpec
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	})
+	gw.apisHandlesByID.Store(adapterSpec.APIID, &ChainObject{ThisHandler: handler})
+
+	req := httptest.NewRequest(http.MethodPost, "/proxy/mcp", nil)
+	gotHandler, target, ok := gw.findInternalHTTPHandlerForLoop("rest-1", caller, req)
+	require.True(t, ok)
+	assert.Equal(t, adapterSpec, target)
+	assert.Equal(t, "proxy-1", ctxGetMCPAdapterCallerProxyID(req))
+
+	rec := httptest.NewRecorder()
+	gotHandler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+}
+
+func TestSyntheticAdapterProcessRequest_UsesSDKAdapter(t *testing.T) {
+	adapterSpec := buildSyntheticAdapterForRuntimeTest(t)
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec}}
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(`{
+		"jsonrpc":"2.0",
+		"id":1,
+		"method":"initialize",
+		"params":{
+			"protocolVersion":"2025-06-18",
+			"clientInfo":{"name":"test","version":"v0.0.1"},
+			"capabilities":{}
+		}
+	}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Contains(t, body, "result", "response body: %s", rec.Body.String())
+	result := body["result"].(map[string]any)
+	assert.Equal(t, adapterSpec.APIID, result["serverInfo"].(map[string]any)["name"])
+	capabilities := result["capabilities"].(map[string]any)
+	tools := capabilities["tools"].(map[string]any)
+	assert.NotContains(t, tools, "listChanged")
+	assert.NotContains(t, capabilities, "resources")
+	assert.NotContains(t, capabilities, "prompts")
+}
+
+func TestRESTAsMCPAdapter_RejectsNonPOSTMethods(t *testing.T) {
+	adapterSpec := buildSyntheticAdapterForRuntimeTest(t)
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec}}
+
+	for _, method := range []string{http.MethodGet, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/mcp", nil)
+			req.Header.Set("Accept", "application/json, text/event-stream")
+			rec := httptest.NewRecorder()
+
+			err, status := mw.ProcessRequest(rec, req, nil)
+			require.NoError(t, err)
+			assert.Equal(t, middleware.StatusRespond, status)
+			assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+			assert.Equal(t, http.MethodPost, rec.Header().Get("Allow"))
+		})
+	}
+}
+
+func TestRESTAsMCPToolView_RewritesToolsListForCallerProxy(t *testing.T) {
+	adapterSpec := buildSyntheticAdapterForRuntimeTest(t)
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec}}
+
+	sessionID := initializeSyntheticAdapterSession(t, mw)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(`{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/list",
+		"params":{}
+	}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Contains(t, body, "result", "response body: %s", rec.Body.String())
+	result := body["result"].(map[string]any)
+	tools := result["tools"].([]any)
+	require.Len(t, tools, 1)
+	tool := tools[0].(map[string]any)
+	assert.Equal(t, "orders", tool["name"])
+	assert.Equal(t, "proxy one list", tool["description"])
+}
+
+func TestBuildAdapterSpec_ReusedSDKAdapterUsesUpdatedToolViewsForCalls(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	initialProxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "list_orders"}, Name: "orders", Allow: boolPtr(true)},
+		},
+	})
+	first, err := buildMCPAdapterSpec(rest, []*APISpec{initialProxy}, nil)
+	require.NoError(t, err)
+
+	updatedProxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "create_order"}, Name: "make_order", Allow: boolPtr(true)},
+		},
+	})
+	reused, err := buildMCPAdapterSpec(rest, []*APISpec{updatedProxy}, first)
+	require.NoError(t, err)
+	require.Same(t, first.MCPSDKAdapter, reused.MCPSDKAdapter)
+
+	gw := &Gateway{
+		apisByID: map[string]*APISpec{
+			"rest-1":     rest,
+			reused.APIID: reused,
+			"proxy-1":    updatedProxy,
+		},
+		apisHandlesByID: &sync.Map{},
+	}
+	gw.apisHandlesByID.Store("rest-1", &ChainObject{ThisHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/orders", r.URL.Path)
+		w.WriteHeader(http.StatusCreated)
+	})})
+	snapshot, err := computeMCPPairing([]*APISpec{rest, updatedProxy})
+	require.NoError(t, err)
+	gw.mcpPairingIndex.Set(snapshot)
+
+	tool := mustAdapterTool(t, reused, "make_order")
+	rec, err := defaultMCPAdapterCallTool(
+		mcpAdapterCallContext(t, gw, reused, "proxy-1"),
+		&tool,
+		map[string]any{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Status())
+}
+
+func TestCallMCPAdapterTool_RequiresActualCallerProxyToBeAllowed(t *testing.T) {
+	gw, adapterSpec, sourceCalled := syntheticAdapterGatewayForCallTest(t)
+	tool := mustAdapterTool(t, adapterSpec, "orders")
+
+	_, err := defaultMCPAdapterCallTool(
+		mcpAdapterCallContext(t, gw, adapterSpec, "forged-proxy"),
+		&tool,
+		map[string]any{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "caller proxy is not allowed")
+	assert.False(t, *sourceCalled)
+
+	rec, err := defaultMCPAdapterCallTool(
+		mcpAdapterCallContext(t, gw, adapterSpec, "proxy-1"),
+		&tool,
+		map[string]any{},
+	)
+	require.NoError(t, err)
+	assert.True(t, *sourceCalled)
+	assert.Equal(t, http.StatusOK, rec.Status())
+}
+
+func TestCallMCPAdapterTool_UsesExactSourceRESTAPIID(t *testing.T) {
+	gw, adapterSpec, sourceCalled := syntheticAdapterGatewayForCallTest(t)
+	decoyCalled := false
+	gw.apisByID["rest-10"] = restSourceSpec("rest-10", "org-1", true)
+	gw.apisHandlesByID.Store("rest-10", &ChainObject{ThisHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		decoyCalled = true
+		w.WriteHeader(http.StatusTeapot)
+	})})
+
+	tool := mustAdapterTool(t, adapterSpec, "orders")
+	rec, err := defaultMCPAdapterCallTool(
+		mcpAdapterCallContext(t, gw, adapterSpec, "proxy-1"),
+		&tool,
+		map[string]any{},
+	)
+	require.NoError(t, err)
+	assert.True(t, *sourceCalled)
+	assert.False(t, decoyCalled)
+	assert.Equal(t, http.StatusOK, rec.Status())
+}
+
+func TestCallMCPAdapterTool_AliasUsesCanonicalRequest(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	var gotMethod, gotPath string
+	gw.apisHandlesByID.Store("rest-1", &ChainObject{ThisHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})})
+
+	tool := mustAdapterTool(t, adapterSpec, "orders")
+	_, err := defaultMCPAdapterCallTool(
+		mcpAdapterCallContext(t, gw, adapterSpec, "proxy-1"),
+		&tool,
+		map[string]any{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Equal(t, "/orders", gotPath)
+}
+
+func TestCallMCPAdapterTool_RejectsToolHiddenFromCallerProxy(t *testing.T) {
+	gw, adapterSpec, sourceCalled := syntheticAdapterGatewayForCallTest(t)
+	tool := mustAdapterTool(t, adapterSpec, "make_order")
+
+	_, err := defaultMCPAdapterCallTool(
+		mcpAdapterCallContext(t, gw, adapterSpec, "proxy-1"),
+		&tool,
+		map[string]any{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool not found")
+	assert.False(t, *sourceCalled)
+}
+
+func TestCallMCPAdapterTool_LogsToolHiddenFromCallerProxy(t *testing.T) {
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.WarnLevel)
+	originalLog := log
+	log = logger
+	t.Cleanup(func() {
+		log = originalLog
+	})
+
+	gw, adapterSpec, sourceCalled := syntheticAdapterGatewayForCallTest(t)
+	tool := mustAdapterTool(t, adapterSpec, "make_order")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, &user.SessionState{KeyID: "session-key-1"})
+
+	_, err := gw.callMCPAdapterTool(req, adapterSpec, &tool, map[string]any{})
+	require.Error(t, err)
+	assert.False(t, *sourceCalled)
+
+	var warningEntry *logrus.Entry
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.WarnLevel && entry.Message == "MCP tool is not exposed for caller proxy" {
+			warningEntry = entry
+			break
+		}
+	}
+	require.NotNil(t, warningEntry)
+	assert.Equal(t, "make_order", warningEntry.Data["tool_name"])
+	assert.Equal(t, "proxy-1", warningEntry.Data["proxy_api_id"])
+	assert.Equal(t, "rest-1", warningEntry.Data["source_rest_api_id"])
+	assert.Equal(t, adapterSpec.APIID, warningEntry.Data["adapter_api_id"])
+	assert.Equal(t, "session-key-1", warningEntry.Data["session_key"])
+}
+
+func TestCallMCPAdapterTool_RunsSourceRESTMiddlewareChain(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	source := gw.apisByID["rest-1"]
+	base := &BaseMiddleware{Spec: source, Gw: gw}
+	bypass := &MCPLoopAuthBypassMiddleware{BaseMiddleware: base}
+	restore := &MCPLoopAuthRestoreMiddleware{BaseMiddleware: base}
+
+	var order []string
+	gw.apisHandlesByID.Store("rest-1", &ChainObject{ThisHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err, _ := bypass.ProcessRequest(w, r, nil)
+		require.NoError(t, err)
+		order = append(order, string(ctxGetRequestStatus(r)))
+
+		if ctxGetRequestStatus(r) != StatusOkAndIgnore {
+			http.Error(w, "auth was not bypassed", http.StatusUnauthorized)
+			return
+		}
+		order = append(order, "source-auth")
+
+		err, _ = restore.ProcessRequest(w, r, nil)
+		require.NoError(t, err)
+		order = append(order, string(ctxGetRequestStatus(r)))
+
+		r.Header.Set("X-Source-Transform", "seen")
+		order = append(order, "source-transform")
+
+		require.Equal(t, "seen", r.Header.Get("X-Source-Transform"))
+		order = append(order, "upstream")
+		w.WriteHeader(http.StatusOK)
+	})})
+
+	tool := mustAdapterTool(t, adapterSpec, "orders")
+	rec, err := defaultMCPAdapterCallTool(
+		mcpAdapterCallContext(t, gw, adapterSpec, "proxy-1"),
+		&tool,
+		map[string]any{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Status())
+	assert.Equal(t, []string{
+		string(StatusOkAndIgnore),
+		"source-auth",
+		string(StatusOk),
+		"source-transform",
+		"upstream",
+	}, order)
+}
+
+func TestCallMCPAdapterTool_ForwardsQueryParamsThroughJSONRPC(t *testing.T) {
+	rest := restSourceSpec("rest-query", "org-1", true)
+	rest.OAS.Paths.Set("/orders", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "list_orders",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{Value: &openapi3.Parameter{
+					Name:     "limit",
+					In:       openapi3.ParameterInQuery,
+					Required: true,
+					Schema:   openapi3.NewStringSchema().NewRef(),
+				}},
+			},
+		},
+	})
+	proxy := pairedMCPProxySpec("proxy-query", "org-1", "rest-query", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "list_orders"}, Name: "orders", Allow: boolPtr(true)},
+		},
+	})
+	adapterSpec, err := buildMCPAdapterSpec(rest, []*APISpec{proxy}, nil)
+	require.NoError(t, err)
+
+	gw := &Gateway{
+		apisByID: map[string]*APISpec{
+			"rest-query":      rest,
+			adapterSpec.APIID: adapterSpec,
+			"proxy-query":     proxy,
+		},
+		apisHandlesByID: &sync.Map{},
+	}
+	gw.apisHandlesByID.Store("rest-query", &ChainObject{ThisHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"query":"` + r.URL.RawQuery + `"}`))
+		require.NoError(t, err)
+	})})
+	snapshot, err := computeMCPPairing([]*APISpec{rest, proxy})
+	require.NoError(t, err)
+	gw.mcpPairingIndex.Set(snapshot)
+
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-query")
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(`{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/call",
+		"params":{"name":"orders","arguments":{"limit":10}}
+	}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-query")
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+	require.NoError(t, err)
+	require.Equal(t, middleware.StatusRespond, status)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Contains(t, body, "result", "response body: %s", rec.Body.String())
+	result := body["result"].(map[string]any)
+	content := result["content"].([]any)
+	text := content[0].(map[string]any)["text"]
+	assert.Equal(t, `{"query":"limit=10"}`, text)
+}
+
+func initializeSyntheticAdapterSession(t *testing.T, mw *JSONRPCMiddleware, callerProxyID ...string) string {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(`{
+		"jsonrpc":"2.0",
+		"id":1,
+		"method":"initialize",
+		"params":{
+			"protocolVersion":"2025-06-18",
+			"clientInfo":{"name":"test","version":"v0.0.1"},
+			"capabilities":{}
+		}
+	}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if len(callerProxyID) > 0 {
+		ctxSetMCPAdapterCallerProxyID(req, callerProxyID[0])
+	}
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+	require.NoError(t, err)
+	require.Equal(t, middleware.StatusRespond, status)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	sessionID := rec.Header().Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+	return sessionID
+}
+
+func buildSyntheticAdapterForRuntimeTest(t *testing.T) *APISpec {
+	t.Helper()
+
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy1 := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "list_orders"}, Name: "orders", Description: "proxy one list", Allow: boolPtr(true)},
+		},
+	})
+	proxy2 := pairedMCPProxySpec("proxy-2", "org-1", "rest-1", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "create_order"}, Name: "make_order", Description: "proxy two create", Allow: boolPtr(true)},
+		},
+	})
+
+	adapterSpec, err := buildMCPAdapterSpec(rest, []*APISpec{proxy1, proxy2}, nil)
+	require.NoError(t, err)
+	return adapterSpec
+}
+
+func syntheticAdapterGatewayForCallTest(t *testing.T) (*Gateway, *APISpec, *bool) {
+	t.Helper()
+
+	adapterSpec := buildSyntheticAdapterForRuntimeTest(t)
+	sourceSpec := restSourceSpec("rest-1", "org-1", true)
+	sourceCalled := false
+
+	gw := &Gateway{
+		apisByID: map[string]*APISpec{
+			"rest-1":          sourceSpec,
+			adapterSpec.APIID: adapterSpec,
+			"proxy-1":         pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil),
+			"proxy-2":         pairedMCPProxySpec("proxy-2", "org-1", "rest-1", nil),
+		},
+		apisHandlesByID: &sync.Map{},
+	}
+	gw.apisHandlesByID.Store("rest-1", &ChainObject{ThisHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sourceCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"path":"` + r.URL.Path + `"}`))
+		require.NoError(t, err)
+	})})
+
+	snapshot, err := computeMCPPairing([]*APISpec{
+		sourceSpec,
+		pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil),
+		pairedMCPProxySpec("proxy-2", "org-1", "rest-1", nil),
+	})
+	require.NoError(t, err)
+	gw.mcpPairingIndex.Set(snapshot)
+
+	return gw, adapterSpec, &sourceCalled
+}
+
+func mcpAdapterCallContext(t *testing.T, gw *Gateway, adapterSpec *APISpec, callerProxyID string) context.Context {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	ctxSetMCPAdapterCallerProxyID(req, callerProxyID)
+	installMCPAdapterCallContext(req, gw, adapterSpec)
+	return req.Context()
+}
+
+func mustAdapterTool(t *testing.T, adapterSpec *APISpec, name string) oas.DerivedTool {
+	t.Helper()
+
+	for _, tool := range adapterSpec.MCPAdapterUnionTools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("adapter tool %q not found", name)
+	return oas.DerivedTool{}
+}

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -83,15 +83,9 @@ type APISpec struct {
 	// Value: VEM path (e.g., "/mcp-tool:get-weather")
 	MCPPrimitives map[string]string
 
-	// Runtime-only REST-as-MCP synthetic adapter fields. These are never
-	// extracted to/persisted from API definitions or OAS documents.
-	MCPAdapterSynthetic           bool
-	MCPAdapterSourceRESTAPIID     string
-	MCPSDKAdapter                 *restmcpadapter.SDKAdapter
-	MCPAllowedCallerProxyAPIIDs   []string
-	MCPAllowedCallerProxyAPIIDSet map[string]struct{}
-	MCPToolViews                  map[string]oas.MCPToolView
-	MCPAdapterUnionTools          []oas.DerivedTool
+	// MCPAdapter holds runtime-only REST-as-MCP synthetic adapter state. It is
+	// never extracted to/persisted from API definitions or OAS documents.
+	MCPAdapter MCPAdapterRuntime
 
 	JSONRPCRouter jsonrpc.Router
 
@@ -120,6 +114,17 @@ type APISpec struct {
 	// compiledErrorOverrides holds the indexed error override rules for O(1) lookup.
 	// Built from apidef.ErrorOverrides during gateway startup.
 	compiledErrorOverrides atomic.Pointer[CompiledErrorOverrides]
+}
+
+// MCPAdapterRuntime groups runtime-only state for a synthetic REST-as-MCP
+// adapter API.
+type MCPAdapterRuntime struct {
+	Synthetic                bool
+	SourceRESTAPIID          string
+	SDKAdapter               *restmcpadapter.SDKAdapter
+	AllowedCallerProxyAPIIDs []string
+	ToolViews                map[string]oas.MCPToolView
+	UnionTools               []oas.DerivedTool
 }
 
 // CheckSpecMatchesStatus checks if a URL spec has a specific status.
@@ -451,5 +456,5 @@ func (a *APISpec) APIType() string {
 // IsSyntheticMCPAdapter reports whether this spec is a hidden runtime-only
 // adapter synthesized for a REST-as-MCP proxy/source pairing.
 func (a *APISpec) IsSyntheticMCPAdapter() bool {
-	return a != nil && a.MCPAdapterSynthetic
+	return a != nil && a.MCPAdapter.Synthetic
 }

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -24,6 +24,7 @@ import (
 	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/jsonrpc"
+	restmcpadapter "github.com/TykTechnologies/tyk/internal/mcp/adapter"
 
 	_ "github.com/TykTechnologies/tyk/internal/mcp" // registers MCP VEM prefixes
 )
@@ -81,6 +82,16 @@ type APISpec struct {
 	// Key format: "tool:{name}", "resource:{pattern}", "prompt:{name}"
 	// Value: VEM path (e.g., "/mcp-tool:get-weather")
 	MCPPrimitives map[string]string
+
+	// Runtime-only REST-as-MCP synthetic adapter fields. These are never
+	// extracted to/persisted from API definitions or OAS documents.
+	MCPAdapterSynthetic           bool
+	MCPAdapterSourceRESTAPIID     string
+	MCPSDKAdapter                 *restmcpadapter.SDKAdapter
+	MCPAllowedCallerProxyAPIIDs   []string
+	MCPAllowedCallerProxyAPIIDSet map[string]struct{}
+	MCPToolViews                  map[string]oas.MCPToolView
+	MCPAdapterUnionTools          []oas.DerivedTool
 
 	JSONRPCRouter jsonrpc.Router
 
@@ -435,4 +446,10 @@ func (a *APISpec) APIType() string {
 	default:
 		return "classic"
 	}
+}
+
+// IsSyntheticMCPAdapter reports whether this spec is a hidden runtime-only
+// adapter synthesized for a REST-as-MCP proxy/source pairing.
+func (a *APISpec) IsSyntheticMCPAdapter() bool {
+	return a != nil && a.MCPAdapterSynthetic
 }

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/jsonrpc"
 	"github.com/TykTechnologies/tyk/internal/mcp"
@@ -171,6 +172,10 @@ func (m *JSONRPCMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		return nil, http.StatusOK
 	}
 
+	if m.Spec.IsSyntheticMCPAdapter() {
+		return m.processSyntheticMCPAdapterRequest(w, r)
+	}
+
 	// Validate request type
 	if !m.validateJSONRPCRequest(r) {
 		return nil, http.StatusOK
@@ -291,5 +296,141 @@ func (m *JSONRPCMiddleware) mapJSONRPCErrorToHTTP(code int) int {
 		return http.StatusForbidden
 	default:
 		return http.StatusInternalServerError
+	}
+}
+
+//nolint:staticcheck // ST1008: middleware helper mirrors ProcessRequest's (error, int) convention.
+func (m *JSONRPCMiddleware) processSyntheticMCPAdapterRequest(w http.ResponseWriter, r *http.Request) (error, int) {
+	if m.Spec == nil || m.Spec.MCPSDKAdapter == nil {
+		http.Error(w, "REST-as-MCP adapter is not initialized", http.StatusInternalServerError)
+		return nil, middleware.StatusRespond
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return nil, middleware.StatusRespond
+	}
+
+	method := syntheticJSONRPCMethod(r)
+	normaliseMCPStreamableAccept(r)
+	installMCPAdapterCallContext(r, m.Gw, m.Spec)
+
+	if method == mcp.MethodToolsList {
+		rec := newBufferedResponseWriter()
+		m.Spec.MCPSDKAdapter.StreamableHTTPHandler(nil).ServeHTTP(rec, r)
+		body := rec.body.Bytes()
+		if view, ok := m.syntheticMCPToolViewForCaller(r); ok && rec.statusCode < http.StatusBadRequest {
+			if rewritten, err := rewriteMCPToolsListResponse(body, view); err == nil {
+				body = rewritten
+			} else {
+				m.Logger().WithError(err).Warn("failed to rewrite REST-as-MCP tools/list response")
+			}
+		}
+		rec.writeTo(w, body)
+		return nil, middleware.StatusRespond
+	}
+
+	m.Spec.MCPSDKAdapter.StreamableHTTPHandler(nil).ServeHTTP(w, r)
+	return nil, middleware.StatusRespond
+}
+
+func syntheticJSONRPCMethod(r *http.Request) string {
+	if r == nil || r.Method != http.MethodPost || r.Body == nil {
+		return ""
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return ""
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	var req JSONRPCRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return ""
+	}
+	return req.Method
+}
+
+func normaliseMCPStreamableAccept(r *http.Request) {
+	if r == nil {
+		return
+	}
+	accept := r.Header.Get("Accept")
+	if strings.Contains(accept, "application/json") && strings.Contains(accept, "text/event-stream") {
+		return
+	}
+	r.Header.Set("Accept", "application/json, text/event-stream")
+}
+
+func (m *JSONRPCMiddleware) syntheticMCPToolViewForCaller(r *http.Request) (oas.MCPToolView, bool) {
+	callerProxyID := ctxGetMCPAdapterCallerProxyID(r)
+	if callerProxyID == "" || m.Spec == nil || m.Spec.MCPToolViews == nil {
+		return oas.MCPToolView{}, false
+	}
+	view, ok := m.Spec.MCPToolViews[callerProxyID]
+	return view, ok
+}
+
+func rewriteMCPToolsListResponse(body []byte, view oas.MCPToolView) ([]byte, error) {
+	var envelope map[string]any
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+	result, ok := envelope["result"].(map[string]any)
+	if !ok {
+		return body, nil
+	}
+	result["tools"] = view.Tools
+	return json.Marshal(envelope)
+}
+
+type bufferedResponseWriter struct {
+	header      http.Header
+	body        bytes.Buffer
+	statusCode  int
+	wroteHeader bool
+}
+
+func newBufferedResponseWriter() *bufferedResponseWriter {
+	return &bufferedResponseWriter{
+		header:     http.Header{},
+		statusCode: http.StatusOK,
+	}
+}
+
+func (w *bufferedResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *bufferedResponseWriter) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
+	w.statusCode = statusCode
+	w.wroteHeader = true
+}
+
+func (w *bufferedResponseWriter) Write(data []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.body.Write(data)
+}
+
+func (w *bufferedResponseWriter) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func (w *bufferedResponseWriter) writeTo(dst http.ResponseWriter, body []byte) {
+	for key, values := range w.header {
+		for _, value := range values {
+			dst.Header().Add(key, value)
+		}
+	}
+	dst.WriteHeader(w.statusCode)
+	if _, err := dst.Write(body); err != nil {
+		log.WithError(err).Debug("failed to write REST-as-MCP response")
 	}
 }

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -26,6 +26,8 @@ const (
 	httpHeaderContentLength = "Content-Length"
 )
 
+const syntheticJSONRPCMethodReadLimit = 1 << 20
+
 // JSONRPCMiddleware handles JSON-RPC 2.0 request detection and routing.
 // When a client sends a JSON-RPC request to a JSON-RPC endpoint, the middleware detects it,
 // extracts the method, routes to the correct VEM, and enables the middleware chain to execute
@@ -334,17 +336,28 @@ func syntheticJSONRPCMethod(r *http.Request) string {
 	if state := httpctx.GetJSONRPCRoutingState(r); state != nil && state.Method != "" {
 		return state.Method
 	}
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(io.LimitReader(r.Body, syntheticJSONRPCMethodReadLimit+1))
+	r.Body = prefixedReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(body), r.Body),
+		Closer: r.Body,
+	}
 	if err != nil {
 		return ""
 	}
-	r.Body = io.NopCloser(bytes.NewReader(body))
+	if len(body) > syntheticJSONRPCMethodReadLimit {
+		return ""
+	}
 
 	var req JSONRPCRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return ""
 	}
 	return req.Method
+}
+
+type prefixedReadCloser struct {
+	io.Reader
+	io.Closer
 }
 
 func normaliseMCPStreamableAccept(r *http.Request) {

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -301,7 +301,7 @@ func (m *JSONRPCMiddleware) mapJSONRPCErrorToHTTP(code int) int {
 
 //nolint:staticcheck // ST1008: middleware helper mirrors ProcessRequest's (error, int) convention.
 func (m *JSONRPCMiddleware) processSyntheticMCPAdapterRequest(w http.ResponseWriter, r *http.Request) (error, int) {
-	if m.Spec == nil || m.Spec.MCPSDKAdapter == nil {
+	if m.Spec == nil || m.Spec.MCPAdapter.SDKAdapter == nil {
 		http.Error(w, "REST-as-MCP adapter is not initialized", http.StatusInternalServerError)
 		return nil, middleware.StatusRespond
 	}
@@ -317,13 +317,13 @@ func (m *JSONRPCMiddleware) processSyntheticMCPAdapterRequest(w http.ResponseWri
 
 	if method == mcp.MethodToolsList {
 		rec := newBufferedResponseWriter()
-		m.Spec.MCPSDKAdapter.StreamableHTTPHandler(nil).ServeHTTP(rec, r)
+		m.Spec.MCPAdapter.SDKAdapter.StreamableHTTPHandler(nil).ServeHTTP(rec, r)
 		view, ok := m.syntheticMCPToolViewForCaller(r)
 		m.writeSyntheticMCPToolsListResponse(w, r, rec, view, ok)
 		return nil, middleware.StatusRespond
 	}
 
-	m.Spec.MCPSDKAdapter.StreamableHTTPHandler(nil).ServeHTTP(w, r)
+	m.Spec.MCPAdapter.SDKAdapter.StreamableHTTPHandler(nil).ServeHTTP(w, r)
 	return nil, middleware.StatusRespond
 }
 
@@ -360,10 +360,10 @@ func normaliseMCPStreamableAccept(r *http.Request) {
 
 func (m *JSONRPCMiddleware) syntheticMCPToolViewForCaller(r *http.Request) (oas.MCPToolView, bool) {
 	callerProxyID := ctxGetMCPAdapterCallerProxyID(r)
-	if callerProxyID == "" || m.Spec == nil || m.Spec.MCPToolViews == nil {
+	if callerProxyID == "" || m.Spec == nil || m.Spec.MCPAdapter.ToolViews == nil {
 		return oas.MCPToolView{}, false
 	}
-	view, ok := m.Spec.MCPToolViews[callerProxyID]
+	view, ok := m.Spec.MCPAdapter.ToolViews[callerProxyID]
 	return view, ok
 }
 

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -407,6 +407,9 @@ func rewriteMCPToolsListResponse(body []byte, view oas.MCPToolView) ([]byte, err
 	return json.Marshal(envelope)
 }
 
+// bufferedResponseWriter is intentionally local to synthetic REST-as-MCP
+// tools/list handling. It captures only the response pieces we need to rewrite
+// SDK JSON responses before forwarding them to the caller.
 type bufferedResponseWriter struct {
 	header      http.Header
 	body        bytes.Buffer

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -318,15 +318,8 @@ func (m *JSONRPCMiddleware) processSyntheticMCPAdapterRequest(w http.ResponseWri
 	if method == mcp.MethodToolsList {
 		rec := newBufferedResponseWriter()
 		m.Spec.MCPSDKAdapter.StreamableHTTPHandler(nil).ServeHTTP(rec, r)
-		body := rec.body.Bytes()
-		if view, ok := m.syntheticMCPToolViewForCaller(r); ok && rec.statusCode < http.StatusBadRequest {
-			if rewritten, err := rewriteMCPToolsListResponse(body, view); err == nil {
-				body = rewritten
-			} else {
-				m.Logger().WithError(err).Warn("failed to rewrite REST-as-MCP tools/list response")
-			}
-		}
-		rec.writeTo(w, body)
+		view, ok := m.syntheticMCPToolViewForCaller(r)
+		m.writeSyntheticMCPToolsListResponse(w, r, rec, view, ok)
 		return nil, middleware.StatusRespond
 	}
 
@@ -369,6 +362,20 @@ func (m *JSONRPCMiddleware) syntheticMCPToolViewForCaller(r *http.Request) (oas.
 	}
 	view, ok := m.Spec.MCPToolViews[callerProxyID]
 	return view, ok
+}
+
+func (m *JSONRPCMiddleware) writeSyntheticMCPToolsListResponse(w http.ResponseWriter, r *http.Request, rec *bufferedResponseWriter, view oas.MCPToolView, filter bool) {
+	body := rec.body.Bytes()
+	if filter && rec.statusCode < http.StatusBadRequest {
+		rewritten, err := rewriteMCPToolsListResponse(body, view)
+		if err != nil {
+			m.Logger().WithError(err).Warn("failed to rewrite REST-as-MCP tools/list response")
+			m.writeJSONRPCError(w, r, nil, mcp.JSONRPCInternalError, "Internal error", nil)
+			return
+		}
+		body = rewritten
+	}
+	rec.writeTo(w, body)
 }
 
 func rewriteMCPToolsListResponse(body []byte, view oas.MCPToolView) ([]byte, error) {

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -331,6 +331,9 @@ func syntheticJSONRPCMethod(r *http.Request) string {
 	if r == nil || r.Method != http.MethodPost || r.Body == nil {
 		return ""
 	}
+	if state := httpctx.GetJSONRPCRoutingState(r); state != nil && state.Method != "" {
+		return state.Method
+	}
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return ""

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -313,15 +313,25 @@ func (m *JSONRPCMiddleware) processSyntheticMCPAdapterRequest(w http.ResponseWri
 		return nil, middleware.StatusRespond
 	}
 
-	method := syntheticJSONRPCMethod(r)
+	policyCtx, responded := m.prepareRESTAsMCPPolicy(w, r)
+	if responded {
+		return nil, middleware.StatusRespond
+	}
+
+	method := ""
+	if policyCtx != nil && policyCtx.rpcReq != nil {
+		method = policyCtx.rpcReq.Method
+	} else {
+		method = syntheticJSONRPCMethod(r)
+	}
 	normaliseMCPStreamableAccept(r)
 	installMCPAdapterCallContext(r, m.Gw, m.Spec)
 
-	if method == mcp.MethodToolsList {
+	if method == mcp.MethodToolsList || (policyCtx != nil && policyCtx.listConfig != nil) {
 		rec := newBufferedResponseWriter()
 		m.Spec.MCPAdapter.SDKAdapter.StreamableHTTPHandler(nil).ServeHTTP(rec, r)
 		view, ok := m.syntheticMCPToolViewForCaller(r)
-		m.writeSyntheticMCPToolsListResponse(w, r, rec, view, ok)
+		m.writeSyntheticMCPToolsListResponse(w, r, rec, view, ok, policyCtx)
 		return nil, middleware.StatusRespond
 	}
 
@@ -380,7 +390,7 @@ func (m *JSONRPCMiddleware) syntheticMCPToolViewForCaller(r *http.Request) (oas.
 	return view, ok
 }
 
-func (m *JSONRPCMiddleware) writeSyntheticMCPToolsListResponse(w http.ResponseWriter, r *http.Request, rec *bufferedResponseWriter, view oas.MCPToolView, filter bool) {
+func (m *JSONRPCMiddleware) writeSyntheticMCPToolsListResponse(w http.ResponseWriter, r *http.Request, rec *bufferedResponseWriter, view oas.MCPToolView, filter bool, policyCtx *restAsMCPPolicyContext) {
 	body := rec.body.Bytes()
 	if filter && rec.statusCode < http.StatusBadRequest {
 		rewritten, err := rewriteMCPToolsListResponse(body, view)
@@ -390,6 +400,11 @@ func (m *JSONRPCMiddleware) writeSyntheticMCPToolsListResponse(w http.ResponseWr
 			return
 		}
 		body = rewritten
+	}
+	if rec.statusCode < http.StatusBadRequest {
+		if filtered, ok := filterRESTAsMCPListResponse(body, policyCtx); ok {
+			body = filtered
+		}
 	}
 	rec.writeTo(w, body)
 }

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy.go
@@ -1,0 +1,294 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/TykTechnologies/tyk/internal/httpctx"
+	"github.com/TykTechnologies/tyk/internal/jsonrpc"
+	jsonrpcerrors "github.com/TykTechnologies/tyk/internal/jsonrpc/errors"
+	"github.com/TykTechnologies/tyk/internal/mcp"
+	"github.com/TykTechnologies/tyk/internal/rate"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+const (
+	jsonrpcRateLimitExceededMessage = "Rate Limit Exceeded"
+	jsonrpcInternalErrorMessage     = "Internal Server Error"
+)
+
+type restAsMCPPolicyContext struct {
+	proxyAPIID string
+	proxySpec  *APISpec
+	session    *user.SessionState
+	accessDef  user.AccessDefinition
+	hasAccess  bool
+	rpcReq     *JSONRPCRequest
+	listConfig *mcp.ListFilterConfig
+}
+
+// prepareRESTAsMCPPolicy parses the JSON-RPC request handled by a synthetic
+// REST-as-MCP adapter and applies caller-proxy policy before SDK execution.
+func (m *JSONRPCMiddleware) prepareRESTAsMCPPolicy(w http.ResponseWriter, r *http.Request) (*restAsMCPPolicyContext, bool) {
+	rpcReq, ok, err := parseSyntheticAdapterJSONRPC(r)
+	if err != nil {
+		m.writeJSONRPCError(w, r, nil, mcp.JSONRPCParseError, mcp.ErrMsgParseError, nil)
+		return nil, true
+	}
+	if !ok {
+		return nil, false
+	}
+
+	route, err := m.routeSyntheticAdapterJSONRPC(rpcReq)
+	if err != nil {
+		m.writeJSONRPCError(w, r, rpcReq.ID, mcp.JSONRPCInvalidParams, err.Error(), nil)
+		return nil, true
+	}
+
+	policyCtx := &restAsMCPPolicyContext{
+		rpcReq:     rpcReq,
+		listConfig: listConfigForMCPMethod(rpcReq.Method),
+	}
+	policyCtx.setJSONRPCState(r, route.VEMChain, route.PrimitiveName)
+	m.loadRESTAsMCPPolicyCaller(r, policyCtx)
+
+	if m.deniesRESTAsMCPPolicies(w, r, policyCtx) {
+		return policyCtx, true
+	}
+
+	return policyCtx, false
+}
+
+func parseSyntheticAdapterJSONRPC(r *http.Request) (*JSONRPCRequest, bool, error) {
+	if r == nil || r.Method != http.MethodPost || r.Body == nil {
+		return nil, false, nil
+	}
+	if !strings.HasPrefix(r.Header.Get(headerContentType), contentTypeJSON) {
+		return nil, false, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, syntheticJSONRPCMethodReadLimit+1))
+	r.Body = prefixedReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(body), r.Body),
+		Closer: r.Body,
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if len(body) > syntheticJSONRPCMethodReadLimit {
+		return nil, false, fmt.Errorf("synthetic JSON-RPC request exceeds %d bytes", syntheticJSONRPCMethodReadLimit)
+	}
+
+	var rpcReq JSONRPCRequest
+	if err := json.Unmarshal(body, &rpcReq); err != nil || rpcReq.Method == "" {
+		return nil, false, nil
+	}
+
+	return &rpcReq, true, nil
+}
+
+func (m *JSONRPCMiddleware) routeSyntheticAdapterJSONRPC(rpcReq *JSONRPCRequest) (jsonrpc.RouteResult, error) {
+	router := m.Spec.JSONRPCRouter
+	if router == nil {
+		router = mcp.NewRouter()
+	}
+
+	result, err := router.RouteMethod(rpcReq.Method, rpcReq.Params, m.Spec.MCPPrimitives)
+	if err != nil {
+		return jsonrpc.RouteResult{}, err
+	}
+	return result, nil
+}
+
+func (c *restAsMCPPolicyContext) setJSONRPCState(r *http.Request, vemChain []string, primitiveName string) {
+	primitiveType := primitiveTypeForMethod(c.rpcReq.Method)
+	httpctx.SetJSONRPCRoutingState(r, &httpctx.JSONRPCRoutingState{
+		Method:        c.rpcReq.Method,
+		Params:        c.rpcReq.Params,
+		ID:            c.rpcReq.ID,
+		OriginalPath:  r.URL.Path,
+		VEMChain:      vemChain,
+		PrimitiveType: primitiveType,
+		PrimitiveName: primitiveName,
+	})
+	httpctx.SetJsonRPCRouting(r, true)
+
+	ctxSetMCPMethod(r, c.rpcReq.Method)
+	ctxSetMCPPrimitiveType(r, primitiveType)
+	ctxSetMCPPrimitiveName(r, primitiveName)
+}
+
+func (m *JSONRPCMiddleware) loadRESTAsMCPPolicyCaller(r *http.Request, policyCtx *restAsMCPPolicyContext) {
+	proxyAPIID := ctxGetMCPAdapterCallerProxyID(r)
+	if proxyAPIID == "" || m.Gw == nil {
+		return
+	}
+
+	policyCtx.proxyAPIID = proxyAPIID
+	policyCtx.proxySpec = m.Gw.getApiSpec(proxyAPIID)
+	policyCtx.session = ctxGetSession(r)
+	if policyCtx.proxySpec == nil || policyCtx.session == nil {
+		return
+	}
+
+	accessDef, found := policyCtx.session.AccessRights[proxyAPIID]
+	if !found {
+		return
+	}
+
+	policyCtx.accessDef = accessDef
+	policyCtx.hasAccess = true
+}
+
+func (m *JSONRPCMiddleware) deniesRESTAsMCPPolicies(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext) bool {
+	if m.deniesRESTAsMCPMethod(w, r, policyCtx) {
+		return true
+	}
+	if m.deniesRESTAsMCPPrimitive(w, r, policyCtx) {
+		return true
+	}
+	return m.enforceRESTAsMCPEndpointRateLimits(w, r, policyCtx)
+}
+
+func (m *JSONRPCMiddleware) deniesRESTAsMCPMethod(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext) bool {
+	if !policyCtx.hasAccess || policyCtx.accessDef.JSONRPCMethodsAccessRights.IsEmpty() {
+		return false
+	}
+	if !mcp.CheckAccessControlRules(policyCtx.accessDef.JSONRPCMethodsAccessRights, policyCtx.rpcReq.Method) {
+		return false
+	}
+
+	writeJSONRPCAccessDenied(w, r, fmt.Sprintf("method '%s' is not available", policyCtx.rpcReq.Method))
+	return true
+}
+
+func (m *JSONRPCMiddleware) deniesRESTAsMCPPrimitive(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext) bool {
+	if !policyCtx.hasAccess || policyCtx.accessDef.MCPAccessRights.IsEmpty() {
+		return false
+	}
+
+	state := httpctx.GetJSONRPCRoutingState(r)
+	if state == nil || state.PrimitiveType == "" || state.PrimitiveName == "" {
+		return false
+	}
+
+	rules := rulesForPrimitiveType(policyCtx.accessDef.MCPAccessRights, state.PrimitiveType)
+	if !mcp.CheckAccessControlRules(rules, state.PrimitiveName) {
+		return false
+	}
+
+	writeJSONRPCAccessDenied(w, r, fmt.Sprintf("%s '%s' is not available", state.PrimitiveType, state.PrimitiveName))
+	return true
+}
+
+func (m *JSONRPCMiddleware) enforceRESTAsMCPEndpointRateLimits(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext) bool {
+	if !policyCtx.hasAccess || policyCtx.proxySpec == nil || m.Gw == nil || m.Gw.SessionLimiter.config == nil {
+		return false
+	}
+
+	state := httpctx.GetJSONRPCRoutingState(r)
+	if state == nil {
+		return false
+	}
+
+	for _, vemPath := range state.VEMChain {
+		if m.enforceRESTAsMCPEndpointRateLimit(w, r, policyCtx, vemPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *JSONRPCMiddleware) enforceRESTAsMCPEndpointRateLimit(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext, vemPath string) bool {
+	if len(policyCtx.accessDef.Endpoints) == 0 {
+		return false
+	}
+
+	rateReq := restAsMCPRateLimitRequest(r, vemPath)
+	if _, ok := m.Gw.SessionLimiter.RateLimitInfo(rateReq, policyCtx.proxySpec, policyCtx.accessDef.Endpoints); !ok {
+		return false
+	}
+
+	reason := m.Gw.SessionLimiter.ForwardMessage(
+		rateReq,
+		policyCtx.session,
+		restAsMCPRateLimitKey(r, policyCtx),
+		"",
+		true,
+		false,
+		policyCtx.proxySpec,
+		false,
+		restAsMCPRateLimitHeaderSender(m.Gw, w),
+	)
+
+	return writeRESTAsMCPRateLimitResult(w, policyCtx.rpcReq.ID, reason)
+}
+
+func restAsMCPRateLimitRequest(r *http.Request, vemPath string) *http.Request {
+	rateReq := r.Clone(r.Context())
+	copiedURL := *r.URL
+	copiedURL.Path = vemPath
+	copiedURL.RawPath = ""
+	rateReq.URL = &copiedURL
+	rateReq.Method = http.MethodPost
+	return rateReq
+}
+
+func restAsMCPRateLimitKey(r *http.Request, policyCtx *restAsMCPPolicyContext) string {
+	if token := ctxGetAuthToken(r); token != "" {
+		return token
+	}
+	return policyCtx.session.KeyID
+}
+
+func restAsMCPRateLimitHeaderSender(gw *Gateway, w http.ResponseWriter) rate.HeaderSender {
+	if gw.limitHeaderFactory == nil {
+		return nil
+	}
+	return gw.limitHeaderFactory(w.Header())
+}
+
+func writeRESTAsMCPRateLimitResult(w http.ResponseWriter, requestID any, reason sessionFailReason) bool {
+	switch reason {
+	case sessionFailNone:
+		return false
+	case sessionFailRateLimit:
+		jsonrpcerrors.WriteJSONRPCError(w, requestID, http.StatusTooManyRequests, jsonrpcRateLimitExceededMessage)
+		return true
+	default:
+		jsonrpcerrors.WriteJSONRPCError(w, requestID, http.StatusInternalServerError, jsonrpcInternalErrorMessage)
+		return true
+	}
+}
+
+func listConfigForMCPMethod(method string) *mcp.ListFilterConfig {
+	switch method {
+	case mcp.MethodToolsList:
+		return mcp.ListFilterConfigs["tools"]
+	case mcp.MethodPromptsList:
+		return mcp.ListFilterConfigs["prompts"]
+	case mcp.MethodResourcesList:
+		return mcp.ListFilterConfigs["resources"]
+	case mcp.MethodResourcesTemplatesList:
+		return mcp.ListFilterConfigs["resourceTemplates"]
+	default:
+		return nil
+	}
+}
+
+func filterRESTAsMCPListResponse(body []byte, policyCtx *restAsMCPPolicyContext) ([]byte, bool) {
+	if policyCtx == nil || policyCtx.proxySpec == nil || policyCtx.session == nil || policyCtx.listConfig == nil {
+		return nil, false
+	}
+
+	ruleSets := effectiveMCPListRuleSets(policyCtx.proxySpec, policyCtx.session, policyCtx.listConfig)
+	if len(ruleSets) == 0 {
+		return nil, false
+	}
+
+	return mcp.FilterJSONRPCBodyWithRuleSets(body, policyCtx.listConfig, ruleSets)
+}

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
@@ -1,0 +1,292 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/drl"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/mcp"
+	mcpadapter "github.com/TykTechnologies/tyk/internal/mcp/adapter"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+	"github.com/TykTechnologies/tyk/internal/rate"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+func TestRESTAsMCPPolicy_DeniesBlockedToolBeforeSDK(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	called := false
+	var err error
+	adapterSpec.MCPAdapter.SDKAdapter, err = mcpadapter.NewSDKAdapter(mcpadapter.SDKServerConfig{
+		Name:  adapterSpec.Name,
+		Tools: adapterSpec.MCPAdapter.UnionTools,
+		CallTool: func(context.Context, *oas.DerivedTool, map[string]any) (*mcpadapter.Recorder, error) {
+			called = true
+			return mcpadapter.NewRecorder(), nil
+		},
+	})
+	require.NoError(t, err)
+
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	req := restAsMCPPolicyRequest(t, sessionID, `{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/call",
+		"params":{"name":"orders","arguments":{}}
+	}`)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		MCPAccessRights: user.MCPAccessRights{
+			Tools: user.AccessControlRules{Blocked: []string{"orders"}},
+		},
+	}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "tool 'orders' is not available")
+	assert.False(t, called)
+	assert.Equal(t, "tools/call", ctxGetMCPMethod(req))
+	assert.Equal(t, "tool", ctxGetMCPPrimitiveType(req))
+	assert.Equal(t, "orders", ctxGetMCPPrimitiveName(req))
+}
+
+func TestRESTAsMCPPolicy_MethodDeniedBeforeSDK(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	req := restAsMCPPolicyRequest(t, sessionID, `{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/list",
+		"params":{}
+	}`)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		JSONRPCMethodsAccessRights: user.AccessControlRules{
+			Blocked: []string{"tools/list"},
+		},
+	}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "method 'tools/list' is not available")
+}
+
+func TestRESTAsMCPPolicy_FiltersToolsListResponseForCallerView(t *testing.T) {
+	gw, adapterSpec := restAsMCPPolicyGatewayWithTwoTools(t)
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	req := restAsMCPPolicyRequest(t, sessionID, `{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/list",
+		"params":{}
+	}`)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		MCPAccessRights: user.MCPAccessRights{
+			Tools: user.AccessControlRules{Allowed: []string{"orders"}},
+		},
+	}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	tools := jsonRPCToolsList(t, rec.Body.Bytes())
+	assert.Equal(t, []string{"orders"}, tools)
+	assert.NotContains(t, rec.Body.String(), "make_order")
+}
+
+func TestRESTAsMCPPolicy_EndpointRateLimitBlocksToolCall(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	cfg := config.Default
+	drlManager := &drl.DRL{RequestTokenValue: 1}
+	drlManager.SetCurrentTokenValue(1)
+	gw.SessionLimiter = NewSessionLimiter(t.Context(), &cfg, drlManager, &cfg.ExternalServices)
+	gw.limitHeaderFactory = rate.NewSenderFactory(cfg.RateLimitResponseHeaders)
+
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	session := restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		MCPPrimitives: []user.MCPPrimitiveLimit{
+			{Type: mcp.PrimitiveTypeTool, Name: "orders", Limit: user.RateLimit{Rate: 1, Per: 60}},
+		},
+	})
+	NormalizeMCPEndpoints(session)
+
+	makeRequest := func() *http.Request {
+		req := restAsMCPPolicyRequest(t, sessionID, `{
+			"jsonrpc":"2.0",
+			"id":2,
+			"method":"tools/call",
+			"params":{"name":"orders","arguments":{}}
+		}`)
+		ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+		setSessionForTest(req, session)
+		return req
+	}
+
+	first := httptest.NewRecorder()
+	err, status := mw.ProcessRequest(first, makeRequest(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusOK, first.Code)
+
+	second := httptest.NewRecorder()
+	err, status = mw.ProcessRequest(second, makeRequest(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusTooManyRequests, second.Code)
+	assert.Contains(t, second.Body.String(), "Rate Limit Exceeded")
+}
+
+func TestRESTAsMCPPolicy_AliasUsesCallerFacingName(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	req := restAsMCPPolicyRequest(t, sessionID, `{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/call",
+		"params":{"name":"orders","arguments":{}}
+	}`)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		MCPAccessRights: user.MCPAccessRights{
+			Tools: user.AccessControlRules{Allowed: []string{"list_orders"}},
+		},
+	}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "tool 'orders' is not available")
+}
+
+func TestRESTAsMCPPolicy_RejectsOversizedJSONRPCBeforeSDK(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	called := false
+	var err error
+	adapterSpec.MCPAdapter.SDKAdapter, err = mcpadapter.NewSDKAdapter(mcpadapter.SDKServerConfig{
+		Name:  adapterSpec.Name,
+		Tools: adapterSpec.MCPAdapter.UnionTools,
+		CallTool: func(context.Context, *oas.DerivedTool, map[string]any) (*mcpadapter.Recorder, error) {
+			called = true
+			return mcpadapter.NewRecorder(), nil
+		},
+	})
+	require.NoError(t, err)
+
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"orders","arguments":{"payload":"` +
+		strings.Repeat("x", syntheticJSONRPCMethodReadLimit) +
+		`"}}}`
+	req := restAsMCPPolicyRequest(t, sessionID, body)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{APIID: "proxy-1"}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), mcp.ErrMsgParseError)
+	assert.False(t, called)
+}
+
+func restAsMCPPolicyGatewayWithTwoTools(t *testing.T) (*Gateway, *APISpec) {
+	t.Helper()
+
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "list_orders"}, Name: "orders", Allow: boolPtr(true)},
+			{Source: oas.TykMCPServerSource{OperationID: "create_order"}, Name: "make_order", Allow: boolPtr(true)},
+		},
+	})
+	adapterSpec, err := buildMCPAdapterSpec(rest, []*APISpec{proxy}, nil)
+	require.NoError(t, err)
+
+	gw := &Gateway{
+		apisByID: map[string]*APISpec{
+			"rest-1":          rest,
+			adapterSpec.APIID: adapterSpec,
+			"proxy-1":         proxy,
+		},
+		apisHandlesByID: &sync.Map{},
+	}
+	gw.apisHandlesByID.Store("rest-1", &ChainObject{ThisHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})})
+	snapshot, err := computeMCPPairing([]*APISpec{rest, proxy})
+	require.NoError(t, err)
+	gw.mcpPairingIndex.Set(snapshot)
+	return gw, adapterSpec
+}
+
+func restAsMCPPolicyRequest(t *testing.T, sessionID, body string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	return req
+}
+
+func restAsMCPSession(apiID string, accessDef user.AccessDefinition) *user.SessionState {
+	return &user.SessionState{
+		KeyID: "agent-key-1",
+		AccessRights: map[string]user.AccessDefinition{
+			apiID: accessDef,
+		},
+	}
+}
+
+func jsonRPCToolsList(t *testing.T, body []byte) []string {
+	t.Helper()
+
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	result := envelope["result"].(map[string]any)
+	rawTools := result["tools"].([]any)
+	names := make([]string, 0, len(rawTools))
+	for _, raw := range rawTools {
+		tool := raw.(map[string]any)
+		names = append(names, tool["name"].(string))
+	}
+	return names
+}

--- a/gateway/mw_jsonrpc_test.go
+++ b/gateway/mw_jsonrpc_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -85,6 +86,19 @@ func TestSyntheticJSONRPCMethod_UsesRoutingStateBeforeReadingBody(t *testing.T) 
 	httpctx.SetJSONRPCRoutingState(r, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList})
 
 	assert.Equal(t, mcp.MethodToolsList, syntheticJSONRPCMethod(r))
+}
+
+func TestSyntheticJSONRPCMethod_LimitsFallbackBodyReadAndPreservesBody(t *testing.T) {
+	body := `{"jsonrpc":"2.0","method":"tools/list","params":{"padding":"` +
+		strings.Repeat("x", syntheticJSONRPCMethodReadLimit+1) +
+		`"}}`
+	r := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+
+	assert.Equal(t, "", syntheticJSONRPCMethod(r))
+
+	preserved, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(preserved))
 }
 
 func TestJSONRPCMiddleware_ProcessRequest_NonPostPassthrough(t *testing.T) {

--- a/gateway/mw_jsonrpc_test.go
+++ b/gateway/mw_jsonrpc_test.go
@@ -79,6 +79,14 @@ func TestJSONRPCMiddleware_EnabledForSpec(t *testing.T) {
 	}
 }
 
+func TestSyntheticJSONRPCMethod_UsesRoutingStateBeforeReadingBody(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	r.Body = &errorReadCloser{err: io.ErrUnexpectedEOF}
+	httpctx.SetJSONRPCRoutingState(r, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList})
+
+	assert.Equal(t, mcp.MethodToolsList, syntheticJSONRPCMethod(r))
+}
+
 func TestJSONRPCMiddleware_ProcessRequest_NonPostPassthrough(t *testing.T) {
 	spec := &APISpec{
 		APIDefinition: &apidef.APIDefinition{

--- a/gateway/mw_mcp_loop_auth.go
+++ b/gateway/mw_mcp_loop_auth.go
@@ -1,0 +1,152 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+type MCPLoopAuthBypassMiddleware struct {
+	*BaseMiddleware
+}
+
+func (m *MCPLoopAuthBypassMiddleware) Name() string {
+	return "MCPLoopAuthBypassMiddleware"
+}
+
+func (m *MCPLoopAuthBypassMiddleware) EnabledForSpec() bool {
+	return mcpLoopAuthEnabledForSpec(m.Spec)
+}
+
+//nolint:staticcheck // ST1008: middleware interface requires (error, int).
+func (m *MCPLoopAuthBypassMiddleware) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	trust, ok := ctxGetMCPAdapterLoopTrust(r)
+	if !ok {
+		return nil, http.StatusOK
+	}
+
+	if !m.validLoopTrust(trust) {
+		m.logInvalidLoopTrust(trust)
+		return errMCPLoopTrustMismatch, http.StatusForbidden
+	}
+
+	m.installLoopSession(r, trust)
+	ctxSetMCPAdapterLoopAuthBypassed(r, true)
+	ctxSetRequestStatus(r, StatusOkAndIgnore)
+	return nil, http.StatusOK
+}
+
+func (m *MCPLoopAuthBypassMiddleware) validLoopTrust(trust mcpAdapterLoopTrust) bool {
+	if m == nil || m.Spec == nil || m.Gw == nil {
+		return false
+	}
+	if trust.SourceRESTAPIID == "" || trust.AdapterAPIID == "" || trust.CallerProxyAPIID == "" {
+		return false
+	}
+	if trust.SourceRESTAPIID != m.Spec.APIID {
+		return false
+	}
+
+	source, ok := m.Gw.mcpPairingIndex.LookupAdapter(trust.AdapterAPIID)
+	if !ok {
+		return false
+	}
+	if source.SourceRESTAPIID != trust.SourceRESTAPIID || source.AdapterAPIID != trust.AdapterAPIID {
+		return false
+	}
+	return m.Gw.mcpPairingIndex.AllowsCaller(trust.AdapterAPIID, trust.CallerProxyAPIID)
+}
+
+func (m *MCPLoopAuthBypassMiddleware) logInvalidLoopTrust(trust mcpAdapterLoopTrust) {
+	if m == nil {
+		return
+	}
+	restAPIID := ""
+	if m.Spec != nil {
+		restAPIID = m.Spec.APIID
+	}
+	m.Logger().WithFields(map[string]interface{}{
+		"rest_api_id":       restAPIID,
+		"flag_rest_api_id":  trust.SourceRESTAPIID,
+		"flag_adapter_id":   trust.AdapterAPIID,
+		"flag_proxy_api_id": trust.CallerProxyAPIID,
+	}).Warn("MCP loop trust descriptor does not match an admitted paired proxy")
+}
+
+func (m *MCPLoopAuthBypassMiddleware) installLoopSession(r *http.Request, trust mcpAdapterLoopTrust) {
+	session := user.NewSessionState()
+	session.OrgID = m.Spec.OrgID
+	session.KeyID = mcpLoopAuthSessionKey(trust)
+	session.MetaData = map[string]interface{}{
+		"mcp_adapter_api_id":      trust.AdapterAPIID,
+		"mcp_caller_proxy_api_id": trust.CallerProxyAPIID,
+		"mcp_source_rest_api_id":  trust.SourceRESTAPIID,
+	}
+	ctxSetMCPAdapterLoopSession(r, session, gatewayHashKeys(m.Gw))
+}
+
+type MCPLoopAuthRestoreMiddleware struct {
+	*BaseMiddleware
+}
+
+func (m *MCPLoopAuthRestoreMiddleware) Name() string {
+	return "MCPLoopAuthRestoreMiddleware"
+}
+
+func (m *MCPLoopAuthRestoreMiddleware) EnabledForSpec() bool {
+	return mcpLoopAuthEnabledForSpec(m.Spec)
+}
+
+//nolint:staticcheck // ST1008: middleware interface requires (error, int).
+func (m *MCPLoopAuthRestoreMiddleware) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxMCPAdapterLoopAuthBypassed(r) && ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		ctxSetRequestStatus(r, StatusOk)
+	}
+	ctxSetMCPAdapterLoopAuthBypassed(r, false)
+	return nil, http.StatusOK
+}
+
+func mcpLoopAuthEnabledForSpec(spec *APISpec) bool {
+	if spec == nil || spec.APIDefinition == nil {
+		return false
+	}
+	return !spec.IsMCPManaged() && !spec.IsSyntheticMCPAdapter()
+}
+
+func mcpLoopAuthSessionKey(trust mcpAdapterLoopTrust) string {
+	return fmt.Sprintf("mcp-loop:%s:%s", trust.AdapterAPIID, trust.CallerProxyAPIID)
+}
+
+var errMCPLoopTrustMismatch = errors.New("MCP loop trust descriptor does not match an admitted paired proxy")
+
+func ctxSetMCPAdapterLoopSession(r *http.Request, session *user.SessionState, hashKeys bool) {
+	if session.KeyID == "" {
+		session.KeyID = ctx.GetAuthToken(r)
+	}
+	if session.KeyHashEmpty() {
+		session.SetKeyHash(storage.HashKey(session.KeyID, hashKeys))
+	}
+
+	reqCtx := r.Context()
+	reqCtx = context.WithValue(reqCtx, ctx.SessionData, session)
+	reqCtx = context.WithValue(reqCtx, ctx.AuthToken, session.KeyID)
+	setContext(r, reqCtx)
+}
+
+func gatewayHashKeys(gw *Gateway) bool {
+	if gw == nil {
+		return false
+	}
+	value := gw.config.Load()
+	if value == nil {
+		return false
+	}
+	cfg, ok := value.(config.Config)
+	return ok && cfg.HashKeys
+}

--- a/gateway/mw_mcp_loop_auth_test.go
+++ b/gateway/mw_mcp_loop_auth_test.go
@@ -1,0 +1,184 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/internal/mcp/pairing"
+)
+
+func TestMCPLoopAuthBypass_Branches(t *testing.T) {
+	source := restSourceSpec("rest-1", "org-1", true)
+	snapshot, err := pairing.NewSnapshot([]pairing.Record{{
+		SourceRESTAPIID:  "rest-1",
+		SourceOrgID:      "org-1",
+		CallerProxyAPIID: "proxy-1",
+		CallerProxyOrgID: "org-1",
+	}})
+	require.NoError(t, err)
+
+	gw := &Gateway{}
+	gw.mcpPairingIndex.Set(snapshot)
+
+	tests := []struct {
+		name        string
+		spec        *APISpec
+		trust       *mcpAdapterLoopTrust
+		wantBypass  bool
+		wantSession bool
+		wantCode    int
+		wantError   bool
+	}{
+		{
+			name:     "no flag pass-through",
+			spec:     source,
+			wantCode: http.StatusOK,
+		},
+		{
+			name: "matched trust installs loop session",
+			spec: source,
+			trust: &mcpAdapterLoopTrust{
+				SourceRESTAPIID:  "rest-1",
+				AdapterAPIID:     pairing.CanonicalAdapterAPIID("rest-1"),
+				CallerProxyAPIID: "proxy-1",
+			},
+			wantBypass:  true,
+			wantSession: true,
+			wantCode:    http.StatusOK,
+		},
+		{
+			name: "REST API ID mismatch returns forbidden",
+			spec: source,
+			trust: &mcpAdapterLoopTrust{
+				SourceRESTAPIID:  "rest-2",
+				AdapterAPIID:     pairing.CanonicalAdapterAPIID("rest-1"),
+				CallerProxyAPIID: "proxy-1",
+			},
+			wantCode:  http.StatusForbidden,
+			wantError: true,
+		},
+		{
+			name: "adapter API ID mismatch returns forbidden",
+			spec: source,
+			trust: &mcpAdapterLoopTrust{
+				SourceRESTAPIID:  "rest-1",
+				AdapterAPIID:     pairing.CanonicalAdapterAPIID("rest-2"),
+				CallerProxyAPIID: "proxy-1",
+			},
+			wantCode:  http.StatusForbidden,
+			wantError: true,
+		},
+		{
+			name: "forged proxy ID returns forbidden",
+			spec: source,
+			trust: &mcpAdapterLoopTrust{
+				SourceRESTAPIID:  "rest-1",
+				AdapterAPIID:     pairing.CanonicalAdapterAPIID("rest-1"),
+				CallerProxyAPIID: "proxy-forged",
+			},
+			wantCode:  http.StatusForbidden,
+			wantError: true,
+		},
+		{
+			name: "missing pairing record returns forbidden",
+			spec: restSourceSpec("rest-unpaired", "org-1", true),
+			trust: &mcpAdapterLoopTrust{
+				SourceRESTAPIID:  "rest-unpaired",
+				AdapterAPIID:     pairing.CanonicalAdapterAPIID("rest-unpaired"),
+				CallerProxyAPIID: "proxy-1",
+			},
+			wantCode:  http.StatusForbidden,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mw := &MCPLoopAuthBypassMiddleware{BaseMiddleware: &BaseMiddleware{Spec: tt.spec, Gw: gw}}
+			req := httptest.NewRequest(http.MethodGet, "/orders", nil)
+			if tt.trust != nil {
+				ctxSetMCPAdapterLoopTrust(req, *tt.trust)
+			}
+
+			err, code := mw.ProcessRequest(httptest.NewRecorder(), req, nil)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCode, code)
+
+			assert.Equal(t, tt.wantBypass, ctxGetRequestStatus(req) == StatusOkAndIgnore)
+			assert.Equal(t, tt.wantBypass, ctxMCPAdapterLoopAuthBypassed(req))
+			assert.Equal(t, tt.wantSession, ctxGetSession(req) != nil)
+			if tt.wantSession {
+				assert.Equal(t, "org-1", ctxGetSession(req).OrgID)
+				assert.Equal(t, "mcp-loop:rest-1__mcp-server:proxy-1", ctxGetSession(req).KeyID)
+			}
+		})
+	}
+}
+
+func TestMCPLoopAuthBypass_PreAuthorizesThenRestoreClearsBypassStatus(t *testing.T) {
+	source := restSourceSpec("rest-1", "org-1", true)
+	snapshot, err := computeMCPPairing([]*APISpec{
+		source,
+		pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil),
+	})
+	require.NoError(t, err)
+
+	gw := &Gateway{}
+	gw.mcpPairingIndex.Set(snapshot)
+
+	req := httptest.NewRequest(http.MethodGet, "/orders", nil)
+	ctxSetMCPAdapterLoopTrust(req, mcpAdapterLoopTrust{
+		SourceRESTAPIID:  "rest-1",
+		AdapterAPIID:     pairing.CanonicalAdapterAPIID("rest-1"),
+		CallerProxyAPIID: "proxy-1",
+	})
+
+	bypass := &MCPLoopAuthBypassMiddleware{BaseMiddleware: &BaseMiddleware{Spec: source, Gw: gw}}
+	restore := &MCPLoopAuthRestoreMiddleware{BaseMiddleware: &BaseMiddleware{Spec: source, Gw: gw}}
+
+	err, code := bypass.ProcessRequest(httptest.NewRecorder(), req, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, code)
+	require.Equal(t, StatusOkAndIgnore, ctxGetRequestStatus(req))
+
+	err, code = restore.ProcessRequest(httptest.NewRecorder(), req, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, StatusOk, ctxGetRequestStatus(req))
+	assert.False(t, ctxMCPAdapterLoopAuthBypassed(req))
+}
+
+func TestMCPLoopAuthBypass_EnabledForSpec(t *testing.T) {
+	source := restSourceSpec("rest-1", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+	synthetic := buildSyntheticAdapterForRuntimeTest(t)
+
+	tests := []struct {
+		name string
+		spec *APISpec
+		want bool
+	}{
+		{name: "source REST spec", spec: source, want: true},
+		{name: "paired MCP proxy", spec: proxy, want: false},
+		{name: "synthetic adapter", spec: synthetic, want: false},
+		{name: "nil spec", spec: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bypass := &MCPLoopAuthBypassMiddleware{BaseMiddleware: &BaseMiddleware{Spec: tt.spec}}
+			restore := &MCPLoopAuthRestoreMiddleware{BaseMiddleware: &BaseMiddleware{Spec: tt.spec}}
+
+			assert.Equal(t, tt.want, bypass.EnabledForSpec())
+			assert.Equal(t, tt.want, restore.EnabledForSpec())
+		})
+	}
+}

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -93,7 +93,7 @@ func (gw *Gateway) validateMCPFieldsInAccessRights(accessRights map[string]user.
 		if spec == nil {
 			continue
 		}
-		if !spec.IsMCP() {
+		if !mcpProxy(spec) {
 			return fmt.Errorf("MCP fields can only be configured on MCP Proxies, API %q is not an MCP Proxy", apiID)
 		}
 		for _, p := range ar.MCPPrimitives {
@@ -127,7 +127,7 @@ func (gw *Gateway) validateNonMCPFieldsOnMCPProxy(accessRights map[string]user.A
 		if spec == nil {
 			continue
 		}
-		if spec.IsMCP() {
+		if mcpProxy(spec) {
 			return fmt.Errorf("HTTP/REST and GraphQL fields cannot be configured on MCP Proxies, API %q is an MCP Proxy", apiID)
 		}
 	}

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/model"
@@ -1527,21 +1528,16 @@ func TestHasMCPFields(t *testing.T) {
 }
 
 func TestValidateMCPFieldsInAccessRights(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-
-	specs := ts.Gw.BuildAndLoadAPI(
-		func(spec *APISpec) {
-			spec.APIID = "mcp-api-id"
-			spec.MarkAsMCP()
-		},
-		func(spec *APISpec) {
-			spec.APIID = "non-mcp-api-id"
-			spec.Name = "non-mcp-api"
-		},
-	)
-	mcpAPIID := specs[0].APIID
-	nonMCPAPIID := specs[1].APIID
+	mcpAPIID := "mcp-api-id"
+	nonMCPAPIID := "non-mcp-api-id"
+	pairedMCPAPIID := "paired-mcp-api-id"
+	mcpDef := &apidef.APIDefinition{APIID: mcpAPIID, OrgID: "org-1"}
+	mcpDef.MarkAsMCP()
+	gw := &Gateway{apisByID: map[string]*APISpec{
+		mcpAPIID:       {APIDefinition: mcpDef},
+		nonMCPAPIID:    {APIDefinition: &apidef.APIDefinition{APIID: nonMCPAPIID, Name: "non-mcp-api"}},
+		pairedMCPAPIID: pairedMCPProxySpec(pairedMCPAPIID, "org-1", "rest-1", nil),
+	}}
 
 	mcpAR := user.AccessDefinition{
 		JSONRPCMethods: []user.JSONRPCMethodLimit{{Name: "tools/call"}},
@@ -1555,6 +1551,10 @@ func TestValidateMCPFieldsInAccessRights(t *testing.T) {
 		{
 			name:         "MCP fields on MCP Proxy are accepted",
 			accessRights: map[string]user.AccessDefinition{mcpAPIID: mcpAR},
+		},
+		{
+			name:         "MCP fields on REST-as-MCP paired proxy are accepted",
+			accessRights: map[string]user.AccessDefinition{pairedMCPAPIID: mcpAR},
 		},
 		{
 			name:         "MCP fields on non-MCP API are rejected",
@@ -1592,9 +1592,9 @@ func TestValidateMCPFieldsInAccessRights(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ts.Gw.validateMCPFieldsInAccessRights(tc.accessRights)
+			err := gw.validateMCPFieldsInAccessRights(tc.accessRights)
 			if tc.expectErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectErr)
 			} else {
 				assert.NoError(t, err)
@@ -1654,21 +1654,16 @@ func TestHasNonMCPFields(t *testing.T) {
 }
 
 func TestValidateNonMCPFieldsOnMCPProxy(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-
-	specs := ts.Gw.BuildAndLoadAPI(
-		func(spec *APISpec) {
-			spec.APIID = "mcp-api-id"
-			spec.MarkAsMCP()
-		},
-		func(spec *APISpec) {
-			spec.APIID = "non-mcp-api-id"
-			spec.Name = "non-mcp-api"
-		},
-	)
-	mcpAPIID := specs[0].APIID
-	nonMCPAPIID := specs[1].APIID
+	mcpAPIID := "mcp-api-id"
+	nonMCPAPIID := "non-mcp-api-id"
+	pairedMCPAPIID := "paired-mcp-api-id"
+	mcpDef := &apidef.APIDefinition{APIID: mcpAPIID, OrgID: "org-1"}
+	mcpDef.MarkAsMCP()
+	gw := &Gateway{apisByID: map[string]*APISpec{
+		mcpAPIID:       {APIDefinition: mcpDef},
+		nonMCPAPIID:    {APIDefinition: &apidef.APIDefinition{APIID: nonMCPAPIID, Name: "non-mcp-api"}},
+		pairedMCPAPIID: pairedMCPProxySpec(pairedMCPAPIID, "org-1", "rest-1", nil),
+	}}
 
 	cases := []struct {
 		name         string
@@ -1679,6 +1674,13 @@ func TestValidateNonMCPFieldsOnMCPProxy(t *testing.T) {
 			name: "AllowedURLs on MCP Proxy is rejected",
 			accessRights: map[string]user.AccessDefinition{
 				mcpAPIID: {AllowedURLs: []user.AccessSpec{{URL: "/foo", Methods: []string{"GET"}}}},
+			},
+			expectErr: "HTTP/REST and GraphQL fields cannot be configured on MCP Proxies",
+		},
+		{
+			name: "AllowedURLs on REST-as-MCP paired proxy is rejected",
+			accessRights: map[string]user.AccessDefinition{
+				pairedMCPAPIID: {AllowedURLs: []user.AccessSpec{{URL: "/foo", Methods: []string{"GET"}}}},
 			},
 			expectErr: "HTTP/REST and GraphQL fields cannot be configured on MCP Proxies",
 		},
@@ -1737,9 +1739,9 @@ func TestValidateNonMCPFieldsOnMCPProxy(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ts.Gw.validateNonMCPFieldsOnMCPProxy(tc.accessRights)
+			err := gw.validateNonMCPFieldsOnMCPProxy(tc.accessRights)
 			if tc.expectErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectErr)
 			} else {
 				assert.NoError(t, err)

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -907,7 +907,7 @@ func (rt *TykRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 			r.Header.Del(apidef.TykInternalApiHeader)
 		}
 
-		handler, _, found := rt.Gw.findInternalHttpHandlerByNameOrID(r.Host)
+		handler, _, found := rt.Gw.findInternalHTTPHandlerForLoop(r.Host, nil, r)
 		if !found {
 			rt.logger.WithField("looping_url", "tyk://"+r.Host).Error("Couldn't detect target")
 			return nil, errors.New("handler could")

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -57,6 +57,7 @@ import (
 	"github.com/TykTechnologies/tyk/internal/crypto"
 	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/mcp"
+	"github.com/TykTechnologies/tyk/internal/mcp/pairing"
 	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/internal/netutil"
 	"github.com/TykTechnologies/tyk/internal/otel"
@@ -172,6 +173,7 @@ type Gateway struct {
 	apiSpecs        []*APISpec
 	apisByID        map[string]*APISpec
 	apisHandlesByID *sync.Map
+	mcpPairingIndex pairing.Index
 
 	// prmCache memoises upstream Protected Resource Metadata (RFC 9728) docs
 	// for MCP APIs running in mirror mode. Lazily initialised on first use.

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -157,6 +157,10 @@ func shouldReloadSpec(existingSpec, newSpec *APISpec) bool {
 		return true
 	}
 
+	if newSpec.IsSyntheticMCPAdapter() {
+		return true
+	}
+
 	if existingSpec.Checksum != newSpec.Checksum {
 		return true
 	}

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -251,6 +251,13 @@ func Test_shouldReloadSpec(t *testing.T) {
 		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
 	})
 
+	t.Run("synthetic rest as mcp adapter", func(t *testing.T) {
+		t.Parallel()
+		existingSpec := &APISpec{Checksum: "1", MCPAdapter: MCPAdapterRuntime{Synthetic: true}}
+		newSpec := &APISpec{Checksum: "1", MCPAdapter: MCPAdapterRuntime{Synthetic: true}}
+		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
+	})
+
 	type testCase struct {
 		name string
 		spec *APISpec

--- a/internal/mcp/adapter/adapter.go
+++ b/internal/mcp/adapter/adapter.go
@@ -11,6 +11,7 @@ package adapter
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	"net/url"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
@@ -50,8 +52,8 @@ const (
 // source REST APIID (so downstream rewriters see a coherent host).
 //
 // The function is parent-context-aware: the returned request inherits
-// the parent's context, body, and trailers are not propagated (the
-// adapter does not stream).
+// parent context values without inheriting parent cancellation. The body
+// and trailers are not propagated (the adapter does not stream).
 //
 // Returned errors are user-facing — they are surfaced via the JSON-RPC
 // `error` envelope.
@@ -400,8 +402,10 @@ func scalarParameterValue(raw any) (string, bool) {
 		return fmt.Sprint(v), true
 	case uint, uint8, uint16, uint32, uint64:
 		return fmt.Sprint(v), true
-	case float32, float64:
-		return fmt.Sprint(v), true
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32), true
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
 	case json.Number:
 		return v.String(), true
 	default:
@@ -453,7 +457,7 @@ func (b *upstreamRequestBuilder) request() (*http.Request, error) {
 		body = bytes.NewReader(buf)
 	}
 
-	req, err := http.NewRequestWithContext(b.parent.Context(), b.tool.Method, b.path, body)
+	req, err := http.NewRequestWithContext(context.WithoutCancel(b.parent.Context()), b.tool.Method, b.path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/adapter/adapter_test.go
+++ b/internal/mcp/adapter/adapter_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -92,6 +93,50 @@ func TestBuildUpstreamRequest_PathQueryHeader(t *testing.T) {
 	assert.Equal(t, "true", req.URL.Query().Get("verbose"))
 	assert.Equal(t, "rest-1", req.URL.Host)
 	assert.Equal(t, "http", req.URL.Scheme)
+}
+
+func TestBuildUpstreamRequest_DetachesFromParentCancellation(t *testing.T) {
+	t.Parallel()
+	type contextKey string
+
+	parentCtx, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey("caller"), "proxy-1"))
+	parent := httptest.NewRequest(http.MethodPost, "/mcp/", nil).WithContext(parentCtx)
+	cancel()
+	tool := sampleTool(t, "getOrder")
+
+	req, err := BuildUpstreamRequest(parent, tool, "rest-1", map[string]any{"id": 42})
+
+	require.NoError(t, err)
+	assert.Equal(t, "proxy-1", req.Context().Value(contextKey("caller")))
+	select {
+	case <-req.Context().Done():
+		t.Fatal("upstream request context should not inherit parent cancellation")
+	default:
+	}
+}
+
+func TestBuildUpstreamRequest_IntegerValuedFloatArgumentUsesDecimalNotation(t *testing.T) {
+	t.Parallel()
+	parent := httptest.NewRequest(http.MethodPost, "/mcp/", nil)
+	tool := &oas.DerivedTool{
+		Name:         "large_response",
+		Method:       http.MethodGet,
+		PathTemplate: "/large/{size}",
+		ParamLocations: map[string]string{
+			"size": oas.DerivedParamLocationPath,
+		},
+		ParamSourceNames: map[string]string{
+			"size": "size",
+		},
+		ParamOrder: []string{"size"},
+	}
+
+	req, err := BuildUpstreamRequest(parent, tool, "rest-1", map[string]any{
+		"size": float64(2097152),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/large/2097152", req.URL.Path)
 }
 
 func TestBuildUpstreamRequest_RejectsUnknownArgs(t *testing.T) {

--- a/internal/mcp/pairing/index.go
+++ b/internal/mcp/pairing/index.go
@@ -1,0 +1,283 @@
+// Package pairing owns the runtime lookup table that connects REST source APIs,
+// synthetic REST-as-MCP adapters, and the MCP proxy APIs allowed to call them.
+package pairing
+
+import (
+	"fmt"
+	"sort"
+	"sync/atomic"
+
+	"github.com/TykTechnologies/tyk/internal/mcpadapter"
+)
+
+// Record is one proxy-to-source pairing discovered from loaded API specs.
+type Record struct {
+	SourceRESTAPIID  string
+	SourceOrgID      string
+	CallerProxyAPIID string
+	CallerProxyOrgID string
+}
+
+// Source records the synthetic adapter and caller proxies for one REST API.
+type Source struct {
+	SourceRESTAPIID   string
+	AdapterAPIID      string
+	CallerProxyAPIIDs []string
+}
+
+// Snapshot is an immutable view of all REST-as-MCP pairings.
+type Snapshot struct {
+	sourcesByRESTID   map[string]Source
+	sourcesByAdapter  map[string]Source
+	callersByAdapter  map[string]map[string]struct{}
+	referencedRESTIDs map[string]struct{}
+}
+
+// Index exposes atomic replacement and lock-free reads of the pairing snapshot.
+type Index struct {
+	value atomic.Value // stores Snapshot
+}
+
+// NewIndex returns an index initialized with an empty snapshot.
+func NewIndex() *Index {
+	idx := &Index{}
+	idx.Set(Snapshot{})
+	return idx
+}
+
+// CanonicalAdapterAPIID returns the runtime-only synthetic adapter ID for a
+// source REST API.
+func CanonicalAdapterAPIID(sourceRESTAPIID string) string {
+	return sourceRESTAPIID + mcpadapter.APIIDSuffix
+}
+
+// NewSnapshot builds an immutable pairing snapshot from proxy-to-source records.
+func NewSnapshot(records []Record) (Snapshot, error) {
+	build := snapshotBuilder{
+		sourcesByRESTID:  map[string]*sourceBuild{},
+		sourceOrgByREST:  map[string]string{},
+		callersByAdapter: map[string]map[string]struct{}{},
+	}
+
+	for _, record := range records {
+		if err := build.add(record); err != nil {
+			return Snapshot{}, err
+		}
+	}
+
+	return build.snapshot(), nil
+}
+
+// Set atomically replaces the current snapshot.
+func (i *Index) Set(snapshot Snapshot) {
+	if i == nil {
+		return
+	}
+	i.value.Store(snapshot.clone())
+}
+
+// Snapshot returns a defensive copy of the current snapshot.
+func (i *Index) Snapshot() Snapshot {
+	if i == nil {
+		return Snapshot{}
+	}
+	return i.load().clone()
+}
+
+// LookupSource returns the source entry for a REST API ID.
+func (i *Index) LookupSource(sourceRESTAPIID string) (Source, bool) {
+	return i.load().LookupSource(sourceRESTAPIID)
+}
+
+// LookupAdapter returns the source entry for a synthetic adapter API ID.
+func (i *Index) LookupAdapter(adapterAPIID string) (Source, bool) {
+	return i.load().LookupAdapter(adapterAPIID)
+}
+
+// AllowsCaller reports whether callerProxyAPIID may invoke adapterAPIID.
+func (i *Index) AllowsCaller(adapterAPIID, callerProxyAPIID string) bool {
+	return i.load().AllowsCaller(adapterAPIID, callerProxyAPIID)
+}
+
+func (i *Index) load() Snapshot {
+	if i == nil {
+		return Snapshot{}
+	}
+	value := i.value.Load()
+	if value == nil {
+		return Snapshot{}
+	}
+	snapshot, ok := value.(Snapshot)
+	if !ok {
+		return Snapshot{}
+	}
+	return snapshot
+}
+
+// Sources returns all source records in deterministic source APIID order.
+func (s Snapshot) Sources() []Source {
+	keys := make([]string, 0, len(s.sourcesByRESTID))
+	for key := range s.sourcesByRESTID {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	out := make([]Source, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, cloneSource(s.sourcesByRESTID[key]))
+	}
+	return out
+}
+
+// ReferencedRESTAPIIDs returns REST APIs currently referenced by paired proxies.
+func (s Snapshot) ReferencedRESTAPIIDs() []string {
+	ids := make([]string, 0, len(s.referencedRESTIDs))
+	for id := range s.referencedRESTIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// LookupSource returns the source entry for a REST API ID.
+func (s Snapshot) LookupSource(sourceRESTAPIID string) (Source, bool) {
+	source, ok := s.sourcesByRESTID[sourceRESTAPIID]
+	if !ok {
+		return Source{}, false
+	}
+	return cloneSource(source), true
+}
+
+// LookupAdapter returns the source entry for a synthetic adapter API ID.
+func (s Snapshot) LookupAdapter(adapterAPIID string) (Source, bool) {
+	source, ok := s.sourcesByAdapter[adapterAPIID]
+	if !ok {
+		return Source{}, false
+	}
+	return cloneSource(source), true
+}
+
+// AllowsCaller reports whether callerProxyAPIID may invoke adapterAPIID.
+func (s Snapshot) AllowsCaller(adapterAPIID, callerProxyAPIID string) bool {
+	callers, ok := s.callersByAdapter[adapterAPIID]
+	if !ok {
+		return false
+	}
+	_, ok = callers[callerProxyAPIID]
+	return ok
+}
+
+func (s Snapshot) clone() Snapshot {
+	out := Snapshot{
+		sourcesByRESTID:   make(map[string]Source, len(s.sourcesByRESTID)),
+		sourcesByAdapter:  make(map[string]Source, len(s.sourcesByAdapter)),
+		callersByAdapter:  make(map[string]map[string]struct{}, len(s.callersByAdapter)),
+		referencedRESTIDs: make(map[string]struct{}, len(s.referencedRESTIDs)),
+	}
+	for key, source := range s.sourcesByRESTID {
+		out.sourcesByRESTID[key] = cloneSource(source)
+	}
+	for key, source := range s.sourcesByAdapter {
+		out.sourcesByAdapter[key] = cloneSource(source)
+	}
+	for adapterID, callers := range s.callersByAdapter {
+		out.callersByAdapter[adapterID] = cloneSet(callers)
+	}
+	for id := range s.referencedRESTIDs {
+		out.referencedRESTIDs[id] = struct{}{}
+	}
+	return out
+}
+
+type sourceBuild struct {
+	sourceRESTAPIID string
+	adapterAPIID    string
+	callers         map[string]struct{}
+}
+
+type snapshotBuilder struct {
+	sourcesByRESTID  map[string]*sourceBuild
+	sourceOrgByREST  map[string]string
+	callersByAdapter map[string]map[string]struct{}
+}
+
+func (b *snapshotBuilder) add(record Record) error {
+	if record.SourceRESTAPIID == "" {
+		return fmt.Errorf("pairing source REST API ID is required")
+	}
+	if record.CallerProxyAPIID == "" {
+		return fmt.Errorf("pairing caller proxy API ID is required")
+	}
+	if record.SourceOrgID != "" && record.CallerProxyOrgID != "" && record.SourceOrgID != record.CallerProxyOrgID {
+		return fmt.Errorf("cross-org REST-as-MCP pairing refused: source %q org %q, caller proxy %q org %q",
+			record.SourceRESTAPIID, record.SourceOrgID, record.CallerProxyAPIID, record.CallerProxyOrgID)
+	}
+	if previousOrg, ok := b.sourceOrgByREST[record.SourceRESTAPIID]; ok && previousOrg != record.SourceOrgID {
+		return fmt.Errorf("source REST API %q has inconsistent org IDs %q and %q", record.SourceRESTAPIID, previousOrg, record.SourceOrgID)
+	}
+	b.sourceOrgByREST[record.SourceRESTAPIID] = record.SourceOrgID
+
+	adapterID := CanonicalAdapterAPIID(record.SourceRESTAPIID)
+	source := b.sourcesByRESTID[record.SourceRESTAPIID]
+	if source == nil {
+		source = &sourceBuild{
+			sourceRESTAPIID: record.SourceRESTAPIID,
+			adapterAPIID:    adapterID,
+			callers:         map[string]struct{}{},
+		}
+		b.sourcesByRESTID[record.SourceRESTAPIID] = source
+	}
+
+	source.callers[record.CallerProxyAPIID] = struct{}{}
+	if b.callersByAdapter[adapterID] == nil {
+		b.callersByAdapter[adapterID] = map[string]struct{}{}
+	}
+	b.callersByAdapter[adapterID][record.CallerProxyAPIID] = struct{}{}
+	return nil
+}
+
+func (b *snapshotBuilder) snapshot() Snapshot {
+	snapshot := Snapshot{
+		sourcesByRESTID:   make(map[string]Source, len(b.sourcesByRESTID)),
+		sourcesByAdapter:  make(map[string]Source, len(b.sourcesByRESTID)),
+		callersByAdapter:  make(map[string]map[string]struct{}, len(b.callersByAdapter)),
+		referencedRESTIDs: make(map[string]struct{}, len(b.sourcesByRESTID)),
+	}
+
+	for sourceRESTID, build := range b.sourcesByRESTID {
+		source := Source{
+			SourceRESTAPIID:   build.sourceRESTAPIID,
+			AdapterAPIID:      build.adapterAPIID,
+			CallerProxyAPIIDs: sortedSet(build.callers),
+		}
+		snapshot.sourcesByRESTID[sourceRESTID] = source
+		snapshot.sourcesByAdapter[source.AdapterAPIID] = source
+		snapshot.referencedRESTIDs[sourceRESTID] = struct{}{}
+	}
+	for adapterID, callers := range b.callersByAdapter {
+		snapshot.callersByAdapter[adapterID] = cloneSet(callers)
+	}
+	return snapshot
+}
+
+func sortedSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func cloneSet(src map[string]struct{}) map[string]struct{} {
+	dst := make(map[string]struct{}, len(src))
+	for key := range src {
+		dst[key] = struct{}{}
+	}
+	return dst
+}
+
+func cloneSource(source Source) Source {
+	source.CallerProxyAPIIDs = append([]string(nil), source.CallerProxyAPIIDs...)
+	return source
+}

--- a/internal/mcp/pairing/index_test.go
+++ b/internal/mcp/pairing/index_test.go
@@ -1,0 +1,148 @@
+package pairing
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndex_SetAndLookup(t *testing.T) {
+	idx := NewIndex()
+
+	snapshot, err := NewSnapshot([]Record{
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-1", CallerProxyOrgID: "org-1"},
+	})
+	require.NoError(t, err)
+
+	idx.Set(snapshot)
+
+	source, ok := idx.LookupSource("rest-1")
+	require.True(t, ok)
+	assert.Equal(t, "rest-1", source.SourceRESTAPIID)
+	assert.Equal(t, "rest-1__mcp-server", source.AdapterAPIID)
+	assert.Equal(t, []string{"proxy-1"}, source.CallerProxyAPIIDs)
+
+	byAdapter, ok := idx.LookupAdapter("rest-1__mcp-server")
+	require.True(t, ok)
+	assert.Equal(t, source, byAdapter)
+	assert.True(t, idx.AllowsCaller("rest-1__mcp-server", "proxy-1"))
+	assert.False(t, idx.AllowsCaller("rest-1__mcp-server", "proxy-2"))
+}
+
+func TestIndex_ReplacesOnEachSet(t *testing.T) {
+	idx := NewIndex()
+
+	first, err := NewSnapshot([]Record{
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-1", CallerProxyOrgID: "org-1"},
+	})
+	require.NoError(t, err)
+	idx.Set(first)
+
+	second, err := NewSnapshot([]Record{
+		{SourceRESTAPIID: "rest-2", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-2", CallerProxyOrgID: "org-1"},
+	})
+	require.NoError(t, err)
+	idx.Set(second)
+
+	_, ok := idx.LookupSource("rest-1")
+	assert.False(t, ok)
+	assert.False(t, idx.AllowsCaller("rest-1__mcp-server", "proxy-1"))
+
+	source, ok := idx.LookupSource("rest-2")
+	require.True(t, ok)
+	assert.Equal(t, []string{"proxy-2"}, source.CallerProxyAPIIDs)
+}
+
+func TestIndex_SnapshotIsDefensive(t *testing.T) {
+	snapshot, err := NewSnapshot([]Record{
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-b", CallerProxyOrgID: "org-1"},
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-a", CallerProxyOrgID: "org-1"},
+	})
+	require.NoError(t, err)
+
+	sources := snapshot.Sources()
+	sources[0].CallerProxyAPIIDs[0] = "mutated"
+
+	source, ok := snapshot.LookupSource("rest-1")
+	require.True(t, ok)
+	assert.Equal(t, []string{"proxy-a", "proxy-b"}, source.CallerProxyAPIIDs)
+
+	source.CallerProxyAPIIDs[0] = "mutated-again"
+	source, ok = snapshot.LookupAdapter("rest-1__mcp-server")
+	require.True(t, ok)
+	assert.Equal(t, []string{"proxy-a", "proxy-b"}, source.CallerProxyAPIIDs)
+}
+
+func TestIndex_ConcurrentReads(t *testing.T) {
+	idx := NewIndex()
+	snapshot, err := NewSnapshot([]Record{
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-1", CallerProxyOrgID: "org-1"},
+		{SourceRESTAPIID: "rest-2", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-2", CallerProxyOrgID: "org-1"},
+	})
+	require.NoError(t, err)
+	idx.Set(snapshot)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				assert.True(t, idx.AllowsCaller("rest-1__mcp-server", "proxy-1"))
+				assert.False(t, idx.AllowsCaller("rest-1__mcp-server", "proxy-2"))
+				_, ok := idx.LookupAdapter("rest-2__mcp-server")
+				assert.True(t, ok)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestNewSnapshot_CrossOrgRefused(t *testing.T) {
+	_, err := NewSnapshot([]Record{
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-rest", CallerProxyAPIID: "proxy-1", CallerProxyOrgID: "org-proxy"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-org")
+}
+
+func TestNewSnapshot_DuplicateProxyTargetsAllowed(t *testing.T) {
+	snapshot, err := NewSnapshot([]Record{
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-1", CallerProxyOrgID: "org-1"},
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-2", CallerProxyOrgID: "org-1"},
+	})
+	require.NoError(t, err)
+
+	source, ok := snapshot.LookupSource("rest-1")
+	require.True(t, ok)
+	assert.Equal(t, []string{"proxy-1", "proxy-2"}, source.CallerProxyAPIIDs)
+	assert.True(t, snapshot.AllowsCaller("rest-1__mcp-server", "proxy-1"))
+	assert.True(t, snapshot.AllowsCaller("rest-1__mcp-server", "proxy-2"))
+}
+
+func TestNewSnapshot_ProxyRemovalBehavior(t *testing.T) {
+	snapshot, err := NewSnapshot([]Record{
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-remaining", CallerProxyOrgID: "org-1"},
+	})
+	require.NoError(t, err)
+
+	source, ok := snapshot.LookupSource("rest-1")
+	require.True(t, ok)
+	assert.Equal(t, []string{"proxy-remaining"}, source.CallerProxyAPIIDs)
+	assert.False(t, snapshot.AllowsCaller("rest-1__mcp-server", "proxy-removed"))
+}
+
+func TestStaticLookup(t *testing.T) {
+	snapshot, err := NewSnapshot([]Record{
+		{SourceRESTAPIID: "rest-1", SourceOrgID: "org-1", CallerProxyAPIID: "proxy-1", CallerProxyOrgID: "org-1"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "rest-1__mcp-server", CanonicalAdapterAPIID("rest-1"))
+	source, ok := snapshot.LookupAdapter(CanonicalAdapterAPIID("rest-1"))
+	require.True(t, ok)
+	assert.Equal(t, "rest-1", source.SourceRESTAPIID)
+	assert.True(t, snapshot.AllowsCaller(CanonicalAdapterAPIID("rest-1"), "proxy-1"))
+}


### PR DESCRIPTION
## What changed

Implements the REST-as-MCP gateway runtime and admin lifecycle for TT-17321.

- Synthesizes hidden internal SDK-backed MCP adapters per referenced REST API.
- Adds an atomic REST/source/adapter/caller pairing index.
- Routes paired MCP proxy `tyk://` calls to canonical synthetic adapters.
- Serves synthetic adapters through the MCP SDK, including caller-specific `tools/list`.
- Validates `tools/call` against the actual caller proxy view, maps aliases, and dispatches through the source REST chain.
- Adds trusted MCP adapter loop auth bypass and restore middleware.
- Blocks deleting a REST source while paired MCP proxies reference it.
- Keeps synthetic adapters hidden from admin list/get/delete and loaded API reporting.

## Why

Paired MCP proxies are the user-facing APIs, while the runtime needs one internal adapter per REST source API. The adapter must reuse the SDK server across reloads, apply caller-specific tool views, and call the source REST API in memory without exposing operator-managed adapter APIs.

## Validation

```bash
GOCACHE=/private/tmp/tyk-go-cache go test ./internal/mcp/pairing ./internal/mcp/adapter
GOCACHE=/private/tmp/tyk-go-cache go test ./apidef/oas ./gateway -run 'RESTAsMCP|MCPAdapter|Synthetic|Pairing|MCPLoopAuth|Paired' -count=1
git diff --cached --check
```

Pre-commit and pre-push hooks also passed during commit/push.
