### PR TITLE
[TT-17176] Mirror upstream PRM from the new oauth2.protectedResourceMetadata block

### DIFF
--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -90,6 +90,22 @@ func (prm *OAuth2PRM) IsAutoDeriveScopes() bool {
 	return *prm.AutoDeriveScopes
 }
 
+// IsMirrorMode reports whether this PRM resolves to mirror mode for the
+// given API context. Mirror is the implicit default for MCP APIs whose
+// PRM configures no static fields (Resource or AuthorizationServers);
+// everything else is static. Mirrors ProtectedResourceMetadata.IsMirrorMode
+// so the new per-scheme block behaves identically to the deprecated
+// top-level block it supersedes.
+func (prm *OAuth2PRM) IsMirrorMode(isMCP bool) bool {
+	if prm == nil || !prm.Enabled {
+		return false
+	}
+	if prm.Resource != "" || len(prm.AuthorizationServers) > 0 {
+		return false
+	}
+	return isMCP
+}
+
 // OAuth2ScopeCheck holds OAS-native scope enforcement configuration.
 //
 // The required scopes themselves live in the OAS root `security:`

--- a/apidef/oas/oauth2_test.go
+++ b/apidef/oas/oauth2_test.go
@@ -402,3 +402,29 @@ func TestValidateOAuth2Schemes_ScopeSource(t *testing.T) {
 		})
 	}
 }
+
+func TestOAuth2PRM_IsMirrorMode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		prm   *OAuth2PRM
+		isMCP bool
+		want  bool
+	}{
+		{"nil", nil, true, false},
+		{"disabled", &OAuth2PRM{Enabled: false}, true, false},
+		{"MCP API with no static fields → mirror", &OAuth2PRM{Enabled: true}, true, true},
+		{"MCP API with resource set → static", &OAuth2PRM{Enabled: true, Resource: "https://x"}, true, false},
+		{"MCP API with authorizationServers only → static",
+			&OAuth2PRM{Enabled: true, AuthorizationServers: []string{"https://auth"}}, true, false},
+		{"non-MCP API never resolves to mirror", &OAuth2PRM{Enabled: true}, false, false},
+		{"non-MCP with resource set → static", &OAuth2PRM{Enabled: true, Resource: "https://x"}, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.prm.IsMirrorMode(tc.isMCP))
+		})
+	}
+}

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -1029,7 +1029,7 @@ func (gw *Gateway) mcpPRMSuffixHandler(spec *APISpec) http.HandlerFunc {
 			return
 		}
 		if prm.IsMirrorMode(spec.IsMCP()) {
-			if err := mw.serveMirroredPRM(w, r, prm); err != nil {
+			if err := mw.serveMirroredPRM(w, r); err != nil {
 				log.WithError(err).Warn("PRM mirror failed at suffix route")
 				http.Error(w, "upstream PRM unavailable", http.StatusBadGateway)
 			}

--- a/gateway/mw_protected_resource.go
+++ b/gateway/mw_protected_resource.go
@@ -72,7 +72,7 @@ func (m *PRMMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 
 	// Mirror mode: fetch from upstream, rewrite resource, serve.
 	if prm.IsMirrorMode(m.Spec.IsMCP()) {
-		if err := m.serveMirroredPRM(w, r, prm); err != nil {
+		if err := m.serveMirroredPRM(w, r); err != nil {
 			log.WithError(err).Warn("PRM mirror failed; passing through to upstream")
 			return nil, http.StatusOK
 		}
@@ -107,6 +107,18 @@ func (m *PRMMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 //
 //nolint:staticcheck // ST1008: middleware interface requires (error, int) return order
 func (m *PRMMiddleware) serveOAuth2PRM(w http.ResponseWriter, r *http.Request, name string, prm *oas.OAuth2PRM) (error, int) {
+	// Mirror mode (MCP, no static fields): serve the upstream's PRM doc,
+	// same as the deprecated top-level block. The new block wins over the
+	// old one, so the mirror path must live here too — otherwise a migrated
+	// mirror-shape MCP API serves an empty static document.
+	if prm.IsMirrorMode(m.Spec.IsMCP()) {
+		if err := m.serveMirroredPRM(w, r); err != nil {
+			log.WithError(err).Warn("PRM mirror failed; passing through to upstream")
+			return nil, http.StatusOK
+		}
+		return nil, middleware.StatusRespond
+	}
+
 	resource := prm.Resource
 	if resource != "" {
 		resource = m.Gw.ReplaceTykVariables(r, resource, false)
@@ -132,7 +144,7 @@ func (m *PRMMiddleware) serveOAuth2PRM(w http.ResponseWriter, r *http.Request, n
 // at Tyk's per-API AS-proxy URL so RFC 8707 `resource`-parameter rewriting
 // can intercept the OAuth flow, and writes the result to w. The fetched
 // document is cached per upstream URL with TTL.
-func (m *PRMMiddleware) serveMirroredPRM(w http.ResponseWriter, r *http.Request, _ *oas.ProtectedResourceMetadata) error {
+func (m *PRMMiddleware) serveMirroredPRM(w http.ResponseWriter, r *http.Request) error {
 	doc, err := m.Gw.upstreamPRMDoc(r.Context(), m.Spec)
 	if err != nil {
 		return err

--- a/gateway/mw_protected_resource_test.go
+++ b/gateway/mw_protected_resource_test.go
@@ -829,6 +829,97 @@ func TestPRMMirrorMode_SuffixRoute(t *testing.T) {
 	})
 }
 
+// TestOAuth2PRM_MirrorMode is the regression guard for the PRM auto-migration
+// (TT-17176). A mirror-shape MCP API (enabled, no resource/authorizationServers)
+// migrated into the new-style oauth2.protectedResourceMetadata block must keep
+// mirroring the upstream's PRM document. The new block wins over the deprecated
+// top-level block, so the new serving path must itself mirror — otherwise the
+// migrated API serves an empty static document instead of the upstream's.
+func TestOAuth2PRM_MirrorMode(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2" {
+			w.Header().Set("Content-Type", "application/json")
+			//nolint:errcheck // test fixture; HTTP response Write failure not actionable here
+			_, _ = io.WriteString(w, `{
+				"resource": "https://upstream.example/v1/mcp/authv2",
+				"authorization_servers": ["https://auth.upstream.example/tenant"],
+				"bearer_methods_supported": ["header"],
+				"resource_documentation": "https://upstream.example/docs"
+			}`)
+			return
+		}
+		w.Header().Set("WWW-Authenticate", `Bearer realm="OAuth"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(upstream.Close)
+
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	const listenPath = "/jira-new/"
+
+	oasDoc := oas.OAS{
+		T: openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: "MCP Mirror New", Version: "1.0"},
+			Paths:   openapi3.NewPaths(),
+		},
+	}
+	oasDoc.SetTykExtension(&oas.XTykAPIGateway{
+		Info:     oas.Info{Name: "mcp-mirror-new-test", State: oas.State{Active: true}},
+		Upstream: oas.Upstream{URL: upstream.URL + "/v1/mcp/authv2"},
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{Value: listenPath, Strip: true},
+			Authentication: &oas.Authentication{
+				Enabled: true,
+				SecuritySchemes: oas.SecuritySchemes{
+					"corpOAuth": &oas.OAuth2{
+						Enabled: true,
+						// Mirror shape: enabled, no Resource / AuthorizationServers.
+						ProtectedResourceMetadata: &oas.OAuth2PRM{Enabled: true},
+					},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.MarkAsMCP()
+		spec.Proxy.ListenPath = listenPath
+		spec.Proxy.TargetURL = upstream.URL + "/v1/mcp/authv2"
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+	})
+
+	ts.Gw.PRMCache().Invalidate(upstream.URL + "/.well-known/oauth-protected-resource/v1/mcp/authv2")
+
+	resp, _ := ts.Run(t, test.TestCase{
+		Method: http.MethodGet,
+		Path:   "/jira-new/.well-known/oauth-protected-resource",
+		Code:   http.StatusOK,
+	})
+
+	var doc map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&doc))
+
+	// Mirror mode rewrites `resource` to the gateway URL the client hit;
+	// an empty static doc would leave it "".
+	got, _ := doc["resource"].(string)
+	assert.True(t, strings.HasSuffix(got, listenPath),
+		"resource %q should be the rewritten gateway URL ending %q (mirror mode), not an empty static value", got, listenPath)
+
+	// Mirror mode redirects authorization_servers at Tyk's per-API AS proxy.
+	authServers, _ := doc["authorization_servers"].([]any)
+	require.Len(t, authServers, 1,
+		"expected mirrored authorization_servers; got %v (empty static doc?)", doc["authorization_servers"])
+	asURL, _ := authServers[0].(string)
+	assert.Contains(t, asURL, "/__tyk-as/", "authorization_servers should point at the Tyk AS proxy")
+
+	// Pass-through fields from the upstream doc prove we mirrored, not assembled.
+	assert.Equal(t, "https://upstream.example/docs", doc["resource_documentation"])
+}
+
 // TestPRMMirrorMode_OAuthProxy exercises the full mirror-mode OAuth flow:
 // PRM points clients at Tyk's AS proxy, the AS metadata endpoint serves
 // rewritten `authorization_endpoint`/`token_endpoint`, the authorize


### PR DESCRIPTION
## Summary

The PRM auto-migration (TT-17176) is non-destructive and copies the deprecated top-level `authentication.protectedResourceMetadata` block into the new per-scheme `oauth2.protectedResourceMetadata` location, where **the new block wins** over the old one at runtime.

For an existing **MCP API in mirror mode** the legacy block is intentionally `{enabled: true}` with no `resource`/`authorizationServers` — the shape the gateway treats as "mirror the upstream's PRM doc". After migration the gateway consults only the new block, but its serving path (`serveOAuth2PRM`) **only ever assembled a static document**. The result: a migrated mirror-mode MCP API served an empty static PRM doc (`resource: ""`, no `authorization_servers`) instead of mirroring the upstream — breaking transparent proxying of OAuth-protected remote MCP servers (mcp-remote / Claude Desktop discovery).

## Fix

- Give `OAuth2PRM` the same `IsMirrorMode(isMCP)` semantics as the legacy `ProtectedResourceMetadata` type (enabled + no static fields + MCP → mirror).
- `serveOAuth2PRM` now dispatches to the shared `serveMirroredPRM` path when the block resolves to mirror mode; static behavior is unchanged otherwise.
- The path-suffix and AS-proxy routes already cover MCP APIs (via `GetPRMConfig`'s MCP default), so only the standard well-known endpoint needed the change.
- Dropped `serveMirroredPRM`'s unused `*oas.ProtectedResourceMetadata` parameter.

## Tests

- `TestOAuth2PRM_MirrorMode` (gateway): regression guard — a mirror-shape MCP API on the new block must serve the mirrored upstream doc (rewritten `resource`, `authorization_servers` pointing at the Tyk AS proxy, upstream pass-through fields), not an empty static doc. Verified RED before the fix, GREEN after.
- `TestOAuth2PRM_IsMirrorMode` (apidef/oas): table-driven unit coverage of the new method, mirroring the legacy type's test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)