### PR TITLE
TT-17322 Implement REST-as-MCP proxy policy enforcement

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -727,6 +727,36 @@ func (a APIDefinitionLoader) GetMCPFilepath(path string) string {
 	return strings.TrimSuffix(path, ".json") + "-mcp.json"
 }
 
+func (a APIDefinitionLoader) isOASCompanionFile(path string) bool {
+	var apiDefPath string
+	switch {
+	case strings.HasSuffix(path, "-oas.json"):
+		apiDefPath = strings.TrimSuffix(path, "-oas.json") + ".json"
+	case strings.HasSuffix(path, "-mcp.json"):
+		apiDefPath = strings.TrimSuffix(path, "-mcp.json") + ".json"
+	default:
+		return false
+	}
+
+	if _, err := os.Stat(apiDefPath); err != nil {
+		return false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+
+	var marker struct {
+		OpenAPI string `json:"openapi"`
+		Swagger string `json:"swagger"`
+	}
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return false
+	}
+	return marker.OpenAPI != "" || marker.Swagger != ""
+}
+
 // FromDir will load APIDefinitions from a directory on the filesystem. Definitions need
 // to be the JSON representation of APIDefinition object
 func (a APIDefinitionLoader) FromDir(dir string) []*APISpec {
@@ -735,7 +765,7 @@ func (a APIDefinitionLoader) FromDir(dir string) []*APISpec {
 	paths, _ := filepath.Glob(filepath.Join(dir, "*.json"))
 	for _, path := range paths {
 		// Skip companion files (loaded separately)
-		if strings.HasSuffix(path, "-oas.json") || strings.HasSuffix(path, "-mcp.json") {
+		if a.isOASCompanionFile(path) {
 			continue
 		}
 

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -3052,3 +3052,47 @@ func TestLoadDefFromFilePath(t *testing.T) {
 		assert.Nil(t, spec)
 	})
 }
+
+func TestAPIDefinitionLoaderFromDir_LoadsAPIDefinitionEndingWithCompanionSuffix(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "api_def_suffix_test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	apiID := "proxy-over-mcp"
+	def := apidef.APIDefinition{
+		Name:  apiID,
+		APIID: apiID,
+		IsOAS: true,
+		Proxy: apidef.ProxyConfig{
+			ListenPath: "/proxy-over-mcp/",
+			TargetURL:  "https://example.org/mcp",
+		},
+	}
+	def.MarkAsMCP()
+
+	apiData, err := json.Marshal(def)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, apiID+".json"), apiData, 0644)
+	assert.NoError(t, err)
+
+	oasDoc := &oas.OAS{T: openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: apiID, Version: "1.0.0"},
+		Paths:   openapi3.NewPaths(),
+	}}
+	oasData, err := json.Marshal(oasDoc)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, apiID+"-mcp.json"), oasData, 0644)
+	assert.NoError(t, err)
+
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.SetConfig(config.Config{})
+	loader := APIDefinitionLoader{Gw: gw}
+	specs := loader.FromDir(tmpDir)
+
+	assert.Len(t, specs, 1)
+	if assert.NotEmpty(t, specs) {
+		assert.Equal(t, apiID, specs[0].APIID)
+		assert.NotNil(t, specs[0].OAS)
+	}
+}

--- a/gateway/api_healthcheck.go
+++ b/gateway/api_healthcheck.go
@@ -39,6 +39,9 @@ type DefaultHealthChecker struct {
 }
 
 func (h *DefaultHealthChecker) Init(storeType storage.Handler) {
+	if h.Gw == nil {
+		return
+	}
 	if !h.Gw.GetConfig().HealthCheck.EnableHealthChecks {
 		return
 	}

--- a/gateway/mcp_api.go
+++ b/gateway/mcp_api.go
@@ -245,6 +245,37 @@ func derivedToolSourceIdentity(tool oas.DerivedTool) string {
 	return tool.CanonicalName
 }
 
+func (gw *Gateway) alignPairedMCPProxyGatewayTags(apiDef *apidef.APIDefinition, oasObj *oas.OAS) error {
+	if apiDef == nil || oasObj == nil {
+		return nil
+	}
+
+	_, restAPIID, ok := pairedMCPAdapterTarget(apiDef.Proxy.TargetURL)
+	if !ok {
+		return nil
+	}
+
+	rest := gw.getApiSpec(restAPIID)
+	if rest == nil || rest.APIDefinition == nil {
+		return fmt.Errorf("paired REST API %s is not loaded; create it first", restAPIID)
+	}
+
+	apiDef.TagsDisabled = rest.TagsDisabled
+	apiDef.Tags = append([]string(nil), rest.Tags...)
+
+	ext := oasObj.GetTykExtension()
+	if ext == nil {
+		return nil
+	}
+	if ext.Server.GatewayTags == nil {
+		ext.Server.GatewayTags = &oas.GatewayTags{}
+	}
+	ext.Server.GatewayTags.Enabled = !apiDef.TagsDisabled
+	ext.Server.GatewayTags.Tags = append([]string(nil), apiDef.Tags...)
+
+	return nil
+}
+
 func (gw *Gateway) handleAddMCP(r *http.Request, fs afero.Fs) (interface{}, int) {
 	versionParams := lib.NewVersionQueryParameters(r.URL.Query())
 	err := versionParams.Validate(func() (bool, string) {
@@ -284,6 +315,10 @@ func (gw *Gateway) handleAddMCP(r *http.Request, fs afero.Fs) (interface{}, int)
 	)
 
 	if err := gw.handleOASServersForNewAPI(newDef, oasObj, versioningParams); err != nil {
+		return apiError(err.Error()), http.StatusBadRequest
+	}
+
+	if err := gw.alignPairedMCPProxyGatewayTags(newDef, oasObj); err != nil {
 		return apiError(err.Error()), http.StatusBadRequest
 	}
 
@@ -332,6 +367,10 @@ func (gw *Gateway) handleUpdateMCP(apiID string, r *http.Request, fs afero.Fs) (
 	}
 
 	if err := gw.handleOASServersForUpdate(spec, newDef, oasObj); err != nil {
+		return apiError(err.Error()), http.StatusBadRequest
+	}
+
+	if err := gw.alignPairedMCPProxyGatewayTags(newDef, oasObj); err != nil {
 		return apiError(err.Error()), http.StatusBadRequest
 	}
 

--- a/gateway/mcp_api_test.go
+++ b/gateway/mcp_api_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -22,6 +23,31 @@ import (
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/config"
 )
+
+func newMCPTestGateway(t *testing.T, appPath ...string) *Gateway {
+	t.Helper()
+
+	var path string
+	if len(appPath) > 0 {
+		path = appPath[0]
+	} else {
+		path = t.TempDir()
+	}
+
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.SetConfig(config.Config{
+		AppPath:    path,
+		HostName:   "localhost",
+		ListenPort: 8080,
+	})
+	return gw
+}
+
+func newValidateMCPHandler(t *testing.T, next http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+
+	return newMCPTestGateway(t).validateMCP(next)
+}
 
 func TestExtractMCPObjFromReq(t *testing.T) {
 	t.Parallel()
@@ -158,16 +184,13 @@ func TestValidateMCP(t *testing.T) {
 	}`
 
 	t.Run("valid MCP object passes validation", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(validMCPDefinition))
 		req.Header.Set("Content-Type", "application/json")
@@ -180,16 +203,13 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("PUT request with valid MCP object", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPut, "/test", strings.NewReader(validMCPDefinition))
 		req.Header.Set("Content-Type", "application/json")
@@ -202,15 +222,12 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("malformed request body", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"invalid": json}`))
 		req.Header.Set("Content-Type", "application/json")
@@ -224,15 +241,12 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("POST without Tyk extension returns error", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithoutExtension := `{
 			"openapi": "3.0.3",
@@ -252,15 +266,12 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("PUT without Tyk extension returns error", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithoutExtension := `{
 			"openapi": "3.0.3",
@@ -280,16 +291,13 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("GET request without Tyk extension passes", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithoutExtension := `{
 			"openapi": "3.0.3",
@@ -309,15 +317,12 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("missing required Tyk fields returns error", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		invalidMCP := `{
 			"openapi": "3.0.3",
@@ -341,9 +346,6 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("request body is preserved for next handler", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		var capturedBody []byte
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var err error
@@ -352,7 +354,7 @@ func TestValidateMCP(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(validMCPDefinition))
 		req.Header.Set("Content-Type", "application/json")
@@ -366,9 +368,6 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("context is passed through", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		type contextKey string
 		testKey := contextKey("test-key")
 		testValue := "test-value"
@@ -381,7 +380,7 @@ func TestValidateMCP(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		ctx := context.WithValue(context.Background(), testKey, testValue)
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(validMCPDefinition))
@@ -396,11 +395,8 @@ func TestValidateMCP(t *testing.T) {
 	})
 
 	t.Run("response headers are set correctly on error", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`invalid`))
 		req.Header.Set("Content-Type", "application/json")
@@ -415,15 +411,12 @@ func TestValidateMCP(t *testing.T) {
 
 func TestValidateMCP_EdgeCases(t *testing.T) {
 	t.Run("empty request body reader", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", &bytes.Buffer{})
 		req.Header.Set("Content-Type", "application/json")
@@ -436,9 +429,6 @@ func TestValidateMCP_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("MCP object with multiple tools", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		mcpWithMultipleTools := `{
 			"openapi": "3.0.3",
 			"info": {"title": "Multi-Tool MCP API", "version": "1.0.0"},
@@ -470,7 +460,7 @@ func TestValidateMCP_EdgeCases(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(mcpWithMultipleTools))
 		req.Header.Set("Content-Type", "application/json")
@@ -483,16 +473,13 @@ func TestValidateMCP_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("DELETE request behavior", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithoutExtension := `{
 			"openapi": "3.0.3",
@@ -550,6 +537,28 @@ func restSourceSpec(apiID, orgID string, isOAS bool) *APISpec {
 			IsOAS: isOAS,
 		},
 		OAS: doc,
+	}
+}
+
+func mcpManagedTestSpec(apiID string) *APISpec {
+	apiDef := &apidef.APIDefinition{
+		APIID: apiID,
+		Name:  apiID,
+		IsOAS: true,
+		Proxy: apidef.ProxyConfig{
+			ListenPath: "/" + apiID + "/",
+			TargetURL:  "http://upstream.url",
+		},
+	}
+	apiDef.MarkAsMCP()
+
+	return &APISpec{
+		APIDefinition: apiDef,
+		OAS: oas.OAS{T: openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: apiID, Version: "1.0.0"},
+			Paths:   openapi3.NewPaths(),
+		}},
 	}
 }
 
@@ -1025,17 +1034,9 @@ func TestMCPListHandler(t *testing.T) {
 }
 
 func TestMCPUpdateHandler(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-
-	// Create a test MCP Proxy
-	ts.Gw.BuildAndLoadAPI(
-		func(spec *APISpec) {
-			spec.APIID = "mcp-update-test"
-			spec.Name = "MCP Update Test"
-			spec.MarkAsMCP()
-		},
-	)
+	appPath := t.TempDir()
+	gw := newMCPTestGateway(t, appPath)
+	gw.apisByID["mcp-update-test"] = mcpManagedTestSpec("mcp-update-test")
 
 	validMCPUpdate := `{
 		"openapi": "3.0.3",
@@ -1076,13 +1077,14 @@ func TestMCPUpdateHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "/tyk/mcps/mcp-update-test", strings.NewReader(validMCPUpdate))
 		w := httptest.NewRecorder()
 
-		// Mock mux.Vars
 		req = mux.SetURLVars(req, map[string]string{"apiID": "mcp-update-test"})
 
-		ts.Gw.mcpUpdateHandler(w, req)
+		gw.mcpUpdateHandler(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), "modified")
+		assert.FileExists(t, filepath.Join(appPath, "mcp-update-test.json"))
+		assert.FileExists(t, filepath.Join(appPath, "mcp-update-test-mcp.json"))
 	})
 
 	t.Run("returns 400 for invalid API ID", func(t *testing.T) {
@@ -1091,7 +1093,7 @@ func TestMCPUpdateHandler(t *testing.T) {
 
 		req = mux.SetURLVars(req, map[string]string{"apiID": "../../../etc/passwd"})
 
-		ts.Gw.mcpUpdateHandler(w, req)
+		gw.mcpUpdateHandler(w, req)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "Invalid API ID")
@@ -1099,8 +1101,13 @@ func TestMCPUpdateHandler(t *testing.T) {
 }
 
 func TestMCPDeleteHandler(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
+	appPath := t.TempDir()
+	gw := newMCPTestGateway(t, appPath)
+	gw.apisByID["test-api"] = mcpManagedTestSpec("test-api")
+
+	fs := afero.NewOsFs()
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(appPath, "test-api.json"), []byte("{}"), 0644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(appPath, "test-api-mcp.json"), []byte("{}"), 0644))
 
 	t.Run("deletes MCP Proxy successfully", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, "/tyk/mcps/test-api", nil)
@@ -1108,9 +1115,12 @@ func TestMCPDeleteHandler(t *testing.T) {
 
 		req = mux.SetURLVars(req, map[string]string{"apiID": "test-api"})
 
-		ts.Gw.mcpDeleteHandler(w, req)
+		gw.mcpDeleteHandler(w, req)
 
-		assert.NotEqual(t, http.StatusInternalServerError, w.Code)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "deleted")
+		assert.NoFileExists(t, filepath.Join(appPath, "test-api.json"))
+		assert.NoFileExists(t, filepath.Join(appPath, "test-api-mcp.json"))
 	})
 
 	t.Run("rejects invalid API ID", func(t *testing.T) {
@@ -1119,7 +1129,7 @@ func TestMCPDeleteHandler(t *testing.T) {
 
 		req = mux.SetURLVars(req, map[string]string{"apiID": "../../etc/passwd"})
 
-		ts.Gw.mcpDeleteHandler(w, req)
+		gw.mcpDeleteHandler(w, req)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "Invalid API ID")
@@ -1128,15 +1138,12 @@ func TestMCPDeleteHandler(t *testing.T) {
 
 func TestValidateMCP_PRM(t *testing.T) {
 	t.Run("rejects PRM without resource", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithBadPRM := `{
 			"openapi": "3.0.3",
@@ -1178,15 +1185,12 @@ func TestValidateMCP_PRM(t *testing.T) {
 	})
 
 	t.Run("rejects PRM without authorizationServers for MCP", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithBadPRM := `{
 			"openapi": "3.0.3",
@@ -1228,16 +1232,13 @@ func TestValidateMCP_PRM(t *testing.T) {
 	})
 
 	t.Run("accepts valid PRM", func(t *testing.T) {
-		ts := StartTest(nil)
-		defer ts.Close()
-
 		nextCalled := false
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := ts.Gw.validateMCP(nextHandler)
+		handler := newValidateMCPHandler(t, nextHandler)
 
 		mcpWithGoodPRM := `{
 			"openapi": "3.0.3",

--- a/gateway/mcp_api_test.go
+++ b/gateway/mcp_api_test.go
@@ -843,85 +843,106 @@ func TestHandleAddApiOAS_ValidatesPairedMCPAdapterUpstream(t *testing.T) {
 	assert.Contains(t, msg.Message, "missing-rest")
 }
 
-func TestHandleAddMCP_CopiesSourceRESTGatewayTagsToPairedProxy(t *testing.T) {
-	gw := &Gateway{apisByID: map[string]*APISpec{}}
-	gw.SetConfig(config.Config{
-		AppPath:    "/apps",
-		HostName:   "localhost",
-		ListenPort: 8080,
-	})
-	gw.apisByID["rest-1"] = restSourceSpec("rest-1", "org-1", true)
-	gw.apisByID["rest-1"].TagsDisabled = false
-	gw.apisByID["rest-1"].Tags = []string{"edge-a", "edge-b"}
+func TestHandleMCP_AlignsSourceRESTGatewayTagsToPairedProxy(t *testing.T) {
+	cases := []struct {
+		name      string
+		handler   func(*Gateway, *http.Request, afero.Fs) (interface{}, int)
+		method    string
+		path      string
+		loadProxy bool
+	}{
+		{
+			name: "add",
+			handler: func(gw *Gateway, req *http.Request, fs afero.Fs) (interface{}, int) {
+				return gw.handleAddMCP(req, fs)
+			},
+			method: http.MethodPost,
+			path:   "/tyk/mcps",
+		},
+		{
+			name: "update",
+			handler: func(gw *Gateway, req *http.Request, fs afero.Fs) (interface{}, int) {
+				return gw.handleUpdateMCP("proxy-1", req, fs)
+			},
+			method:    http.MethodPut,
+			path:      "/tyk/mcps/proxy-1",
+			loadProxy: true,
+		},
+	}
 
-	body, err := json.Marshal(pairedMCPProxyOAS("proxy-1", "org-1", "rest-1"))
-	require.NoError(t, err)
-	req := httptest.NewRequest(http.MethodPost, "/tyk/mcps", bytes.NewReader(body))
-	fs := afero.NewMemMapFs()
-	require.NoError(t, fs.MkdirAll("/apps", 0755))
+	for _, tc := range cases {
+		t.Run(tc.name+" copies source tags", func(t *testing.T) {
+			gw := pairedMCPGatewayForTagAlignment(tc.loadProxy, true)
+			fs := afero.NewMemMapFs()
+			require.NoError(t, fs.MkdirAll("/apps", 0755))
 
-	obj, code := gw.handleAddMCP(req, fs)
+			body, err := json.Marshal(pairedMCPProxyOAS("proxy-1", "org-1", "rest-1"))
+			require.NoError(t, err)
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader(body))
 
-	require.Equal(t, http.StatusOK, code)
-	resp, ok := obj.(apiModifyKeySuccess)
-	require.True(t, ok)
-	assert.Equal(t, "proxy-1", resp.Key)
+			obj, code := tc.handler(gw, req, fs)
 
-	apiDefBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1.json")
-	require.NoError(t, err)
-	var apiDef apidef.APIDefinition
-	require.NoError(t, json.Unmarshal(apiDefBody, &apiDef))
-	assert.False(t, apiDef.TagsDisabled)
-	assert.Equal(t, []string{"edge-a", "edge-b"}, apiDef.Tags)
+			require.Equal(t, http.StatusOK, code)
+			resp, ok := obj.(apiModifyKeySuccess)
+			require.True(t, ok)
+			assert.Equal(t, "proxy-1", resp.Key)
+			assertWrittenPairedMCPGatewayTags(t, gw, fs, false, []string{"edge-a", "edge-b"})
+		})
 
-	oasBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1-mcp.json")
-	require.NoError(t, err)
-	var proxyOAS oas.OAS
-	require.NoError(t, json.Unmarshal(oasBody, &proxyOAS))
-	require.NotNil(t, proxyOAS.GetTykExtension().Server.GatewayTags)
-	assert.True(t, proxyOAS.GetTykExtension().Server.GatewayTags.Enabled)
-	assert.Equal(t, []string{"edge-a", "edge-b"}, proxyOAS.GetTykExtension().Server.GatewayTags.Tags)
+		t.Run(tc.name+" rejects missing source", func(t *testing.T) {
+			gw := pairedMCPGatewayForTagAlignment(tc.loadProxy, false)
+			fs := afero.NewMemMapFs()
+			require.NoError(t, fs.MkdirAll("/apps", 0755))
+
+			body, err := json.Marshal(pairedMCPProxyOAS("proxy-1", "org-1", "rest-1"))
+			require.NoError(t, err)
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader(body))
+
+			obj, code := tc.handler(gw, req, fs)
+
+			require.Equal(t, http.StatusBadRequest, code)
+			msg, ok := obj.(apiStatusMessage)
+			require.True(t, ok)
+			assert.Contains(t, msg.Message, "paired REST API rest-1 is not loaded")
+		})
+	}
 }
 
-func TestHandleUpdateMCP_CopiesSourceRESTGatewayTagsToPairedProxy(t *testing.T) {
+func pairedMCPGatewayForTagAlignment(loadProxy, loadSource bool) *Gateway {
 	gw := &Gateway{apisByID: map[string]*APISpec{}}
 	gw.SetConfig(config.Config{
 		AppPath:    "/apps",
 		HostName:   "localhost",
 		ListenPort: 8080,
 	})
-	gw.apisByID["rest-1"] = restSourceSpec("rest-1", "org-1", true)
-	gw.apisByID["rest-1"].TagsDisabled = false
-	gw.apisByID["rest-1"].Tags = []string{"edge-a", "edge-b"}
-	gw.apisByID["proxy-1"] = pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+	if loadSource {
+		gw.apisByID["rest-1"] = restSourceSpec("rest-1", "org-1", true)
+		gw.apisByID["rest-1"].TagsDisabled = false
+		gw.apisByID["rest-1"].Tags = []string{"edge-a", "edge-b"}
+	}
+	if loadProxy {
+		gw.apisByID["proxy-1"] = pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+	}
+	return gw
+}
 
-	body, err := json.Marshal(pairedMCPProxyOAS("proxy-1", "org-1", "rest-1"))
-	require.NoError(t, err)
-	req := httptest.NewRequest(http.MethodPut, "/tyk/mcps/proxy-1", bytes.NewReader(body))
-	fs := afero.NewMemMapFs()
-	require.NoError(t, fs.MkdirAll("/apps", 0755))
-
-	obj, code := gw.handleUpdateMCP("proxy-1", req, fs)
-
-	require.Equal(t, http.StatusOK, code)
-	resp, ok := obj.(apiModifyKeySuccess)
-	require.True(t, ok)
-	assert.Equal(t, "proxy-1", resp.Key)
+func assertWrittenPairedMCPGatewayTags(t *testing.T, gw *Gateway, fs afero.Fs, tagsDisabled bool, tags []string) {
+	t.Helper()
 
 	apiDefBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1.json")
 	require.NoError(t, err)
 	var apiDef apidef.APIDefinition
 	require.NoError(t, json.Unmarshal(apiDefBody, &apiDef))
-	assert.False(t, apiDef.TagsDisabled)
-	assert.Equal(t, []string{"edge-a", "edge-b"}, apiDef.Tags)
+	assert.Equal(t, tagsDisabled, apiDef.TagsDisabled)
+	assert.Equal(t, tags, apiDef.Tags)
 
 	oasBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1-mcp.json")
 	require.NoError(t, err)
 	var proxyOAS oas.OAS
 	require.NoError(t, json.Unmarshal(oasBody, &proxyOAS))
 	require.NotNil(t, proxyOAS.GetTykExtension().Server.GatewayTags)
-	assert.True(t, proxyOAS.GetTykExtension().Server.GatewayTags.Enabled)
-	assert.Equal(t, []string{"edge-a", "edge-b"}, proxyOAS.GetTykExtension().Server.GatewayTags.Tags)
+	assert.Equal(t, !tagsDisabled, proxyOAS.GetTykExtension().Server.GatewayTags.Enabled)
+	assert.Equal(t, tags, proxyOAS.GetTykExtension().Server.GatewayTags.Tags)
 }
 
 func TestHandleGetMCPListOAS(t *testing.T) {

--- a/gateway/mcp_api_test.go
+++ b/gateway/mcp_api_test.go
@@ -843,6 +843,87 @@ func TestHandleAddApiOAS_ValidatesPairedMCPAdapterUpstream(t *testing.T) {
 	assert.Contains(t, msg.Message, "missing-rest")
 }
 
+func TestHandleAddMCP_CopiesSourceRESTGatewayTagsToPairedProxy(t *testing.T) {
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.SetConfig(config.Config{
+		AppPath:    "/apps",
+		HostName:   "localhost",
+		ListenPort: 8080,
+	})
+	gw.apisByID["rest-1"] = restSourceSpec("rest-1", "org-1", true)
+	gw.apisByID["rest-1"].TagsDisabled = false
+	gw.apisByID["rest-1"].Tags = []string{"edge-a", "edge-b"}
+
+	body, err := json.Marshal(pairedMCPProxyOAS("proxy-1", "org-1", "rest-1"))
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/tyk/mcps", bytes.NewReader(body))
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/apps", 0755))
+
+	obj, code := gw.handleAddMCP(req, fs)
+
+	require.Equal(t, http.StatusOK, code)
+	resp, ok := obj.(apiModifyKeySuccess)
+	require.True(t, ok)
+	assert.Equal(t, "proxy-1", resp.Key)
+
+	apiDefBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1.json")
+	require.NoError(t, err)
+	var apiDef apidef.APIDefinition
+	require.NoError(t, json.Unmarshal(apiDefBody, &apiDef))
+	assert.False(t, apiDef.TagsDisabled)
+	assert.Equal(t, []string{"edge-a", "edge-b"}, apiDef.Tags)
+
+	oasBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1-mcp.json")
+	require.NoError(t, err)
+	var proxyOAS oas.OAS
+	require.NoError(t, json.Unmarshal(oasBody, &proxyOAS))
+	require.NotNil(t, proxyOAS.GetTykExtension().Server.GatewayTags)
+	assert.True(t, proxyOAS.GetTykExtension().Server.GatewayTags.Enabled)
+	assert.Equal(t, []string{"edge-a", "edge-b"}, proxyOAS.GetTykExtension().Server.GatewayTags.Tags)
+}
+
+func TestHandleUpdateMCP_CopiesSourceRESTGatewayTagsToPairedProxy(t *testing.T) {
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.SetConfig(config.Config{
+		AppPath:    "/apps",
+		HostName:   "localhost",
+		ListenPort: 8080,
+	})
+	gw.apisByID["rest-1"] = restSourceSpec("rest-1", "org-1", true)
+	gw.apisByID["rest-1"].TagsDisabled = false
+	gw.apisByID["rest-1"].Tags = []string{"edge-a", "edge-b"}
+	gw.apisByID["proxy-1"] = pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+
+	body, err := json.Marshal(pairedMCPProxyOAS("proxy-1", "org-1", "rest-1"))
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPut, "/tyk/mcps/proxy-1", bytes.NewReader(body))
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/apps", 0755))
+
+	obj, code := gw.handleUpdateMCP("proxy-1", req, fs)
+
+	require.Equal(t, http.StatusOK, code)
+	resp, ok := obj.(apiModifyKeySuccess)
+	require.True(t, ok)
+	assert.Equal(t, "proxy-1", resp.Key)
+
+	apiDefBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1.json")
+	require.NoError(t, err)
+	var apiDef apidef.APIDefinition
+	require.NoError(t, json.Unmarshal(apiDefBody, &apiDef))
+	assert.False(t, apiDef.TagsDisabled)
+	assert.Equal(t, []string{"edge-a", "edge-b"}, apiDef.Tags)
+
+	oasBody, err := afero.ReadFile(fs, gw.GetConfig().AppPath+"/proxy-1-mcp.json")
+	require.NoError(t, err)
+	var proxyOAS oas.OAS
+	require.NoError(t, json.Unmarshal(oasBody, &proxyOAS))
+	require.NotNil(t, proxyOAS.GetTykExtension().Server.GatewayTags)
+	assert.True(t, proxyOAS.GetTykExtension().Server.GatewayTags.Enabled)
+	assert.Equal(t, []string{"edge-a", "edge-b"}, proxyOAS.GetTykExtension().Server.GatewayTags.Tags)
+}
+
 func TestHandleGetMCPListOAS(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()

--- a/gateway/mcp_pairing.go
+++ b/gateway/mcp_pairing.go
@@ -162,6 +162,7 @@ func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (
 	}
 
 	adapterID := pairing.CanonicalAdapterAPIID(rest.APIID)
+	gw := gatewayForSyntheticAdapter(rest, existing)
 	sdkAdapter := (*restmcpadapter.SDKAdapter)(nil)
 	if existing != nil {
 		sdkAdapter = existing.MCPAdapter.SDKAdapter
@@ -225,6 +226,16 @@ func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (
 	return &APISpec{
 		APIDefinition: adapterDef,
 		OAS:           doc,
+		Health: &DefaultHealthChecker{
+			Gw:    gw,
+			APIID: adapterID,
+		},
+		AuthManager: &DefaultSessionManager{Gw: gw},
+		OrgSessionManager: &DefaultSessionManager{
+			orgID: rest.OrgID,
+			Gw:    gw,
+		},
+		GlobalConfig: rest.GlobalConfig,
 		MCPAdapter: MCPAdapterRuntime{
 			Synthetic:                true,
 			SourceRESTAPIID:          rest.APIID,
@@ -235,6 +246,24 @@ func buildMCPAdapterSpec(rest *APISpec, proxies []*APISpec, existing *APISpec) (
 		},
 		JSONRPCRouter: mcp.NewRouter(),
 	}, nil
+}
+
+func gatewayForSyntheticAdapter(specs ...*APISpec) *Gateway {
+	for _, spec := range specs {
+		if spec == nil {
+			continue
+		}
+		if manager, ok := spec.AuthManager.(*DefaultSessionManager); ok && manager.Gw != nil {
+			return manager.Gw
+		}
+		if manager, ok := spec.OrgSessionManager.(*DefaultSessionManager); ok && manager.Gw != nil {
+			return manager.Gw
+		}
+		if health, ok := spec.Health.(*DefaultHealthChecker); ok && health.Gw != nil {
+			return health.Gw
+		}
+	}
+	return nil
 }
 
 func deriveMCPAdapterCatalogue(rest *APISpec, proxies []*APISpec) (mcpAdapterCatalogue, error) {

--- a/gateway/mcp_pairing_test.go
+++ b/gateway/mcp_pairing_test.go
@@ -151,7 +151,7 @@ func TestBuildAdapterSpec_InitializesManagerFields(t *testing.T) {
 	store.EXPECT().Connect().Return(true).Times(2)
 
 	require.NotPanics(t, func() {
-		adapterSpec.Init(store, store, store, store)
+		adapterSpec.Init(store, store, store)
 	})
 }
 

--- a/gateway/mcp_pairing_test.go
+++ b/gateway/mcp_pairing_test.go
@@ -6,10 +6,12 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/internal/mcp/pairing"
+	mockstorage "github.com/TykTechnologies/tyk/storage/mock"
 )
 
 func TestComputeMCPPairing(t *testing.T) {
@@ -135,6 +137,22 @@ func TestBuildAdapterSpec_ReusesSDKAdapterAndUpdatesTools(t *testing.T) {
 	tool, ok := reused.MCPAdapter.ToolViews["proxy-1"].ToolByName("list_orders")
 	require.True(t, ok)
 	assert.Equal(t, "updated list orders", tool.Description)
+}
+
+func TestBuildAdapterSpec_InitializesManagerFields(t *testing.T) {
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", nil)
+
+	adapterSpec, err := buildMCPAdapterSpec(rest, []*APISpec{proxy}, nil)
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	store := mockstorage.NewMockHandler(ctrl)
+	store.EXPECT().Connect().Return(true).Times(2)
+
+	require.NotPanics(t, func() {
+		adapterSpec.Init(store, store, store, store)
+	})
 }
 
 func TestSynthesizeMCPAdapterSpecs_AppendsHiddenInternalAdapters(t *testing.T) {

--- a/gateway/mcp_synthetic_runtime_test.go
+++ b/gateway/mcp_synthetic_runtime_test.go
@@ -150,7 +150,7 @@ func TestWriteSyntheticMCPToolsListResponse_FailsClosedWhenRewriteFails(t *testi
 			Name:        "visible",
 			InputSchema: map[string]any{"type": "object"},
 		}},
-	}, true)
+	}, true, nil)
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.NotContains(t, rec.Body.String(), "hidden")

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -313,15 +313,25 @@ func (m *JSONRPCMiddleware) processSyntheticMCPAdapterRequest(w http.ResponseWri
 		return nil, middleware.StatusRespond
 	}
 
-	method := syntheticJSONRPCMethod(r)
+	policyCtx, responded := m.prepareRESTAsMCPPolicy(w, r)
+	if responded {
+		return nil, middleware.StatusRespond
+	}
+
+	method := ""
+	if policyCtx != nil && policyCtx.rpcReq != nil {
+		method = policyCtx.rpcReq.Method
+	} else {
+		method = syntheticJSONRPCMethod(r)
+	}
 	normaliseMCPStreamableAccept(r)
 	installMCPAdapterCallContext(r, m.Gw, m.Spec)
 
-	if method == mcp.MethodToolsList {
+	if method == mcp.MethodToolsList || (policyCtx != nil && policyCtx.listConfig != nil) {
 		rec := newBufferedResponseWriter()
 		m.Spec.MCPAdapter.SDKAdapter.StreamableHTTPHandler(nil).ServeHTTP(rec, r)
 		view, ok := m.syntheticMCPToolViewForCaller(r)
-		m.writeSyntheticMCPToolsListResponse(w, r, rec, view, ok)
+		m.writeSyntheticMCPToolsListResponse(w, r, rec, view, ok, policyCtx)
 		return nil, middleware.StatusRespond
 	}
 
@@ -380,7 +390,7 @@ func (m *JSONRPCMiddleware) syntheticMCPToolViewForCaller(r *http.Request) (oas.
 	return view, ok
 }
 
-func (m *JSONRPCMiddleware) writeSyntheticMCPToolsListResponse(w http.ResponseWriter, r *http.Request, rec *bufferedResponseWriter, view oas.MCPToolView, filter bool) {
+func (m *JSONRPCMiddleware) writeSyntheticMCPToolsListResponse(w http.ResponseWriter, r *http.Request, rec *bufferedResponseWriter, view oas.MCPToolView, filter bool, policyCtx *restAsMCPPolicyContext) {
 	body := rec.body.Bytes()
 	if filter && rec.statusCode < http.StatusBadRequest {
 		rewritten, err := rewriteMCPToolsListResponse(body, view)
@@ -390,6 +400,11 @@ func (m *JSONRPCMiddleware) writeSyntheticMCPToolsListResponse(w http.ResponseWr
 			return
 		}
 		body = rewritten
+	}
+	if rec.statusCode < http.StatusBadRequest {
+		if filtered, ok := filterRESTAsMCPListResponse(body, policyCtx); ok {
+			body = filtered
+		}
 	}
 	rec.writeTo(w, body)
 }

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy.go
@@ -34,7 +34,11 @@ type restAsMCPPolicyContext struct {
 // prepareRESTAsMCPPolicy parses the JSON-RPC request handled by a synthetic
 // REST-as-MCP adapter and applies caller-proxy policy before SDK execution.
 func (m *JSONRPCMiddleware) prepareRESTAsMCPPolicy(w http.ResponseWriter, r *http.Request) (*restAsMCPPolicyContext, bool) {
-	rpcReq, ok := parseSyntheticAdapterJSONRPC(r)
+	rpcReq, ok, err := parseSyntheticAdapterJSONRPC(r)
+	if err != nil {
+		m.writeJSONRPCError(w, r, nil, mcp.JSONRPCParseError, mcp.ErrMsgParseError, nil)
+		return nil, true
+	}
 	if !ok {
 		return nil, false
 	}
@@ -59,27 +63,32 @@ func (m *JSONRPCMiddleware) prepareRESTAsMCPPolicy(w http.ResponseWriter, r *htt
 	return policyCtx, false
 }
 
-func parseSyntheticAdapterJSONRPC(r *http.Request) (*JSONRPCRequest, bool) {
+func parseSyntheticAdapterJSONRPC(r *http.Request) (*JSONRPCRequest, bool, error) {
 	if r == nil || r.Method != http.MethodPost || r.Body == nil {
-		return nil, false
+		return nil, false, nil
 	}
 	if !strings.HasPrefix(r.Header.Get(headerContentType), contentTypeJSON) {
-		return nil, false
+		return nil, false, nil
 	}
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		r.Body = io.NopCloser(bytes.NewReader(nil))
-		return nil, false
+	body, err := io.ReadAll(io.LimitReader(r.Body, syntheticJSONRPCMethodReadLimit+1))
+	r.Body = prefixedReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(body), r.Body),
+		Closer: r.Body,
 	}
-	r.Body = io.NopCloser(bytes.NewReader(body))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(body) > syntheticJSONRPCMethodReadLimit {
+		return nil, false, fmt.Errorf("synthetic JSON-RPC request exceeds %d bytes", syntheticJSONRPCMethodReadLimit)
+	}
 
 	var rpcReq JSONRPCRequest
 	if err := json.Unmarshal(body, &rpcReq); err != nil || rpcReq.Method == "" {
-		return nil, false
+		return nil, false, nil
 	}
 
-	return &rpcReq, true
+	return &rpcReq, true, nil
 }
 
 func (m *JSONRPCMiddleware) routeSyntheticAdapterJSONRPC(rpcReq *JSONRPCRequest) (jsonrpc.RouteResult, error) {

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy.go
@@ -1,0 +1,285 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/TykTechnologies/tyk/internal/httpctx"
+	"github.com/TykTechnologies/tyk/internal/jsonrpc"
+	jsonrpcerrors "github.com/TykTechnologies/tyk/internal/jsonrpc/errors"
+	"github.com/TykTechnologies/tyk/internal/mcp"
+	"github.com/TykTechnologies/tyk/internal/rate"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+const (
+	jsonrpcRateLimitExceededMessage = "Rate Limit Exceeded"
+	jsonrpcInternalErrorMessage     = "Internal Server Error"
+)
+
+type restAsMCPPolicyContext struct {
+	proxyAPIID string
+	proxySpec  *APISpec
+	session    *user.SessionState
+	accessDef  user.AccessDefinition
+	hasAccess  bool
+	rpcReq     *JSONRPCRequest
+	listConfig *mcp.ListFilterConfig
+}
+
+// prepareRESTAsMCPPolicy parses the JSON-RPC request handled by a synthetic
+// REST-as-MCP adapter and applies caller-proxy policy before SDK execution.
+func (m *JSONRPCMiddleware) prepareRESTAsMCPPolicy(w http.ResponseWriter, r *http.Request) (*restAsMCPPolicyContext, bool) {
+	rpcReq, ok := parseSyntheticAdapterJSONRPC(r)
+	if !ok {
+		return nil, false
+	}
+
+	route, err := m.routeSyntheticAdapterJSONRPC(rpcReq)
+	if err != nil {
+		m.writeJSONRPCError(w, r, rpcReq.ID, mcp.JSONRPCInvalidParams, err.Error(), nil)
+		return nil, true
+	}
+
+	policyCtx := &restAsMCPPolicyContext{
+		rpcReq:     rpcReq,
+		listConfig: listConfigForMCPMethod(rpcReq.Method),
+	}
+	policyCtx.setJSONRPCState(r, route.VEMChain, route.PrimitiveName)
+	m.loadRESTAsMCPPolicyCaller(r, policyCtx)
+
+	if m.deniesRESTAsMCPPolicies(w, r, policyCtx) {
+		return policyCtx, true
+	}
+
+	return policyCtx, false
+}
+
+func parseSyntheticAdapterJSONRPC(r *http.Request) (*JSONRPCRequest, bool) {
+	if r == nil || r.Method != http.MethodPost || r.Body == nil {
+		return nil, false
+	}
+	if !strings.HasPrefix(r.Header.Get(headerContentType), contentTypeJSON) {
+		return nil, false
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		r.Body = io.NopCloser(bytes.NewReader(nil))
+		return nil, false
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	var rpcReq JSONRPCRequest
+	if err := json.Unmarshal(body, &rpcReq); err != nil || rpcReq.Method == "" {
+		return nil, false
+	}
+
+	return &rpcReq, true
+}
+
+func (m *JSONRPCMiddleware) routeSyntheticAdapterJSONRPC(rpcReq *JSONRPCRequest) (jsonrpc.RouteResult, error) {
+	router := m.Spec.JSONRPCRouter
+	if router == nil {
+		router = mcp.NewRouter()
+	}
+
+	result, err := router.RouteMethod(rpcReq.Method, rpcReq.Params, m.Spec.MCPPrimitives)
+	if err != nil {
+		return jsonrpc.RouteResult{}, err
+	}
+	return result, nil
+}
+
+func (c *restAsMCPPolicyContext) setJSONRPCState(r *http.Request, vemChain []string, primitiveName string) {
+	primitiveType := primitiveTypeForMethod(c.rpcReq.Method)
+	httpctx.SetJSONRPCRoutingState(r, &httpctx.JSONRPCRoutingState{
+		Method:        c.rpcReq.Method,
+		Params:        c.rpcReq.Params,
+		ID:            c.rpcReq.ID,
+		OriginalPath:  r.URL.Path,
+		VEMChain:      vemChain,
+		PrimitiveType: primitiveType,
+		PrimitiveName: primitiveName,
+	})
+	httpctx.SetJsonRPCRouting(r, true)
+
+	ctxSetMCPMethod(r, c.rpcReq.Method)
+	ctxSetMCPPrimitiveType(r, primitiveType)
+	ctxSetMCPPrimitiveName(r, primitiveName)
+}
+
+func (m *JSONRPCMiddleware) loadRESTAsMCPPolicyCaller(r *http.Request, policyCtx *restAsMCPPolicyContext) {
+	proxyAPIID := ctxGetMCPAdapterCallerProxyID(r)
+	if proxyAPIID == "" || m.Gw == nil {
+		return
+	}
+
+	policyCtx.proxyAPIID = proxyAPIID
+	policyCtx.proxySpec = m.Gw.getApiSpec(proxyAPIID)
+	policyCtx.session = ctxGetSession(r)
+	if policyCtx.proxySpec == nil || policyCtx.session == nil {
+		return
+	}
+
+	accessDef, found := policyCtx.session.AccessRights[proxyAPIID]
+	if !found {
+		return
+	}
+
+	policyCtx.accessDef = accessDef
+	policyCtx.hasAccess = true
+}
+
+func (m *JSONRPCMiddleware) deniesRESTAsMCPPolicies(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext) bool {
+	if m.deniesRESTAsMCPMethod(w, r, policyCtx) {
+		return true
+	}
+	if m.deniesRESTAsMCPPrimitive(w, r, policyCtx) {
+		return true
+	}
+	return m.enforceRESTAsMCPEndpointRateLimits(w, r, policyCtx)
+}
+
+func (m *JSONRPCMiddleware) deniesRESTAsMCPMethod(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext) bool {
+	if !policyCtx.hasAccess || policyCtx.accessDef.JSONRPCMethodsAccessRights.IsEmpty() {
+		return false
+	}
+	if !mcp.CheckAccessControlRules(policyCtx.accessDef.JSONRPCMethodsAccessRights, policyCtx.rpcReq.Method) {
+		return false
+	}
+
+	writeJSONRPCAccessDenied(w, r, fmt.Sprintf("method '%s' is not available", policyCtx.rpcReq.Method))
+	return true
+}
+
+func (m *JSONRPCMiddleware) deniesRESTAsMCPPrimitive(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext) bool {
+	if !policyCtx.hasAccess || policyCtx.accessDef.MCPAccessRights.IsEmpty() {
+		return false
+	}
+
+	state := httpctx.GetJSONRPCRoutingState(r)
+	if state == nil || state.PrimitiveType == "" || state.PrimitiveName == "" {
+		return false
+	}
+
+	rules := rulesForPrimitiveType(policyCtx.accessDef.MCPAccessRights, state.PrimitiveType)
+	if !mcp.CheckAccessControlRules(rules, state.PrimitiveName) {
+		return false
+	}
+
+	writeJSONRPCAccessDenied(w, r, fmt.Sprintf("%s '%s' is not available", state.PrimitiveType, state.PrimitiveName))
+	return true
+}
+
+func (m *JSONRPCMiddleware) enforceRESTAsMCPEndpointRateLimits(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext) bool {
+	if !policyCtx.hasAccess || policyCtx.proxySpec == nil || m.Gw == nil || m.Gw.SessionLimiter.config == nil {
+		return false
+	}
+
+	state := httpctx.GetJSONRPCRoutingState(r)
+	if state == nil {
+		return false
+	}
+
+	for _, vemPath := range state.VEMChain {
+		if m.enforceRESTAsMCPEndpointRateLimit(w, r, policyCtx, vemPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *JSONRPCMiddleware) enforceRESTAsMCPEndpointRateLimit(w http.ResponseWriter, r *http.Request, policyCtx *restAsMCPPolicyContext, vemPath string) bool {
+	if len(policyCtx.accessDef.Endpoints) == 0 {
+		return false
+	}
+
+	rateReq := restAsMCPRateLimitRequest(r, vemPath)
+	if _, ok := m.Gw.SessionLimiter.RateLimitInfo(rateReq, policyCtx.proxySpec, policyCtx.accessDef.Endpoints); !ok {
+		return false
+	}
+
+	reason := m.Gw.SessionLimiter.ForwardMessage(
+		rateReq,
+		policyCtx.session,
+		restAsMCPRateLimitKey(r, policyCtx),
+		"",
+		true,
+		false,
+		policyCtx.proxySpec,
+		false,
+		restAsMCPRateLimitHeaderSender(m.Gw, w),
+	)
+
+	return writeRESTAsMCPRateLimitResult(w, policyCtx.rpcReq.ID, reason)
+}
+
+func restAsMCPRateLimitRequest(r *http.Request, vemPath string) *http.Request {
+	rateReq := r.Clone(r.Context())
+	copiedURL := *r.URL
+	copiedURL.Path = vemPath
+	copiedURL.RawPath = ""
+	rateReq.URL = &copiedURL
+	rateReq.Method = http.MethodPost
+	return rateReq
+}
+
+func restAsMCPRateLimitKey(r *http.Request, policyCtx *restAsMCPPolicyContext) string {
+	if token := ctxGetAuthToken(r); token != "" {
+		return token
+	}
+	return policyCtx.session.KeyID
+}
+
+func restAsMCPRateLimitHeaderSender(gw *Gateway, w http.ResponseWriter) rate.HeaderSender {
+	if gw.limitHeaderFactory == nil {
+		return nil
+	}
+	return gw.limitHeaderFactory(w.Header())
+}
+
+func writeRESTAsMCPRateLimitResult(w http.ResponseWriter, requestID any, reason sessionFailReason) bool {
+	switch reason {
+	case sessionFailNone:
+		return false
+	case sessionFailRateLimit:
+		jsonrpcerrors.WriteJSONRPCError(w, requestID, http.StatusTooManyRequests, jsonrpcRateLimitExceededMessage)
+		return true
+	default:
+		jsonrpcerrors.WriteJSONRPCError(w, requestID, http.StatusInternalServerError, jsonrpcInternalErrorMessage)
+		return true
+	}
+}
+
+func listConfigForMCPMethod(method string) *mcp.ListFilterConfig {
+	switch method {
+	case mcp.MethodToolsList:
+		return mcp.ListFilterConfigs["tools"]
+	case mcp.MethodPromptsList:
+		return mcp.ListFilterConfigs["prompts"]
+	case mcp.MethodResourcesList:
+		return mcp.ListFilterConfigs["resources"]
+	case mcp.MethodResourcesTemplatesList:
+		return mcp.ListFilterConfigs["resourceTemplates"]
+	default:
+		return nil
+	}
+}
+
+func filterRESTAsMCPListResponse(body []byte, policyCtx *restAsMCPPolicyContext) ([]byte, bool) {
+	if policyCtx == nil || policyCtx.proxySpec == nil || policyCtx.session == nil || policyCtx.listConfig == nil {
+		return nil, false
+	}
+
+	ruleSets := effectiveMCPListRuleSets(policyCtx.proxySpec, policyCtx.session, policyCtx.listConfig)
+	if len(ruleSets) == 0 {
+		return nil, false
+	}
+
+	return mcp.FilterJSONRPCBodyWithRuleSets(body, policyCtx.listConfig, ruleSets)
+}

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
@@ -1,0 +1,258 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/drl"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/mcp"
+	mcpadapter "github.com/TykTechnologies/tyk/internal/mcp/adapter"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+	"github.com/TykTechnologies/tyk/internal/rate"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+func TestRESTAsMCPPolicy_DeniesBlockedToolBeforeSDK(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	called := false
+	var err error
+	adapterSpec.MCPAdapter.SDKAdapter, err = mcpadapter.NewSDKAdapter(mcpadapter.SDKServerConfig{
+		Name:  adapterSpec.Name,
+		Tools: adapterSpec.MCPAdapter.UnionTools,
+		CallTool: func(context.Context, *oas.DerivedTool, map[string]any) (*mcpadapter.Recorder, error) {
+			called = true
+			return mcpadapter.NewRecorder(), nil
+		},
+	})
+	require.NoError(t, err)
+
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	req := restAsMCPPolicyRequest(t, sessionID, `{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/call",
+		"params":{"name":"orders","arguments":{}}
+	}`)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		MCPAccessRights: user.MCPAccessRights{
+			Tools: user.AccessControlRules{Blocked: []string{"orders"}},
+		},
+	}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "tool 'orders' is not available")
+	assert.False(t, called)
+	assert.Equal(t, "tools/call", ctxGetMCPMethod(req))
+	assert.Equal(t, "tool", ctxGetMCPPrimitiveType(req))
+	assert.Equal(t, "orders", ctxGetMCPPrimitiveName(req))
+}
+
+func TestRESTAsMCPPolicy_MethodDeniedBeforeSDK(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	req := restAsMCPPolicyRequest(t, sessionID, `{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/list",
+		"params":{}
+	}`)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		JSONRPCMethodsAccessRights: user.AccessControlRules{
+			Blocked: []string{"tools/list"},
+		},
+	}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "method 'tools/list' is not available")
+}
+
+func TestRESTAsMCPPolicy_FiltersToolsListResponseForCallerView(t *testing.T) {
+	gw, adapterSpec := restAsMCPPolicyGatewayWithTwoTools(t)
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	req := restAsMCPPolicyRequest(t, sessionID, `{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/list",
+		"params":{}
+	}`)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		MCPAccessRights: user.MCPAccessRights{
+			Tools: user.AccessControlRules{Allowed: []string{"orders"}},
+		},
+	}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	tools := jsonRPCToolsList(t, rec.Body.Bytes())
+	assert.Equal(t, []string{"orders"}, tools)
+	assert.NotContains(t, rec.Body.String(), "make_order")
+}
+
+func TestRESTAsMCPPolicy_EndpointRateLimitBlocksToolCall(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	cfg := config.Default
+	drlManager := &drl.DRL{RequestTokenValue: 1}
+	drlManager.SetCurrentTokenValue(1)
+	gw.SessionLimiter = NewSessionLimiter(t.Context(), &cfg, drlManager, &cfg.ExternalServices)
+	gw.limitHeaderFactory = rate.NewSenderFactory(cfg.RateLimitResponseHeaders)
+
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	session := restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		MCPPrimitives: []user.MCPPrimitiveLimit{
+			{Type: mcp.PrimitiveTypeTool, Name: "orders", Limit: user.RateLimit{Rate: 1, Per: 60}},
+		},
+	})
+	NormalizeMCPEndpoints(session)
+
+	makeRequest := func() *http.Request {
+		req := restAsMCPPolicyRequest(t, sessionID, `{
+			"jsonrpc":"2.0",
+			"id":2,
+			"method":"tools/call",
+			"params":{"name":"orders","arguments":{}}
+		}`)
+		ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+		setSessionForTest(req, session)
+		return req
+	}
+
+	first := httptest.NewRecorder()
+	err, status := mw.ProcessRequest(first, makeRequest(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusOK, first.Code)
+
+	second := httptest.NewRecorder()
+	err, status = mw.ProcessRequest(second, makeRequest(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusTooManyRequests, second.Code)
+	assert.Contains(t, second.Body.String(), "Rate Limit Exceeded")
+}
+
+func TestRESTAsMCPPolicy_AliasUsesCallerFacingName(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	req := restAsMCPPolicyRequest(t, sessionID, `{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/call",
+		"params":{"name":"orders","arguments":{}}
+	}`)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		MCPAccessRights: user.MCPAccessRights{
+			Tools: user.AccessControlRules{Allowed: []string{"list_orders"}},
+		},
+	}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "tool 'orders' is not available")
+}
+
+func restAsMCPPolicyGatewayWithTwoTools(t *testing.T) (*Gateway, *APISpec) {
+	t.Helper()
+
+	rest := restSourceSpec("rest-1", "org-1", true)
+	proxy := pairedMCPProxySpec("proxy-1", "org-1", "rest-1", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "list_orders"}, Name: "orders", Allow: boolPtr(true)},
+			{Source: oas.TykMCPServerSource{OperationID: "create_order"}, Name: "make_order", Allow: boolPtr(true)},
+		},
+	})
+	adapterSpec, err := buildMCPAdapterSpec(rest, []*APISpec{proxy}, nil)
+	require.NoError(t, err)
+
+	gw := &Gateway{
+		apisByID: map[string]*APISpec{
+			"rest-1":          rest,
+			adapterSpec.APIID: adapterSpec,
+			"proxy-1":         proxy,
+		},
+		apisHandlesByID: &sync.Map{},
+	}
+	gw.apisHandlesByID.Store("rest-1", &ChainObject{ThisHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})})
+	snapshot, err := computeMCPPairing([]*APISpec{rest, proxy})
+	require.NoError(t, err)
+	gw.mcpPairingIndex.Set(snapshot)
+	return gw, adapterSpec
+}
+
+func restAsMCPPolicyRequest(t *testing.T, sessionID, body string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	return req
+}
+
+func restAsMCPSession(apiID string, accessDef user.AccessDefinition) *user.SessionState {
+	return &user.SessionState{
+		KeyID: "agent-key-1",
+		AccessRights: map[string]user.AccessDefinition{
+			apiID: accessDef,
+		},
+	}
+}
+
+func jsonRPCToolsList(t *testing.T, body []byte) []string {
+	t.Helper()
+
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	result := envelope["result"].(map[string]any)
+	rawTools := result["tools"].([]any)
+	names := make([]string, 0, len(rawTools))
+	for _, raw := range rawTools {
+		tool := raw.(map[string]any)
+		names = append(names, tool["name"].(string))
+	}
+	return names
+}

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -191,6 +192,39 @@ func TestRESTAsMCPPolicy_AliasUsesCallerFacingName(t *testing.T) {
 	assert.Equal(t, middleware.StatusRespond, status)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	assert.Contains(t, rec.Body.String(), "tool 'orders' is not available")
+}
+
+func TestRESTAsMCPPolicy_RejectsOversizedJSONRPCBeforeSDK(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	called := false
+	var err error
+	adapterSpec.MCPAdapter.SDKAdapter, err = mcpadapter.NewSDKAdapter(mcpadapter.SDKServerConfig{
+		Name:  adapterSpec.Name,
+		Tools: adapterSpec.MCPAdapter.UnionTools,
+		CallTool: func(context.Context, *oas.DerivedTool, map[string]any) (*mcpadapter.Recorder, error) {
+			called = true
+			return mcpadapter.NewRecorder(), nil
+		},
+	})
+	require.NoError(t, err)
+
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"orders","arguments":{"payload":"` +
+		strings.Repeat("x", syntheticJSONRPCMethodReadLimit) +
+		`"}}}`
+	req := restAsMCPPolicyRequest(t, sessionID, body)
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{APIID: "proxy-1"}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), mcp.ErrMsgParseError)
+	assert.False(t, called)
 }
 
 func restAsMCPPolicyGatewayWithTwoTools(t *testing.T) (*Gateway, *APISpec) {

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -93,7 +93,7 @@ func (gw *Gateway) validateMCPFieldsInAccessRights(accessRights map[string]user.
 		if spec == nil {
 			continue
 		}
-		if !spec.IsMCP() {
+		if !mcpProxy(spec) {
 			return fmt.Errorf("MCP fields can only be configured on MCP Proxies, API %q is not an MCP Proxy", apiID)
 		}
 		for _, p := range ar.MCPPrimitives {
@@ -127,7 +127,7 @@ func (gw *Gateway) validateNonMCPFieldsOnMCPProxy(accessRights map[string]user.A
 		if spec == nil {
 			continue
 		}
-		if spec.IsMCP() {
+		if mcpProxy(spec) {
 			return fmt.Errorf("HTTP/REST and GraphQL fields cannot be configured on MCP Proxies, API %q is an MCP Proxy", apiID)
 		}
 	}

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/model"
@@ -1527,21 +1528,16 @@ func TestHasMCPFields(t *testing.T) {
 }
 
 func TestValidateMCPFieldsInAccessRights(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-
-	specs := ts.Gw.BuildAndLoadAPI(
-		func(spec *APISpec) {
-			spec.APIID = "mcp-api-id"
-			spec.MarkAsMCP()
-		},
-		func(spec *APISpec) {
-			spec.APIID = "non-mcp-api-id"
-			spec.Name = "non-mcp-api"
-		},
-	)
-	mcpAPIID := specs[0].APIID
-	nonMCPAPIID := specs[1].APIID
+	mcpAPIID := "mcp-api-id"
+	nonMCPAPIID := "non-mcp-api-id"
+	pairedMCPAPIID := "paired-mcp-api-id"
+	mcpDef := &apidef.APIDefinition{APIID: mcpAPIID, OrgID: "org-1"}
+	mcpDef.MarkAsMCP()
+	gw := &Gateway{apisByID: map[string]*APISpec{
+		mcpAPIID:       {APIDefinition: mcpDef},
+		nonMCPAPIID:    {APIDefinition: &apidef.APIDefinition{APIID: nonMCPAPIID, Name: "non-mcp-api"}},
+		pairedMCPAPIID: pairedMCPProxySpec(pairedMCPAPIID, "org-1", "rest-1", nil),
+	}}
 
 	mcpAR := user.AccessDefinition{
 		JSONRPCMethods: []user.JSONRPCMethodLimit{{Name: "tools/call"}},
@@ -1555,6 +1551,10 @@ func TestValidateMCPFieldsInAccessRights(t *testing.T) {
 		{
 			name:         "MCP fields on MCP Proxy are accepted",
 			accessRights: map[string]user.AccessDefinition{mcpAPIID: mcpAR},
+		},
+		{
+			name:         "MCP fields on REST-as-MCP paired proxy are accepted",
+			accessRights: map[string]user.AccessDefinition{pairedMCPAPIID: mcpAR},
 		},
 		{
 			name:         "MCP fields on non-MCP API are rejected",
@@ -1592,9 +1592,9 @@ func TestValidateMCPFieldsInAccessRights(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ts.Gw.validateMCPFieldsInAccessRights(tc.accessRights)
+			err := gw.validateMCPFieldsInAccessRights(tc.accessRights)
 			if tc.expectErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectErr)
 			} else {
 				assert.NoError(t, err)
@@ -1654,21 +1654,16 @@ func TestHasNonMCPFields(t *testing.T) {
 }
 
 func TestValidateNonMCPFieldsOnMCPProxy(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-
-	specs := ts.Gw.BuildAndLoadAPI(
-		func(spec *APISpec) {
-			spec.APIID = "mcp-api-id"
-			spec.MarkAsMCP()
-		},
-		func(spec *APISpec) {
-			spec.APIID = "non-mcp-api-id"
-			spec.Name = "non-mcp-api"
-		},
-	)
-	mcpAPIID := specs[0].APIID
-	nonMCPAPIID := specs[1].APIID
+	mcpAPIID := "mcp-api-id"
+	nonMCPAPIID := "non-mcp-api-id"
+	pairedMCPAPIID := "paired-mcp-api-id"
+	mcpDef := &apidef.APIDefinition{APIID: mcpAPIID, OrgID: "org-1"}
+	mcpDef.MarkAsMCP()
+	gw := &Gateway{apisByID: map[string]*APISpec{
+		mcpAPIID:       {APIDefinition: mcpDef},
+		nonMCPAPIID:    {APIDefinition: &apidef.APIDefinition{APIID: nonMCPAPIID, Name: "non-mcp-api"}},
+		pairedMCPAPIID: pairedMCPProxySpec(pairedMCPAPIID, "org-1", "rest-1", nil),
+	}}
 
 	cases := []struct {
 		name         string
@@ -1679,6 +1674,13 @@ func TestValidateNonMCPFieldsOnMCPProxy(t *testing.T) {
 			name: "AllowedURLs on MCP Proxy is rejected",
 			accessRights: map[string]user.AccessDefinition{
 				mcpAPIID: {AllowedURLs: []user.AccessSpec{{URL: "/foo", Methods: []string{"GET"}}}},
+			},
+			expectErr: "HTTP/REST and GraphQL fields cannot be configured on MCP Proxies",
+		},
+		{
+			name: "AllowedURLs on REST-as-MCP paired proxy is rejected",
+			accessRights: map[string]user.AccessDefinition{
+				pairedMCPAPIID: {AllowedURLs: []user.AccessSpec{{URL: "/foo", Methods: []string{"GET"}}}},
 			},
 			expectErr: "HTTP/REST and GraphQL fields cannot be configured on MCP Proxies",
 		},
@@ -1737,9 +1739,9 @@ func TestValidateNonMCPFieldsOnMCPProxy(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ts.Gw.validateNonMCPFieldsOnMCPProxy(tc.accessRights)
+			err := gw.validateNonMCPFieldsOnMCPProxy(tc.accessRights)
 			if tc.expectErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectErr)
 			} else {
 				assert.NoError(t, err)

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -157,6 +157,10 @@ func shouldReloadSpec(existingSpec, newSpec *APISpec) bool {
 		return true
 	}
 
+	if newSpec.IsSyntheticMCPAdapter() {
+		return true
+	}
+
 	if existingSpec.Checksum != newSpec.Checksum {
 		return true
 	}

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -251,6 +251,13 @@ func Test_shouldReloadSpec(t *testing.T) {
 		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
 	})
 
+	t.Run("synthetic rest as mcp adapter", func(t *testing.T) {
+		t.Parallel()
+		existingSpec := &APISpec{Checksum: "1", MCPAdapter: MCPAdapterRuntime{Synthetic: true}}
+		newSpec := &APISpec{Checksum: "1", MCPAdapter: MCPAdapterRuntime{Synthetic: true}}
+		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
+	})
+
 	type testCase struct {
 		name string
 		spec *APISpec

--- a/internal/mcp/adapter/adapter.go
+++ b/internal/mcp/adapter/adapter.go
@@ -11,6 +11,7 @@ package adapter
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	"net/url"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
@@ -50,8 +52,8 @@ const (
 // source REST APIID (so downstream rewriters see a coherent host).
 //
 // The function is parent-context-aware: the returned request inherits
-// the parent's context, body, and trailers are not propagated (the
-// adapter does not stream).
+// parent context values without inheriting parent cancellation. The body
+// and trailers are not propagated (the adapter does not stream).
 //
 // Returned errors are user-facing — they are surfaced via the JSON-RPC
 // `error` envelope.
@@ -400,8 +402,10 @@ func scalarParameterValue(raw any) (string, bool) {
 		return fmt.Sprint(v), true
 	case uint, uint8, uint16, uint32, uint64:
 		return fmt.Sprint(v), true
-	case float32, float64:
-		return fmt.Sprint(v), true
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32), true
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
 	case json.Number:
 		return v.String(), true
 	default:
@@ -453,7 +457,7 @@ func (b *upstreamRequestBuilder) request() (*http.Request, error) {
 		body = bytes.NewReader(buf)
 	}
 
-	req, err := http.NewRequestWithContext(b.parent.Context(), b.tool.Method, b.path, body)
+	req, err := http.NewRequestWithContext(context.WithoutCancel(b.parent.Context()), b.tool.Method, b.path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/adapter/adapter_test.go
+++ b/internal/mcp/adapter/adapter_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -92,6 +93,50 @@ func TestBuildUpstreamRequest_PathQueryHeader(t *testing.T) {
 	assert.Equal(t, "true", req.URL.Query().Get("verbose"))
 	assert.Equal(t, "rest-1", req.URL.Host)
 	assert.Equal(t, "http", req.URL.Scheme)
+}
+
+func TestBuildUpstreamRequest_DetachesFromParentCancellation(t *testing.T) {
+	t.Parallel()
+	type contextKey string
+
+	parentCtx, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey("caller"), "proxy-1"))
+	parent := httptest.NewRequest(http.MethodPost, "/mcp/", nil).WithContext(parentCtx)
+	cancel()
+	tool := sampleTool(t, "getOrder")
+
+	req, err := BuildUpstreamRequest(parent, tool, "rest-1", map[string]any{"id": 42})
+
+	require.NoError(t, err)
+	assert.Equal(t, "proxy-1", req.Context().Value(contextKey("caller")))
+	select {
+	case <-req.Context().Done():
+		t.Fatal("upstream request context should not inherit parent cancellation")
+	default:
+	}
+}
+
+func TestBuildUpstreamRequest_IntegerValuedFloatArgumentUsesDecimalNotation(t *testing.T) {
+	t.Parallel()
+	parent := httptest.NewRequest(http.MethodPost, "/mcp/", nil)
+	tool := &oas.DerivedTool{
+		Name:         "large_response",
+		Method:       http.MethodGet,
+		PathTemplate: "/large/{size}",
+		ParamLocations: map[string]string{
+			"size": oas.DerivedParamLocationPath,
+		},
+		ParamSourceNames: map[string]string{
+			"size": "size",
+		},
+		ParamOrder: []string{"size"},
+	}
+
+	req, err := BuildUpstreamRequest(parent, tool, "rest-1", map[string]any{
+		"size": float64(2097152),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/large/2097152", req.URL.Path)
 }
 
 func TestBuildUpstreamRequest_RejectsUnknownArgs(t *testing.T) {


### PR DESCRIPTION
## Summary
- Enforce REST-as-MCP caller proxy JSON-RPC method ACLs, MCP tool ACLs, and per-primitive endpoint rate limits before SDK tool execution.
- Rewrite and policy-filter synthetic adapter list responses using the actual caller proxy tool view.
- Copy source REST gateway tags onto paired MCP proxy create/update persistence.

## Test Plan
- GOCACHE=/private/tmp/tyk-go-cache go test ./gateway -run 'RESTAsMCPPolicy|Handle(Add|Update)MCP_CopiesSourceRESTGatewayTags' -count=1
- GOCACHE=/private/tmp/tyk-go-cache go test -count=1 ./internal/mcp/adapter ./internal/mcp/pairing ./internal/mcp
- CI=true GOCACHE=/private/tmp/tyk-go-cache go test -count=1 ./apidef/oas ./apidef/mcp ./gateway -run 'MCP|JSONRPC|RESTAsMCP|Pairing|Synthetic|Loop|Paired'

Stacked on #8280 / TT-17321.