### PR TITLE
[TT-17386]: Fix timeout prioritization on 5.8

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1202,14 +1202,21 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		}
 
 		timeout := proxyTimeout(p.TykAPISpec)
+		transportTimeout := timeout
 
-		// If an enforced timeout is configured for this API endpoint, use it instead
-		// of the global default timeout, as it should take precedence
+		// If an enforced timeout is configured for this API endpoint, we use context timeout instead of transport timeout
+		// to avoid conflicts between ResponseHeaderTimeout and context timeout
 		if isTimeoutEnforced {
-			timeout = enforcedTimeout
+			// Don't pass the enforced timeout to transport - let context timeout handle it
+			// Use the default proxy timeout for transport instead
+			transportTimeout = proxyTimeout(p.TykAPISpec)
+			p.logger.Debug("Using context timeout for hard timeout, transport timeout: ", transportTimeout)
+		} else {
+			// For non-enforced timeouts, we can use the global timeout on transport
+			p.logger.Debug("Using transport timeout: ", timeout)
 		}
 
-		p.TykAPISpec.HTTPTransport = p.httpTransport(timeout, rw, req, outreq)
+		p.TykAPISpec.HTTPTransport = p.httpTransport(transportTimeout, rw, req, outreq)
 		p.TykAPISpec.HTTPTransportCreated = time.Now()
 
 		if oldTransport != nil {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
[TT-17386](https://tyktech.atlassian.net/browse/TT-17386)
## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-17386]: https://tyktech.atlassian.net/browse/TT-17386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ