### PR TITLE
Token Exchange — Microsoft Entra On-Behalf-Of flow + private_key_jwt client auth

### DIFF
--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -2161,6 +2161,9 @@
         "defaultTarget": {
           "$ref": "#/definitions/X-Tyk-OAuth2-DefaultTarget"
         },
+        "actorToken": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorToken"
+        },
         "timeout": {
           "type": "string",
           "description": "Per-call timeout for the RFC 8693 exchange request, Tyk ReadableDuration (e.g. \"100ms\", \"5s\"). Defaults to 15s when zero/unset."
@@ -2190,6 +2193,60 @@
         "safetyMargin": { "type": "string", "description": "Shaved from the computed TTL to avoid serving near-expired tokens. Defaults to 30s." }
       },
       "required": ["enabled"]
+    },
+    "X-Tyk-OAuth2-ActorToken": {
+      "type": "object",
+      "description": "RFC 8693 actor token (delegation). When set, exchange requests carry actor_token; omit to use impersonation.",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": ["client_credentials", "header", "static"]
+        },
+        "actorTokenType": {
+          "type": "string",
+          "enum": ["urn:ietf:params:oauth:token-type:access_token", "urn:ietf:params:oauth:token-type:jwt"],
+          "description": "RFC 8693 token-type URN advertised for the actor token. Defaults to ...:access_token; set ...:jwt only for an RFC-strict IdP."
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorClientCredentials"
+        },
+        "header": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorHeader"
+        },
+        "static": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorStatic"
+        },
+        "requireMayAct": {
+          "type": "boolean",
+          "description": "When true, the gateway verifies the subject token's may_act (RFC 8693 §4.4) authorizes the configured actor before calling the IdP. Defaults false."
+        }
+      },
+      "required": ["source"]
+    },
+    "X-Tyk-OAuth2-ActorClientCredentials": {
+      "type": "object",
+      "properties": {
+        "tokenEndpoint": { "type": "string" },
+        "clientId": { "type": "string" },
+        "clientSecret": { "type": "string" },
+        "scopes": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["tokenEndpoint", "clientId"]
+    },
+    "X-Tyk-OAuth2-ActorHeader": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "description": "Request header carrying the actor token. Defaults to X-Actor-Token." },
+        "strip": { "type": "boolean", "description": "Remove the header from the proxied request. Defaults true." },
+        "required": { "type": "boolean", "description": "Reject requests missing the header. Defaults true." }
+      }
+    },
+    "X-Tyk-OAuth2-ActorStatic": {
+      "type": "object",
+      "properties": {
+        "token": { "type": "string", "description": "Pre-configured actor token (env://, secrets://, vault://, consul:// honoured). Testing only." }
+      },
+      "required": ["token"]
     },
     "X-Tyk-OAuth2-ClientAuth": {
       "type": "object",

--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -2146,6 +2146,11 @@
         "name": {
           "type": "string"
         },
+        "flow": {
+          "type": "string",
+          "enum": ["token-exchange", "on-behalf-of"],
+          "description": "Delegation flow this provider speaks. Defaults to token-exchange (the RFC 8693 grant). Set on-behalf-of for identity providers that implement the On-Behalf-Of flow (jwt-bearer grant) instead of RFC 8693 token exchange."
+        },
         "issuers": {
           "type": "array",
           "items": {

--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -2260,13 +2260,17 @@
           "type": "string",
           "enum": [
             "client_secret_basic",
-            "client_secret_post"
+            "client_secret_post",
+            "private_key_jwt"
           ]
         },
         "clientId": {
           "type": "string"
         },
         "clientSecret": {
+          "type": "string"
+        },
+        "certId": {
           "type": "string"
         }
       }

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -208,6 +208,12 @@ type OAuth2TokenExchangeProvider struct {
 	// when the matched operation has no per-op exchange override.
 	DefaultTarget *OAuth2DefaultTarget `bson:"defaultTarget,omitempty" json:"defaultTarget,omitempty"`
 
+	// ActorToken, when set, makes exchange requests carry `actor_token`
+	// (RFC 8693 delegation intent). When omitted, requests carry only
+	// `subject_token` (impersonation); removing the block reverts to
+	// impersonation with no migration.
+	ActorToken *OAuth2ActorToken `bson:"actorToken,omitempty" json:"actorToken,omitempty"`
+
 	// Timeout caps each call to TokenEndpoint. Uses Tyk's ReadableDuration ("5s", "100ms").
 	// Defaults to 15s when unset.
 	Timeout tyktime.ReadableDuration `bson:"timeout,omitempty" json:"timeout,omitempty"`
@@ -219,6 +225,64 @@ type OAuth2TokenExchangeProvider struct {
 
 	// Cache controls Redis-backed caching of exchanged tokens for this provider.
 	Cache *OAuth2ExchangeCache `bson:"cache,omitempty" json:"cache,omitempty"`
+}
+
+// OAuth2ActorToken describes how Tyk obtains the actor token sent on the
+// exchange request. Exactly one source sub-block is used, selected by Source.
+type OAuth2ActorToken struct {
+	// Source: client_credentials | header | static.
+	Source string `bson:"source" json:"source"`
+
+	// ActorTokenType is the RFC 8693 token-type URN advertised for the actor
+	// token. Empty defaults to urn:ietf:params:oauth:token-type:access_token,
+	// the interoperable choice (PingOne/PingAM reject :jwt on the actor token).
+	// Operators targeting an RFC-strict IdP may set :jwt. Not surfaced in the UI.
+	ActorTokenType string `bson:"actorTokenType,omitempty" json:"actorTokenType,omitempty"`
+
+	// ClientCredentials — used when Source=="client_credentials".
+	ClientCredentials *OAuth2ActorClientCredentials `bson:"clientCredentials,omitempty" json:"clientCredentials,omitempty"`
+
+	// Header — used when Source=="header".
+	Header *OAuth2ActorHeader `bson:"header,omitempty" json:"header,omitempty"`
+
+	// Static — used when Source=="static". Testing only.
+	Static *OAuth2ActorStatic `bson:"static,omitempty" json:"static,omitempty"`
+
+	// RequireMayAct, when true, makes the gateway verify the inbound subject
+	// token carries a `may_act` claim (RFC 8693 §4.4) authorizing the
+	// configured actor BEFORE calling the IdP — a clear 403 instead of an
+	// opaque IdP rejection. Defaults false: the IdP is the authoritative
+	// enforcement point, and multi-hop/central-policy tokens (e.g. PingFederate
+	// TEPP) may legitimately carry no `may_act`.
+	RequireMayAct *bool `bson:"requireMayAct,omitempty" json:"requireMayAct,omitempty"`
+}
+
+// OAuth2ActorClientCredentials drives the OAuth2 client_credentials flow Tyk
+// uses to mint a gateway-as-actor token. The acquired token is cached for its
+// own lifetime. ClientSecret accepts env://, secrets://, vault://, consul://.
+type OAuth2ActorClientCredentials struct {
+	TokenEndpoint string   `bson:"tokenEndpoint" json:"tokenEndpoint"`
+	ClientID      string   `bson:"clientId" json:"clientId"`
+	ClientSecret  string   `bson:"clientSecret,omitempty" json:"clientSecret,omitempty"`
+	Scopes        []string `bson:"scopes,omitempty" json:"scopes,omitempty"`
+}
+
+// OAuth2ActorHeader pulls the actor token from a request header presented by
+// the upstream caller. Strip defaults true (don't leak to backend); Required
+// defaults true (no silent fallback to impersonation).
+type OAuth2ActorHeader struct {
+	// Name is the request header name. Defaults to "X-Actor-Token".
+	Name string `bson:"name,omitempty" json:"name,omitempty"`
+	// Strip removes the header from the proxied request. Defaults true.
+	Strip *bool `bson:"strip,omitempty" json:"strip,omitempty"`
+	// Required rejects requests missing the header. Defaults true.
+	Required *bool `bson:"required,omitempty" json:"required,omitempty"`
+}
+
+// OAuth2ActorStatic carries a pre-configured static actor token. Testing only —
+// static tokens don't rotate. Token accepts env://, secrets://, vault://, consul://.
+type OAuth2ActorStatic struct {
+	Token string `bson:"token" json:"token"`
 }
 
 // OAuth2ExchangeCache controls caching of exchanged tokens per provider.
@@ -307,6 +371,7 @@ const (
 	OAuth2ErrExchangeFailed     = "exchange_failed"
 	OAuth2ErrNoMatchingProvider = "no_matching_provider"
 	OAuth2ErrMisconfigured      = "misconfigured"
+	OAuth2ErrActorNotAuthorized = "actor_not_authorized"
 
 	OAuth2AuthSchemeBearer = "Bearer" // RFC 6750 §2.1
 
@@ -326,9 +391,10 @@ const (
 	OAuth2FormClientAssertionType = "client_assertion_type"
 
 	// RFC 8693 URNs.
-	OAuth2GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
-	OAuth2TokenTypeAccessToken   = "urn:ietf:params:oauth:token-type:access_token"
-	OAuth2TokenTypeJWT           = "urn:ietf:params:oauth:token-type:jwt"
+	OAuth2GrantTypeTokenExchange     = "urn:ietf:params:oauth:grant-type:token-exchange"
+	OAuth2GrantTypeClientCredentials = "client_credentials"
+	OAuth2TokenTypeAccessToken       = "urn:ietf:params:oauth:token-type:access_token"
+	OAuth2TokenTypeJWT               = "urn:ietf:params:oauth:token-type:jwt"
 
 	// OAuth2ClientAuth.Method values.
 	OAuth2ClientAuthBasic = "client_secret_basic"
@@ -338,11 +404,22 @@ const (
 	OAuth2CacheModeDerived = "derived"
 	OAuth2CacheModeStatic  = "static"
 
+	// OAuth2ActorToken.Source values, plus the synthesized actor identifier
+	// used for the impersonation (no-delegation) case.
+	OAuth2ActorSourceClientCredentials = "client_credentials"
+	OAuth2ActorSourceHeader            = "header"
+	OAuth2ActorSourceStatic            = "static"
+	OAuth2ActorImpersonation           = "impersonation"
+
 	// JWT standard claim keys.
 	OAuth2ClaimIss = "iss"
 	OAuth2ClaimSub = "sub"
 	OAuth2ClaimExp = "exp"
 	OAuth2ClaimAzp = "azp"
+	// OAuth2ClaimMayAct is the RFC 8693 §4.4 may_act claim; OAuth2ClaimClientID
+	// is the alternate identity member the gateway accepts inside it.
+	OAuth2ClaimMayAct   = "may_act"
+	OAuth2ClaimClientID = "client_id"
 
 	// OAuth2 response / WWW-Authenticate field names.
 	OAuth2FieldError            = "error"
@@ -451,7 +528,10 @@ func validateOAuth2ExchangeProvider(schemeName string, i int, p *OAuth2TokenExch
 	if err := validateExchangeCustomParams(schemeName, p); err != nil {
 		return err
 	}
-	return validateExchangeCacheMode(schemeName, p)
+	if err := validateExchangeCacheMode(schemeName, p); err != nil {
+		return err
+	}
+	return validateOAuth2ActorToken(schemeName, p.Name, p.ActorToken)
 }
 
 // validateExchangeTokenEndpoint requires a non-empty, absolute http(s)
@@ -491,6 +571,37 @@ func validateExchangeCustomParams(schemeName string, p *OAuth2TokenExchangeProvi
 		if _, reserved := oauth2ReservedExchangeFormKeys[key]; reserved {
 			return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q customParams cannot override reserved RFC 8693 wire key %q", schemeName, p.Name, key)
 		}
+	}
+	return nil
+}
+
+// validateOAuth2ActorToken enforces that the actorToken block names a valid
+// source, carries the sub-block that source requires, and advertises an
+// allowed actor_token_type URN. A no-op when no actor token is configured
+// (impersonation).
+func validateOAuth2ActorToken(schemeName, providerName string, at *OAuth2ActorToken) error {
+	if at == nil {
+		return nil
+	}
+	if at.ActorTokenType != "" &&
+		at.ActorTokenType != OAuth2TokenTypeAccessToken && at.ActorTokenType != OAuth2TokenTypeJWT {
+		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q actorToken.actorTokenType %q is invalid; valid values are %q and %q",
+			schemeName, providerName, at.ActorTokenType, OAuth2TokenTypeAccessToken, OAuth2TokenTypeJWT)
+	}
+	switch at.Source {
+	case OAuth2ActorSourceClientCredentials:
+		if at.ClientCredentials == nil || at.ClientCredentials.TokenEndpoint == "" || at.ClientCredentials.ClientID == "" {
+			return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q actorToken.source=client_credentials requires clientCredentials.tokenEndpoint and clientId", schemeName, providerName)
+		}
+	case OAuth2ActorSourceStatic:
+		if at.Static == nil || at.Static.Token == "" {
+			return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q actorToken.source=static requires static.token", schemeName, providerName)
+		}
+	case OAuth2ActorSourceHeader:
+		// header sub-block is optional; defaults apply (X-Actor-Token, strip+required true).
+	default:
+		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q actorToken.source %q is invalid; valid values are %q, %q, %q",
+			schemeName, providerName, at.Source, OAuth2ActorSourceClientCredentials, OAuth2ActorSourceHeader, OAuth2ActorSourceStatic)
 	}
 	return nil
 }

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -342,6 +342,7 @@ const (
 	OAuth2ClaimIss = "iss"
 	OAuth2ClaimSub = "sub"
 	OAuth2ClaimExp = "exp"
+	OAuth2ClaimAzp = "azp"
 
 	// OAuth2 response / WWW-Authenticate field names.
 	OAuth2FieldError            = "error"

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -351,12 +351,19 @@ type OAuth2ClientAuth struct {
 	//     HTTP Authorization header.
 	//   - "client_secret_post" (RFC 6749 §2.3.1) — credentials in the
 	//     form body.
+	//   - "private_key_jwt" (OIDC Core §9) — a signed client-assertion JWT
+	//     authenticated by a certificate referenced via CertID; no shared
+	//     secret. Required for Microsoft Entra certificate login.
 	// Empty string defaults to client_secret_basic.
 	Method string `bson:"method,omitempty" json:"method,omitempty"`
 	// ClientID is the OAuth2 client identifier Tyk presents to the IdP token endpoint.
 	ClientID string `bson:"clientId,omitempty" json:"clientId,omitempty"`
 	// ClientSecret accepts env://, secrets://, vault://, consul:// prefixes.
 	ClientSecret string `bson:"clientSecret,omitempty" json:"clientSecret,omitempty"`
+	// CertID references a certificate (with private key) in the gateway
+	// certificate store used to sign the private_key_jwt client assertion.
+	// Required when Method is private_key_jwt; ignored otherwise.
+	CertID string `bson:"certId,omitempty" json:"certId,omitempty"`
 }
 
 // OAuth2DefaultTarget is the fallback audience and scopes when no per-op override is set.
@@ -456,8 +463,12 @@ const (
 	OAuth2RequestedTokenUseOBO  = "on_behalf_of"
 
 	// OAuth2ClientAuth.Method values.
-	OAuth2ClientAuthBasic = "client_secret_basic"
-	OAuth2ClientAuthPost  = "client_secret_post"
+	OAuth2ClientAuthBasic         = "client_secret_basic"
+	OAuth2ClientAuthPost          = "client_secret_post"
+	OAuth2ClientAuthPrivateKeyJWT = "private_key_jwt"
+
+	// client_assertion_type value for the private_key_jwt method (RFC 7523 §2.2).
+	OAuth2ClientAssertionTypeJWTBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
 	// OAuth2ExchangeCache.Mode values.
 	OAuth2CacheModeDerived = "derived"
@@ -586,6 +597,9 @@ func validateOAuth2ExchangeProvider(schemeName string, i int, p *OAuth2TokenExch
 	if p.ClientAuth == nil || p.ClientAuth.ClientID == "" {
 		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q has empty clientAuth.clientId", schemeName, p.Name)
 	}
+	if err := validateExchangeClientAuth(schemeName, p); err != nil {
+		return err
+	}
 	if err := validateExchangeIssuers(schemeName, p, issuerOwner); err != nil {
 		return err
 	}
@@ -676,6 +690,26 @@ func validateExchangeTokenEndpoint(schemeName string, p *OAuth2TokenExchangeProv
 		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q tokenEndpoint must be an absolute http(s) URL", schemeName, p.Name)
 	}
 	return nil
+}
+
+// validateExchangeClientAuth validates the client-authentication method.
+// Secret methods (basic/post, and the empty default) are accepted as-is;
+// private_key_jwt additionally requires a certId to sign the client assertion;
+// any other method is rejected at config load rather than at the first call.
+func validateExchangeClientAuth(schemeName string, p *OAuth2TokenExchangeProvider) error {
+	switch p.ClientAuth.Method {
+	case "", OAuth2ClientAuthBasic, OAuth2ClientAuthPost:
+		return nil
+	case OAuth2ClientAuthPrivateKeyJWT:
+		if p.ClientAuth.CertID == "" {
+			return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q clientAuth.method %q requires a certId to sign the client assertion",
+				schemeName, p.Name, OAuth2ClientAuthPrivateKeyJWT)
+		}
+		return nil
+	default:
+		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q clientAuth.method %q is invalid; valid values are %q, %q and %q",
+			schemeName, p.Name, p.ClientAuth.Method, OAuth2ClientAuthBasic, OAuth2ClientAuthPost, OAuth2ClientAuthPrivateKeyJWT)
+	}
 }
 
 // validateExchangeIssuers rejects an issuer claimed by more than one provider

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -191,6 +192,13 @@ type OAuth2TokenExchangeProvider struct {
 	// Name is an operator-chosen identifier used in audit logs. Unique within Providers.
 	Name string `bson:"name" json:"name"`
 
+	// Flow selects the delegation flow this provider speaks. Empty or
+	// "token-exchange" (default) uses the RFC 8693 token-exchange grant;
+	// "on-behalf-of" uses the On-Behalf-Of flow (jwt-bearer grant, single token,
+	// target named by scope) implemented by some identity providers. The default
+	// keeps existing providers unchanged.
+	Flow string `bson:"flow,omitempty" json:"flow,omitempty"`
+
 	// Issuers is the set of inbound token `iss` values routed to this provider.
 	// Must not overlap with issuers on other providers — dispatch would be non-deterministic.
 	Issuers []string `bson:"issuers,omitempty" json:"issuers,omitempty"`
@@ -225,6 +233,40 @@ type OAuth2TokenExchangeProvider struct {
 
 	// Cache controls Redis-backed caching of exchanged tokens for this provider.
 	Cache *OAuth2ExchangeCache `bson:"cache,omitempty" json:"cache,omitempty"`
+}
+
+// IsOnBehalfOf reports whether this provider uses the On-Behalf-Of flow.
+// Empty flow defaults to RFC 8693 token-exchange.
+func (p *OAuth2TokenExchangeProvider) IsOnBehalfOf() bool {
+	return p != nil && p.Flow == OAuth2FlowOnBehalfOf
+}
+
+// EntraScopeList translates an RFC 8693-style target (audience + scopes) into
+// the Entra On-Behalf-Of `scope` list. Each discrete scope is prefixed with the
+// audience resource; a scope that already carries a resource (contains "/") is
+// taken verbatim — the explicit-scope escape hatch; an audience with no scopes
+// becomes "<audience>/.default" (all statically-consented permissions).
+func EntraScopeList(audience string, scopes []string) []string {
+	out := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		switch {
+		case strings.Contains(s, "/"):
+			out = append(out, s)
+		case audience != "":
+			out = append(out, audience+"/"+s)
+		default:
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 && audience != "" {
+		out = append(out, audience+"/.default")
+	}
+	return out
+}
+
+// EntraScopeString space-joins EntraScopeList into the Entra `scope` value.
+func EntraScopeString(audience string, scopes []string) string {
+	return strings.Join(EntraScopeList(audience, scopes), " ")
 }
 
 // OAuth2ActorToken describes how Tyk obtains the actor token sent on the
@@ -373,6 +415,12 @@ const (
 	OAuth2ErrMisconfigured      = "misconfigured"
 	OAuth2ErrActorNotAuthorized = "actor_not_authorized"
 
+	// Entra On-Behalf-Of step-up (Conditional Access claims challenge).
+	OAuth2ErrInteractionRequired = "interaction_required" // Entra back-channel error
+	OAuth2ErrInsufficientClaims  = "insufficient_claims"  // re-emitted front-channel challenge
+	OAuth2FieldClaims            = "claims"
+	OAuth2FieldAuthorizationURI  = "authorization_uri"
+
 	OAuth2AuthSchemeBearer = "Bearer" // RFC 6750 §2.1
 
 	// RFC 8693 form keys.
@@ -395,6 +443,17 @@ const (
 	OAuth2GrantTypeClientCredentials = "client_credentials"
 	OAuth2TokenTypeAccessToken       = "urn:ietf:params:oauth:token-type:access_token"
 	OAuth2TokenTypeJWT               = "urn:ietf:params:oauth:token-type:jwt"
+
+	// OAuth2TokenExchangeProvider.Flow values.
+	OAuth2FlowTokenExchange = "token-exchange"
+	OAuth2FlowOnBehalfOf    = "on-behalf-of"
+
+	// Entra On-Behalf-Of wire constants (RFC 7523 jwt-bearer grant + the
+	// Microsoft-specific requested_token_use flag).
+	OAuth2FormAssertion         = "assertion"
+	OAuth2FormRequestedTokenUse = "requested_token_use"
+	OAuth2GrantTypeJWTBearer    = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	OAuth2RequestedTokenUseOBO  = "on_behalf_of"
 
 	// OAuth2ClientAuth.Method values.
 	OAuth2ClientAuthBasic = "client_secret_basic"
@@ -447,6 +506,8 @@ var oauth2ReservedExchangeFormKeys = map[string]struct{}{
 	OAuth2FormClientSecret:        {},
 	OAuth2FormClientAssertion:     {},
 	OAuth2FormClientAssertionType: {},
+	OAuth2FormAssertion:           {},
+	OAuth2FormRequestedTokenUse:   {},
 }
 
 // ValidateOAuth2Schemes enforces token-exchange invariants across all configured
@@ -516,6 +577,9 @@ func validateOAuth2ExchangeProvider(schemeName string, i int, p *OAuth2TokenExch
 		return fmt.Errorf("oauth2 scheme %q: duplicate tokenExchange.provider name %q", schemeName, p.Name)
 	}
 	seenNames[p.Name] = struct{}{}
+	if err := validateExchangeFlow(schemeName, p); err != nil {
+		return err
+	}
 	if err := validateExchangeTokenEndpoint(schemeName, p); err != nil {
 		return err
 	}
@@ -531,7 +595,72 @@ func validateOAuth2ExchangeProvider(schemeName string, i int, p *OAuth2TokenExch
 	if err := validateExchangeCacheMode(schemeName, p); err != nil {
 		return err
 	}
+	if p.IsOnBehalfOf() {
+		return validateOnBehalfOfProvider(schemeName, p)
+	}
 	return validateOAuth2ActorToken(schemeName, p.Name, p.ActorToken)
+}
+
+// validateOnBehalfOfProvider enforces the On-Behalf-Of invariants: no actor
+// token (single-token delegation) and a resolvable, single-resource target.
+func validateOnBehalfOfProvider(schemeName string, p *OAuth2TokenExchangeProvider) error {
+	if p.ActorToken != nil {
+		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q actorToken is not valid when flow is %q; the On-Behalf-Of flow is single-token delegation",
+			schemeName, p.Name, OAuth2FlowOnBehalfOf)
+	}
+	return validateOnBehalfOfTarget(schemeName, p.Name, p.DefaultTarget)
+}
+
+// validateOnBehalfOfTarget enforces the Entra scope rules on the provider's default
+// target: a target must name a scope/resource, every scope must be
+// resource-qualified, all scopes must share one resource, and ".default" must not
+// mix with discrete scopes (Entra AADSTS70011). A nil target is allowed — a
+// per-operation / per-primitive override may supply it.
+func validateOnBehalfOfTarget(schemeName, providerName string, dt *OAuth2DefaultTarget) error {
+	if dt == nil {
+		return nil
+	}
+	scopes := EntraScopeList(dt.Audience, dt.Scopes)
+	if len(scopes) == 0 {
+		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q flow %q requires a defaultTarget audience or scope",
+			schemeName, providerName, OAuth2FlowOnBehalfOf)
+	}
+	resources := make(map[string]struct{}, len(scopes))
+	var hasDefault, hasDiscrete bool
+	for _, s := range scopes {
+		idx := strings.LastIndex(s, "/")
+		if idx <= 0 {
+			return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q flow %q scope %q must be resource-qualified (set defaultTarget.audience, or use a fully-qualified scope like api://x/Scope or <resource>/.default)",
+				schemeName, providerName, OAuth2FlowOnBehalfOf, s)
+		}
+		resources[s[:idx]] = struct{}{}
+		if s[idx+1:] == ".default" {
+			hasDefault = true
+		} else {
+			hasDiscrete = true
+		}
+	}
+	if hasDefault && hasDiscrete {
+		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q flow %q cannot combine .default with discrete scopes in one target",
+			schemeName, providerName, OAuth2FlowOnBehalfOf)
+	}
+	if len(resources) > 1 {
+		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q flow %q target spans multiple resources; one On-Behalf-Of exchange targets a single resource",
+			schemeName, providerName, OAuth2FlowOnBehalfOf)
+	}
+	return nil
+}
+
+// validateExchangeFlow rejects an unknown provider flow. Empty is valid and
+// resolves to token-exchange.
+func validateExchangeFlow(schemeName string, p *OAuth2TokenExchangeProvider) error {
+	switch p.Flow {
+	case "", OAuth2FlowTokenExchange, OAuth2FlowOnBehalfOf:
+		return nil
+	default:
+		return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q flow %q is invalid; valid values are %q and %q",
+			schemeName, p.Name, p.Flow, OAuth2FlowTokenExchange, OAuth2FlowOnBehalfOf)
+	}
 }
 
 // validateExchangeTokenEndpoint requires a non-empty, absolute http(s)

--- a/apidef/oas/oauth2_actor_token_test.go
+++ b/apidef/oas/oauth2_actor_token_test.go
@@ -1,0 +1,145 @@
+package oas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuth2ActorToken_RoundTripPreservesAllFields(t *testing.T) {
+	strip, required, mayAct := false, false, true
+	te := &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{
+				Name:          "primary",
+				Issuers:       []string{"https://idp.example.com"},
+				TokenEndpoint: "https://idp.example.com/oauth/token",
+				ClientAuth:    &OAuth2ClientAuth{ClientID: "tyk-gateway"},
+				ActorToken: &OAuth2ActorToken{
+					Source:         OAuth2ActorSourceClientCredentials,
+					ActorTokenType: OAuth2TokenTypeJWT,
+					RequireMayAct:  &mayAct,
+					ClientCredentials: &OAuth2ActorClientCredentials{
+						TokenEndpoint: "https://idp.example.com/oauth/token",
+						ClientID:      "tyk-gateway-actor",
+						ClientSecret:  "vault://kv/tyk/actor",
+						Scopes:        []string{"agent"},
+					},
+					Header: &OAuth2ActorHeader{Name: "X-Delegate", Strip: &strip, Required: &required},
+					Static: &OAuth2ActorStatic{Token: "env://ACTOR_TOKEN"},
+				},
+			},
+		},
+	}
+
+	b, err := json.Marshal(te)
+	require.NoError(t, err)
+
+	var out OAuth2TokenExchange
+	require.NoError(t, json.Unmarshal(b, &out))
+
+	require.Len(t, out.Providers, 1)
+	at := out.Providers[0].ActorToken
+	require.NotNil(t, at)
+	assert.Equal(t, OAuth2ActorSourceClientCredentials, at.Source)
+	assert.Equal(t, OAuth2TokenTypeJWT, at.ActorTokenType)
+	require.NotNil(t, at.RequireMayAct)
+	assert.True(t, *at.RequireMayAct)
+	require.NotNil(t, at.ClientCredentials)
+	assert.Equal(t, "tyk-gateway-actor", at.ClientCredentials.ClientID)
+	assert.Equal(t, "vault://kv/tyk/actor", at.ClientCredentials.ClientSecret)
+	assert.Equal(t, []string{"agent"}, at.ClientCredentials.Scopes)
+	require.NotNil(t, at.Header)
+	assert.Equal(t, "X-Delegate", at.Header.Name)
+	require.NotNil(t, at.Header.Strip)
+	assert.False(t, *at.Header.Strip)
+	require.NotNil(t, at.Static)
+	assert.Equal(t, "env://ACTOR_TOKEN", at.Static.Token)
+}
+
+func TestOAuth2ActorToken_OmittedWhenAbsent(t *testing.T) {
+	b, err := json.Marshal(OAuth2TokenExchangeProvider{Name: "p"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "actorToken")
+}
+
+func teProviderWithActor(at *OAuth2ActorToken) *OAuth2TokenExchange {
+	return &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{Name: "p", Issuers: []string{"https://a"}, TokenEndpoint: "https://a/token", ClientAuth: &OAuth2ClientAuth{ClientID: "ca"}, ActorToken: at},
+		},
+	}
+}
+
+func TestValidateOAuth2Schemes_ActorToken_InvalidSource(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", teProviderWithActor(&OAuth2ActorToken{Source: "bogus"}))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `actorToken.source "bogus" is invalid`)
+}
+
+func TestValidateOAuth2Schemes_ActorToken_CCRequiresSubBlock(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", teProviderWithActor(&OAuth2ActorToken{Source: OAuth2ActorSourceClientCredentials}))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires clientCredentials.tokenEndpoint and clientId")
+}
+
+func TestValidateOAuth2Schemes_ActorToken_StaticRequiresToken(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", teProviderWithActor(&OAuth2ActorToken{Source: OAuth2ActorSourceStatic, Static: &OAuth2ActorStatic{}}))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires static.token")
+}
+
+func TestValidateOAuth2Schemes_ActorToken_Happy(t *testing.T) {
+	cc := newOAuth2WithTokenExchange("corpOAuth", teProviderWithActor(&OAuth2ActorToken{
+		Source:            OAuth2ActorSourceClientCredentials,
+		ClientCredentials: &OAuth2ActorClientCredentials{TokenEndpoint: "https://idp/token", ClientID: "tyk-gateway-actor"},
+	}))
+	assert.NoError(t, cc.ValidateOAuth2Schemes())
+
+	hdr := newOAuth2WithTokenExchange("corpOAuth", teProviderWithActor(&OAuth2ActorToken{Source: OAuth2ActorSourceHeader}))
+	assert.NoError(t, hdr.ValidateOAuth2Schemes(), "header sub-block is optional; defaults apply")
+
+	stat := newOAuth2WithTokenExchange("corpOAuth", teProviderWithActor(&OAuth2ActorToken{Source: OAuth2ActorSourceStatic, Static: &OAuth2ActorStatic{Token: "t"}}))
+	assert.NoError(t, stat.ValidateOAuth2Schemes())
+}
+
+func TestValidateOAuth2Schemes_ActorTokenType(t *testing.T) {
+	base := func(tokenType string) *OAuth2ActorToken {
+		return &OAuth2ActorToken{
+			Source:            OAuth2ActorSourceClientCredentials,
+			ActorTokenType:    tokenType,
+			ClientCredentials: &OAuth2ActorClientCredentials{TokenEndpoint: "https://idp/token", ClientID: "actor"},
+		}
+	}
+
+	t.Run("empty defaults to access_token and is accepted", func(t *testing.T) {
+		s := newOAuth2WithTokenExchange("x", teProviderWithActor(base("")))
+		assert.NoError(t, s.ValidateOAuth2Schemes())
+	})
+
+	t.Run("explicit access_token accepted", func(t *testing.T) {
+		s := newOAuth2WithTokenExchange("x", teProviderWithActor(base(OAuth2TokenTypeAccessToken)))
+		assert.NoError(t, s.ValidateOAuth2Schemes())
+	})
+
+	t.Run("jwt override accepted", func(t *testing.T) {
+		s := newOAuth2WithTokenExchange("x", teProviderWithActor(base(OAuth2TokenTypeJWT)))
+		assert.NoError(t, s.ValidateOAuth2Schemes())
+	})
+
+	t.Run("unknown URN rejected naming the allowed values", func(t *testing.T) {
+		s := newOAuth2WithTokenExchange("x", teProviderWithActor(base("urn:bogus")))
+		err := s.ValidateOAuth2Schemes()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "actorToken.actorTokenType")
+		assert.Contains(t, err.Error(), OAuth2TokenTypeAccessToken)
+		assert.Contains(t, err.Error(), OAuth2TokenTypeJWT)
+	})
+}

--- a/apidef/oas/oauth2_clientauth_test.go
+++ b/apidef/oas/oauth2_clientauth_test.go
@@ -1,0 +1,73 @@
+package oas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOAuth2ClientAuth_PrivateKeyJWT_RoundTrip pins that the private_key_jwt
+// method and its certId survive a JSON round-trip, and that certId is omitted
+// when empty (so secret-auth providers serialise unchanged).
+func TestOAuth2ClientAuth_PrivateKeyJWT_RoundTrip(t *testing.T) {
+	ca := OAuth2ClientAuth{Method: OAuth2ClientAuthPrivateKeyJWT, ClientID: "app", CertID: "cert-1"}
+	b, err := json.Marshal(ca)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"method":"private_key_jwt"`)
+	assert.Contains(t, string(b), `"certId":"cert-1"`)
+
+	var out OAuth2ClientAuth
+	require.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, ca, out)
+
+	secret, err := json.Marshal(OAuth2ClientAuth{Method: OAuth2ClientAuthBasic, ClientID: "app", ClientSecret: "s"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(secret), "certId")
+}
+
+// clientAuth builds a token-exchange scheme whose provider carries the given
+// clientAuth, reusing the Entra-OBO test target so the provider is otherwise valid.
+func clientAuth(ca *OAuth2ClientAuth) *OAuth2TokenExchange {
+	return entra(func(p *OAuth2TokenExchangeProvider) { p.ClientAuth = ca })
+}
+
+// TestValidateOAuth2Schemes_ClientAuth_PrivateKeyJWT_Happy pins that a
+// private_key_jwt provider with a certId validates clean (no shared secret).
+func TestValidateOAuth2Schemes_ClientAuth_PrivateKeyJWT_Happy(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", clientAuth(
+		&OAuth2ClientAuth{Method: OAuth2ClientAuthPrivateKeyJWT, ClientID: "app", CertID: "cert-1"}))
+	assert.NoError(t, s.ValidateOAuth2Schemes())
+}
+
+// TestValidateOAuth2Schemes_ClientAuth_PrivateKeyJWT_RequiresCertID pins that
+// private_key_jwt without a certId fails loud at config load.
+func TestValidateOAuth2Schemes_ClientAuth_PrivateKeyJWT_RequiresCertID(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", clientAuth(
+		&OAuth2ClientAuth{Method: OAuth2ClientAuthPrivateKeyJWT, ClientID: "app"}))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certId")
+	assert.Contains(t, err.Error(), OAuth2ClientAuthPrivateKeyJWT)
+}
+
+// TestValidateOAuth2Schemes_ClientAuth_UnknownMethod pins that an unsupported
+// clientAuth method is rejected at load, not deferred to a runtime call failure.
+func TestValidateOAuth2Schemes_ClientAuth_UnknownMethod(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", clientAuth(
+		&OAuth2ClientAuth{Method: "mutual_tls", ClientID: "app"}))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutual_tls")
+}
+
+// TestValidateOAuth2Schemes_ClientAuth_SecretMethods pins that the secret
+// methods (and the empty default) are unaffected — certId is not required.
+func TestValidateOAuth2Schemes_ClientAuth_SecretMethods(t *testing.T) {
+	for _, m := range []string{"", OAuth2ClientAuthBasic, OAuth2ClientAuthPost} {
+		s := newOAuth2WithTokenExchange("corpOAuth", clientAuth(
+			&OAuth2ClientAuth{Method: m, ClientID: "app", ClientSecret: "s"}))
+		assert.NoError(t, s.ValidateOAuth2Schemes(), "method %q should validate", m)
+	}
+}

--- a/apidef/oas/oauth2_entra_obo_test.go
+++ b/apidef/oas/oauth2_entra_obo_test.go
@@ -1,0 +1,163 @@
+package oas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// teProvider builds a minimal valid provider, overlaid by the mutator.
+func teProvider(mut func(*OAuth2TokenExchangeProvider)) *OAuth2TokenExchange {
+	p := OAuth2TokenExchangeProvider{
+		Name:          "p",
+		Issuers:       []string{"https://login.microsoftonline.com/tid/v2.0"},
+		TokenEndpoint: "https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+		ClientAuth:    &OAuth2ClientAuth{Method: OAuth2ClientAuthPost, ClientID: "app", ClientSecret: "s"},
+		DefaultTarget: &OAuth2DefaultTarget{Audience: "api://orders", Scopes: []string{"Orders.Read"}},
+	}
+	if mut != nil {
+		mut(&p)
+	}
+	return &OAuth2TokenExchange{Enabled: true, Providers: []OAuth2TokenExchangeProvider{p}}
+}
+
+// TestOAuth2Provider_Flow_RoundTrip pins that the flow discriminator survives
+// a JSON round-trip and is omitted when absent (so existing RFC 8693 providers
+// serialise unchanged).
+func TestOAuth2Provider_Flow_RoundTrip(t *testing.T) {
+	withFlow := teProvider(func(p *OAuth2TokenExchangeProvider) { p.Flow = OAuth2FlowOnBehalfOf })
+	b, err := json.Marshal(withFlow)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"flow":"on-behalf-of"`)
+
+	var out OAuth2TokenExchange
+	require.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, OAuth2FlowOnBehalfOf, out.Providers[0].Flow)
+
+	noFlow, err := json.Marshal(OAuth2TokenExchangeProvider{Name: "p"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(noFlow), "flow")
+}
+
+// TestOAuth2Provider_IsOnBehalfOf pins the discriminator helper: only the explicit
+// on-behalf-of value is Entra; empty (default) and token-exchange are not.
+func TestOAuth2Provider_IsOnBehalfOf(t *testing.T) {
+	assert.False(t, (&OAuth2TokenExchangeProvider{}).IsOnBehalfOf(), "empty flow defaults to token-exchange")
+	assert.False(t, (&OAuth2TokenExchangeProvider{Flow: OAuth2FlowTokenExchange}).IsOnBehalfOf())
+	assert.True(t, (&OAuth2TokenExchangeProvider{Flow: OAuth2FlowOnBehalfOf}).IsOnBehalfOf())
+}
+
+// TestEntraScopeString pins the audience+scopes → Entra `scope` translation:
+// discrete scopes are resource-prefixed, an audience with no scopes becomes
+// "<audience>/.default", and an already-qualified scope is taken verbatim
+// (the explicit-scope escape hatch).
+func TestEntraScopeString(t *testing.T) {
+	tests := []struct {
+		name     string
+		audience string
+		scopes   []string
+		want     string
+	}{
+		{"audience plus discrete scopes are resource-prefixed", "api://orders", []string{"Orders.Read", "Orders.Write"}, "api://orders/Orders.Read api://orders/Orders.Write"},
+		{"audience alone becomes .default", "api://orders", nil, "api://orders/.default"},
+		{"already-qualified scope is verbatim (escape hatch)", "api://orders", []string{"https://graph.microsoft.com/User.Read"}, "https://graph.microsoft.com/User.Read"},
+		{"explicit .default scope passes through", "api://orders", []string{"api://orders/.default"}, "api://orders/.default"},
+		{"no audience, no scopes yields empty", "", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, EntraScopeString(tt.audience, tt.scopes))
+		})
+	}
+}
+
+// TestValidateOAuth2Schemes_Flow pins that the flow enum is validated at
+// API-load: empty and the two known values pass, anything else is rejected.
+func TestValidateOAuth2Schemes_Flow(t *testing.T) {
+	for _, f := range []string{"", OAuth2FlowTokenExchange, OAuth2FlowOnBehalfOf} {
+		s := newOAuth2WithTokenExchange("corpOAuth", teProvider(func(p *OAuth2TokenExchangeProvider) { p.Flow = f }))
+		assert.NoError(t, s.ValidateOAuth2Schemes(), "flow %q should be accepted", f)
+	}
+
+	s := newOAuth2WithTokenExchange("corpOAuth", teProvider(func(p *OAuth2TokenExchangeProvider) { p.Flow = "saml-bearer" }))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "flow")
+	assert.Contains(t, err.Error(), OAuth2FlowOnBehalfOf)
+}
+
+func entra(mut func(*OAuth2TokenExchangeProvider)) *OAuth2TokenExchange {
+	return teProvider(func(p *OAuth2TokenExchangeProvider) {
+		p.Flow = OAuth2FlowOnBehalfOf
+		if mut != nil {
+			mut(p)
+		}
+	})
+}
+
+// TestValidateOAuth2Schemes_EntraOBO_Happy pins that a well-formed Entra OBO
+// provider (secret login, single-resource default target) validates clean.
+func TestValidateOAuth2Schemes_EntraOBO_Happy(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", entra(nil))
+	assert.NoError(t, s.ValidateOAuth2Schemes())
+}
+
+// TestValidateOAuth2Schemes_EntraOBO_RejectsActorToken pins that an actorToken
+// block is rejected under on-behalf-of — OBO is single-token delegation.
+func TestValidateOAuth2Schemes_EntraOBO_RejectsActorToken(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", entra(func(p *OAuth2TokenExchangeProvider) {
+		p.ActorToken = &OAuth2ActorToken{Source: OAuth2ActorSourceHeader}
+	}))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "actorToken is not valid")
+	assert.Contains(t, err.Error(), OAuth2FlowOnBehalfOf)
+}
+
+// TestValidateOAuth2Schemes_EntraOBO_RequiresTarget pins that an empty default
+// target (no audience, no scopes) is rejected — Entra cannot infer the target.
+func TestValidateOAuth2Schemes_EntraOBO_RequiresTarget(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", entra(func(p *OAuth2TokenExchangeProvider) {
+		p.DefaultTarget = &OAuth2DefaultTarget{}
+	}))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audience")
+}
+
+// TestValidateOAuth2Schemes_EntraOBO_RejectsDefaultMixing pins the .default
+// mixing rule (Entra AADSTS70011): .default cannot ride with discrete scopes.
+func TestValidateOAuth2Schemes_EntraOBO_RejectsDefaultMixing(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", entra(func(p *OAuth2TokenExchangeProvider) {
+		p.DefaultTarget = &OAuth2DefaultTarget{Audience: "api://orders", Scopes: []string{"Orders.Read", ".default"}}
+	}))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".default")
+}
+
+// TestValidateOAuth2Schemes_EntraOBO_RejectsMultiResource pins the single-resource
+// rule: one OBO exchange targets one resource.
+func TestValidateOAuth2Schemes_EntraOBO_RejectsMultiResource(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", entra(func(p *OAuth2TokenExchangeProvider) {
+		p.DefaultTarget = &OAuth2DefaultTarget{Scopes: []string{"api://orders/Read", "api://billing/Read"}}
+	}))
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single resource")
+}
+
+// TestValidateOAuth2Schemes_EntraOBO_ReservedParams pins that the OBO-owned wire
+// keys (assertion, requested_token_use) cannot be set via customParams.
+func TestValidateOAuth2Schemes_EntraOBO_ReservedParams(t *testing.T) {
+	for _, key := range []string{OAuth2FormAssertion, OAuth2FormRequestedTokenUse} {
+		s := newOAuth2WithTokenExchange("corpOAuth", entra(func(p *OAuth2TokenExchangeProvider) {
+			p.CustomParams = map[string]string{key: "x"}
+		}))
+		err := s.ValidateOAuth2Schemes()
+		require.Error(t, err, "customParams key %q must be reserved", key)
+		assert.Contains(t, err.Error(), key)
+	}
+}

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -2073,6 +2073,11 @@
         "name": {
           "type": "string"
         },
+        "flow": {
+          "type": "string",
+          "enum": ["token-exchange", "on-behalf-of"],
+          "description": "Delegation flow this provider speaks. Defaults to token-exchange (the RFC 8693 grant). Set on-behalf-of for identity providers that implement the On-Behalf-Of flow (jwt-bearer grant) instead of RFC 8693 token exchange."
+        },
         "issuers": {
           "type": "array",
           "items": {

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -2187,13 +2187,17 @@
           "type": "string",
           "enum": [
             "client_secret_basic",
-            "client_secret_post"
+            "client_secret_post",
+            "private_key_jwt"
           ]
         },
         "clientId": {
           "type": "string"
         },
         "clientSecret": {
+          "type": "string"
+        },
+        "certId": {
           "type": "string"
         }
       }

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -2088,6 +2088,9 @@
         "defaultTarget": {
           "$ref": "#/definitions/X-Tyk-OAuth2-DefaultTarget"
         },
+        "actorToken": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorToken"
+        },
         "timeout": {
           "type": "string",
           "description": "Per-call timeout for the RFC 8693 exchange request, Tyk ReadableDuration (e.g. \"100ms\", \"5s\"). Defaults to 15s when zero/unset."
@@ -2117,6 +2120,60 @@
         "safetyMargin": { "type": "string", "description": "Shaved from the computed TTL to avoid serving near-expired tokens. Defaults to 30s." }
       },
       "required": ["enabled"]
+    },
+    "X-Tyk-OAuth2-ActorToken": {
+      "type": "object",
+      "description": "RFC 8693 actor token (delegation). When set, exchange requests carry actor_token; omit to use impersonation.",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": ["client_credentials", "header", "static"]
+        },
+        "actorTokenType": {
+          "type": "string",
+          "enum": ["urn:ietf:params:oauth:token-type:access_token", "urn:ietf:params:oauth:token-type:jwt"],
+          "description": "RFC 8693 token-type URN advertised for the actor token. Defaults to ...:access_token; set ...:jwt only for an RFC-strict IdP."
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorClientCredentials"
+        },
+        "header": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorHeader"
+        },
+        "static": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorStatic"
+        },
+        "requireMayAct": {
+          "type": "boolean",
+          "description": "When true, the gateway verifies the subject token's may_act (RFC 8693 §4.4) authorizes the configured actor before calling the IdP. Defaults false."
+        }
+      },
+      "required": ["source"]
+    },
+    "X-Tyk-OAuth2-ActorClientCredentials": {
+      "type": "object",
+      "properties": {
+        "tokenEndpoint": { "type": "string" },
+        "clientId": { "type": "string" },
+        "clientSecret": { "type": "string" },
+        "scopes": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["tokenEndpoint", "clientId"]
+    },
+    "X-Tyk-OAuth2-ActorHeader": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "description": "Request header carrying the actor token. Defaults to X-Actor-Token." },
+        "strip": { "type": "boolean", "description": "Remove the header from the proxied request. Defaults true." },
+        "required": { "type": "boolean", "description": "Reject requests missing the header. Defaults true." }
+      }
+    },
+    "X-Tyk-OAuth2-ActorStatic": {
+      "type": "object",
+      "properties": {
+        "token": { "type": "string", "description": "Pre-configured actor token (env://, secrets://, vault://, consul:// honoured). Testing only." }
+      },
+      "required": ["token"]
     },
     "X-Tyk-OAuth2-ClientAuth": {
       "type": "object",

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2285,13 +2285,17 @@
           "type": "string",
           "enum": [
             "client_secret_basic",
-            "client_secret_post"
+            "client_secret_post",
+            "private_key_jwt"
           ]
         },
         "clientId": {
           "type": "string"
         },
         "clientSecret": {
+          "type": "string"
+        },
+        "certId": {
           "type": "string"
         }
       },

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2161,6 +2161,9 @@
         "defaultTarget": {
           "$ref": "#/definitions/X-Tyk-OAuth2-DefaultTarget"
         },
+        "actorToken": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorToken"
+        },
         "timeout": {
           "type": "string",
           "description": "Per-call timeout for the RFC 8693 exchange request, Tyk ReadableDuration (e.g. \"100ms\", \"5s\"). Defaults to 15s when zero/unset."
@@ -2210,6 +2213,64 @@
       "required": [
         "enabled"
       ],
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-ActorToken": {
+      "type": "object",
+      "description": "RFC 8693 actor token (delegation). When set, exchange requests carry actor_token; omit to use impersonation.",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": ["client_credentials", "header", "static"]
+        },
+        "actorTokenType": {
+          "type": "string",
+          "enum": ["urn:ietf:params:oauth:token-type:access_token", "urn:ietf:params:oauth:token-type:jwt"],
+          "description": "RFC 8693 token-type URN advertised for the actor token. Defaults to ...:access_token; set ...:jwt only for an RFC-strict IdP."
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorClientCredentials"
+        },
+        "header": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorHeader"
+        },
+        "static": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorStatic"
+        },
+        "requireMayAct": {
+          "type": "boolean",
+          "description": "When true, the gateway verifies the subject token's may_act (RFC 8693 §4.4) authorizes the configured actor before calling the IdP. Defaults false."
+        }
+      },
+      "required": ["source"],
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-ActorClientCredentials": {
+      "type": "object",
+      "properties": {
+        "tokenEndpoint": { "type": "string" },
+        "clientId": { "type": "string" },
+        "clientSecret": { "type": "string" },
+        "scopes": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["tokenEndpoint", "clientId"],
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-ActorHeader": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "description": "Request header carrying the actor token. Defaults to X-Actor-Token." },
+        "strip": { "type": "boolean", "description": "Remove the header from the proxied request. Defaults true." },
+        "required": { "type": "boolean", "description": "Reject requests missing the header. Defaults true." }
+      },
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-ActorStatic": {
+      "type": "object",
+      "properties": {
+        "token": { "type": "string", "description": "Pre-configured actor token (env://, secrets://, vault://, consul:// honoured). Testing only." }
+      },
+      "required": ["token"],
       "additionalProperties": false
     },
     "X-Tyk-OAuth2-ClientAuth": {

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2146,6 +2146,11 @@
         "name": {
           "type": "string"
         },
+        "flow": {
+          "type": "string",
+          "enum": ["token-exchange", "on-behalf-of"],
+          "description": "Delegation flow this provider speaks. Defaults to token-exchange (the RFC 8693 grant). Set on-behalf-of for identity providers that implement the On-Behalf-Of flow (jwt-bearer grant) instead of RFC 8693 token exchange."
+        },
         "issuers": {
           "type": "array",
           "items": {

--- a/apidef/streams/schema/x-tyk-api-gateway.json
+++ b/apidef/streams/schema/x-tyk-api-gateway.json
@@ -1920,13 +1920,17 @@
           "type": "string",
           "enum": [
             "client_secret_basic",
-            "client_secret_post"
+            "client_secret_post",
+            "private_key_jwt"
           ]
         },
         "clientId": {
           "type": "string"
         },
         "clientSecret": {
+          "type": "string"
+        },
+        "certId": {
           "type": "string"
         }
       }

--- a/apidef/streams/schema/x-tyk-api-gateway.json
+++ b/apidef/streams/schema/x-tyk-api-gateway.json
@@ -1821,6 +1821,9 @@
         "defaultTarget": {
           "$ref": "#/definitions/X-Tyk-OAuth2-DefaultTarget"
         },
+        "actorToken": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorToken"
+        },
         "timeout": {
           "type": "string",
           "description": "Per-call timeout for the RFC 8693 exchange request, Tyk ReadableDuration (e.g. \"100ms\", \"5s\"). Defaults to 15s when zero/unset."
@@ -1850,6 +1853,60 @@
         "safetyMargin": { "type": "string", "description": "Shaved from the computed TTL to avoid serving near-expired tokens. Defaults to 30s." }
       },
       "required": ["enabled"]
+    },
+    "X-Tyk-OAuth2-ActorToken": {
+      "type": "object",
+      "description": "RFC 8693 actor token (delegation). When set, exchange requests carry actor_token; omit to use impersonation.",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": ["client_credentials", "header", "static"]
+        },
+        "actorTokenType": {
+          "type": "string",
+          "enum": ["urn:ietf:params:oauth:token-type:access_token", "urn:ietf:params:oauth:token-type:jwt"],
+          "description": "RFC 8693 token-type URN advertised for the actor token. Defaults to ...:access_token; set ...:jwt only for an RFC-strict IdP."
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorClientCredentials"
+        },
+        "header": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorHeader"
+        },
+        "static": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ActorStatic"
+        },
+        "requireMayAct": {
+          "type": "boolean",
+          "description": "When true, the gateway verifies the subject token's may_act (RFC 8693 §4.4) authorizes the configured actor before calling the IdP. Defaults false."
+        }
+      },
+      "required": ["source"]
+    },
+    "X-Tyk-OAuth2-ActorClientCredentials": {
+      "type": "object",
+      "properties": {
+        "tokenEndpoint": { "type": "string" },
+        "clientId": { "type": "string" },
+        "clientSecret": { "type": "string" },
+        "scopes": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["tokenEndpoint", "clientId"]
+    },
+    "X-Tyk-OAuth2-ActorHeader": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "description": "Request header carrying the actor token. Defaults to X-Actor-Token." },
+        "strip": { "type": "boolean", "description": "Remove the header from the proxied request. Defaults true." },
+        "required": { "type": "boolean", "description": "Reject requests missing the header. Defaults true." }
+      }
+    },
+    "X-Tyk-OAuth2-ActorStatic": {
+      "type": "object",
+      "properties": {
+        "token": { "type": "string", "description": "Pre-configured actor token (env://, secrets://, vault://, consul:// honoured). Testing only." }
+      },
+      "required": ["token"]
     },
     "X-Tyk-OAuth2-ClientAuth": {
       "type": "object",

--- a/apidef/streams/schema/x-tyk-api-gateway.json
+++ b/apidef/streams/schema/x-tyk-api-gateway.json
@@ -1806,6 +1806,11 @@
         "name": {
           "type": "string"
         },
+        "flow": {
+          "type": "string",
+          "enum": ["token-exchange", "on-behalf-of"],
+          "description": "Delegation flow this provider speaks. Defaults to token-exchange (the RFC 8693 grant). Set on-behalf-of for identity providers that implement the On-Behalf-Of flow (jwt-bearer grant) instead of RFC 8693 token exchange."
+        },
         "issuers": {
           "type": "array",
           "items": {

--- a/ee/middleware/oauth2tokenexchange/actor.go
+++ b/ee/middleware/oauth2tokenexchange/actor.go
@@ -1,0 +1,248 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+	tyktime "github.com/TykTechnologies/tyk/internal/time"
+)
+
+const (
+	// DefaultActorTokenHeader is the request header read when
+	// actorToken.source==header and no explicit name is configured.
+	DefaultActorTokenHeader = "X-Actor-Token"
+
+	// DefaultActorTokenTTL caches a CC actor token when the IdP returns
+	// no usable expires_in.
+	DefaultActorTokenTTL = 5 * time.Minute
+
+	// ActorTokenTTLSafetyMargin is trimmed off the IdP-reported lifetime
+	// so a cached actor token is never replayed right at its expiry.
+	ActorTokenTTLSafetyMargin = 30 * time.Second
+)
+
+// actorSF coalesces concurrent first-misses for the same CC actor-token key.
+var actorSF singleflight.Group
+
+// actorTokenCache is a minimal in-process TTL cache for client_credentials
+// actor tokens. Keyed by ActorCacheKey (tokenEndpoint+clientId+scopes), which
+// is non-secret operator config.
+type actorTokenCache struct {
+	mu      sync.RWMutex
+	entries map[string]actorCacheEntry
+}
+
+type actorCacheEntry struct {
+	token  string
+	expiry time.Time
+}
+
+func newActorTokenCache() *actorTokenCache {
+	return &actorTokenCache{entries: make(map[string]actorCacheEntry)}
+}
+
+func (c *actorTokenCache) get(key string) (string, bool) {
+	c.mu.RLock()
+	e, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok || time.Now().After(e.expiry) {
+		return "", false
+	}
+	return e.token, true
+}
+
+func (c *actorTokenCache) put(key, token string, ttl time.Duration) {
+	if ttl <= 0 {
+		return
+	}
+	c.mu.Lock()
+	c.entries[key] = actorCacheEntry{token: token, expiry: time.Now().Add(ttl)}
+	c.mu.Unlock()
+}
+
+// acquireActorToken returns (actorToken, actorID) for the matched provider's
+// actorToken config, or ("", OAuth2ActorImpersonation) when no actor token is
+// configured. Errors only when a source is configured but the token can't be
+// obtained — CC flow fails, or `header` source is `required: true` but absent.
+func (m *Middleware) acquireActorToken(r *http.Request, provider *oas.OAuth2TokenExchangeProvider) (string, string, error) {
+	at := provider.ActorToken
+	if at == nil {
+		return "", oas.OAuth2ActorImpersonation, nil
+	}
+	switch at.Source {
+	case oas.OAuth2ActorSourceClientCredentials:
+		if at.ClientCredentials == nil {
+			return "", "", errors.New("actorToken.source=client_credentials but clientCredentials block is missing")
+		}
+		token, err := m.getOrAcquireActorTokenViaCC(r.Context(), at.ClientCredentials, provider.Timeout, provider.Name)
+		if err != nil {
+			return "", "", err
+		}
+		return token, at.ClientCredentials.ClientID, nil
+	case oas.OAuth2ActorSourceHeader:
+		hdr, strip, required := actorHeaderSettings(at.Header)
+		raw := r.Header.Get(hdr)
+		if raw == "" {
+			if required {
+				return "", "", &oauth2common.MissingActorTokenError{Header: hdr}
+			}
+			return "", oas.OAuth2ActorImpersonation, nil
+		}
+		if strip {
+			r.Header.Del(hdr)
+		}
+		return raw, oauth2common.HashActorID(raw), nil
+	case oas.OAuth2ActorSourceStatic:
+		if at.Static == nil || at.Static.Token == "" {
+			return "", "", errors.New("actorToken.source=static but static.token is empty")
+		}
+		return at.Static.Token, oauth2common.HashActorID(at.Static.Token), nil
+	default:
+		return "", "", fmt.Errorf("unsupported actorToken.source %q", at.Source)
+	}
+}
+
+// maybeStripActorHeader removes the configured actor-token header from the
+// proxied request when source==header and strip!=false. Called on the success
+// paths so the upstream never sees the actor token, even on a cache hit (where
+// acquireActorToken's strip branch isn't reached).
+func (m *Middleware) maybeStripActorHeader(r *http.Request, provider *oas.OAuth2TokenExchangeProvider) {
+	at := provider.ActorToken
+	if at == nil || at.Source != oas.OAuth2ActorSourceHeader {
+		return
+	}
+	hdr, strip, _ := actorHeaderSettings(at.Header)
+	if strip {
+		r.Header.Del(hdr)
+	}
+}
+
+// actorHeaderSettings resolves header name/strip/required with their defaults
+// (X-Actor-Token, strip=true, required=true).
+func actorHeaderSettings(h *oas.OAuth2ActorHeader) (name string, strip, required bool) {
+	name, strip, required = DefaultActorTokenHeader, true, true
+	if h != nil {
+		if h.Name != "" {
+			name = h.Name
+		}
+		if h.Strip != nil {
+			strip = *h.Strip
+		}
+		if h.Required != nil {
+			required = *h.Required
+		}
+	}
+	return name, strip, required
+}
+
+// getOrAcquireActorTokenViaCC returns a cached CC actor token or runs the CC
+// flow against the configured endpoint. Concurrent first-misses for the same
+// key are coalesced via singleflight.
+func (m *Middleware) getOrAcquireActorTokenViaCC(ctx context.Context, cc *oas.OAuth2ActorClientCredentials, timeout tyktime.ReadableDuration, providerName string) (string, error) {
+	key := oauth2common.ActorCacheKey(cc.TokenEndpoint, cc.ClientID, cc.Scopes)
+	if m.actorCache != nil {
+		if cached, ok := m.actorCache.get(key); ok {
+			// Served from the actor-token cache: no IdP round-trip, so the
+			// acquisition metric is not re-incremented (the counter reads
+			// actual IdP load).
+			return cached, nil
+		}
+	}
+	start := time.Now()
+	v, err, _ := actorSF.Do(key, func() (interface{}, error) {
+		if m.actorCache != nil {
+			if cached, ok := m.actorCache.get(key); ok {
+				return cached, nil
+			}
+		}
+		return m.fetchActorTokenViaCC(ctx, cc, key, timeout)
+	})
+	m.recordActor(ctx, providerName, time.Since(start), err)
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+// recordActor records one client-credentials actor-token acquisition on the
+// observability layer's actor instruments. A no-op when no Base is wired (unit
+// tests that exercise acquisition without metrics). The outcome is ok unless
+// the acquisition failed (idp_error).
+func (m *Middleware) recordActor(ctx context.Context, providerName string, dur time.Duration, err error) {
+	if m.Base == nil {
+		return
+	}
+	outcome := oauth2common.OutcomeOK
+	if err != nil {
+		outcome = oauth2common.OutcomeIdPError
+	}
+	m.Base.RecordActorAcquisition(ctx, string(outcome), providerName, dur)
+}
+
+// fetchActorTokenViaCC performs the CC HTTP call and populates the cache. ctx
+// is the inbound request context — a cancelled inbound request cancels this too.
+func (m *Middleware) fetchActorTokenViaCC(ctx context.Context, cc *oas.OAuth2ActorClientCredentials, cacheKey string, timeout tyktime.ReadableDuration) (string, error) {
+	form := url.Values{}
+	form.Set(oas.OAuth2FormGrantType, oas.OAuth2GrantTypeClientCredentials)
+	if len(cc.Scopes) > 0 {
+		form.Set(oas.OAuth2FormScope, strings.Join(cc.Scopes, " "))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cc.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("building actor CC request: %w", err)
+	}
+	req.Header.Set(header.ContentType, header.ApplicationFormURLEncoded)
+	req.Header.Set(header.Accept, header.ApplicationJSON)
+	if cc.ClientID != "" {
+		req.SetBasicAuth(cc.ClientID, cc.ClientSecret)
+	}
+
+	client := oauth2common.NewIdPHTTPClient(EffectiveIdPTimeout(time.Duration(timeout)))
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("actor CC call failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, oauth2common.MaxIdPResponseBytes))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Sanitize the IdP body before embedding in the error chain — a
+		// misconfigured IdP that echoes request bytes would otherwise leak
+		// the inbound bearer into logs via downstream WithError(err).
+		idpErr, idpDesc := oauth2common.DecodeIdPError(body)
+		return "", fmt.Errorf("actor CC call returned status %d: %s: %s", resp.StatusCode, idpErr, idpDesc)
+	}
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("decoding actor CC response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return "", errors.New("actor CC response missing access_token")
+	}
+	ttl := time.Duration(parsed.ExpiresIn) * time.Second
+	if ttl <= 0 {
+		ttl = DefaultActorTokenTTL
+	}
+	if m.actorCache != nil {
+		m.actorCache.put(cacheKey, parsed.AccessToken, ttl-ActorTokenTTLSafetyMargin)
+	}
+	return parsed.AccessToken, nil
+}

--- a/ee/middleware/oauth2tokenexchange/actor_test.go
+++ b/ee/middleware/oauth2tokenexchange/actor_test.go
@@ -1,0 +1,171 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func newTestMiddleware() *Middleware {
+	return &Middleware{actorCache: newActorTokenCache()}
+}
+
+func TestAcquireActorToken_NoActorBlock_Impersonation(t *testing.T) {
+	m := newTestMiddleware()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	tok, id, err := m.acquireActorToken(r, &oas.OAuth2TokenExchangeProvider{})
+	require.NoError(t, err)
+	assert.Empty(t, tok)
+	assert.Equal(t, oas.OAuth2ActorImpersonation, id, "no actor block must signal impersonation")
+}
+
+func TestAcquireActorToken_Static_ReturnsTokenAndID(t *testing.T) {
+	m := newTestMiddleware()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	provider := &oas.OAuth2TokenExchangeProvider{
+		ActorToken: &oas.OAuth2ActorToken{
+			Source: oas.OAuth2ActorSourceStatic,
+			Static: &oas.OAuth2ActorStatic{Token: "static-actor-token"},
+		},
+	}
+
+	tok, id, err := m.acquireActorToken(r, provider)
+	require.NoError(t, err)
+	assert.Equal(t, "static-actor-token", tok)
+	assert.Equal(t, oauth2common.HashActorID("static-actor-token"), id)
+	assert.NotEqual(t, oas.OAuth2ActorImpersonation, id, "delegation actorID must differ from impersonation")
+}
+
+func TestAcquireActorToken_Static_EmptyTokenErrors(t *testing.T) {
+	m := newTestMiddleware()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	provider := &oas.OAuth2TokenExchangeProvider{
+		ActorToken: &oas.OAuth2ActorToken{Source: oas.OAuth2ActorSourceStatic, Static: &oas.OAuth2ActorStatic{}},
+	}
+
+	_, _, err := m.acquireActorToken(r, provider)
+	require.Error(t, err)
+}
+
+func TestAcquireActorToken_Header_StripsByDefault(t *testing.T) {
+	m := newTestMiddleware()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(DefaultActorTokenHeader, "header-actor-token")
+	provider := &oas.OAuth2TokenExchangeProvider{
+		ActorToken: &oas.OAuth2ActorToken{Source: oas.OAuth2ActorSourceHeader},
+	}
+
+	tok, id, err := m.acquireActorToken(r, provider)
+	require.NoError(t, err)
+	assert.Equal(t, "header-actor-token", tok)
+	assert.Equal(t, oauth2common.HashActorID("header-actor-token"), id)
+	assert.Empty(t, r.Header.Get(DefaultActorTokenHeader), "actor header must be stripped from the proxied request by default")
+}
+
+func TestAcquireActorToken_Header_NoStripWhenDisabled(t *testing.T) {
+	m := newTestMiddleware()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Custom-Actor", "tok")
+	provider := &oas.OAuth2TokenExchangeProvider{
+		ActorToken: &oas.OAuth2ActorToken{
+			Source: oas.OAuth2ActorSourceHeader,
+			Header: &oas.OAuth2ActorHeader{Name: "X-Custom-Actor", Strip: boolPtr(false)},
+		},
+	}
+
+	_, _, err := m.acquireActorToken(r, provider)
+	require.NoError(t, err)
+	assert.Equal(t, "tok", r.Header.Get("X-Custom-Actor"), "strip:false must leave the header intact")
+}
+
+func TestAcquireActorToken_Header_RequiredButAbsentErrors(t *testing.T) {
+	m := newTestMiddleware()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	provider := &oas.OAuth2TokenExchangeProvider{
+		ActorToken: &oas.OAuth2ActorToken{Source: oas.OAuth2ActorSourceHeader},
+	}
+
+	_, _, err := m.acquireActorToken(r, provider)
+	require.Error(t, err, "required header (default) absent must error, not silently impersonate")
+}
+
+func TestAcquireActorToken_Header_NotRequiredFallsBackToImpersonation(t *testing.T) {
+	m := newTestMiddleware()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	provider := &oas.OAuth2TokenExchangeProvider{
+		ActorToken: &oas.OAuth2ActorToken{
+			Source: oas.OAuth2ActorSourceHeader,
+			Header: &oas.OAuth2ActorHeader{Required: boolPtr(false)},
+		},
+	}
+
+	tok, id, err := m.acquireActorToken(r, provider)
+	require.NoError(t, err)
+	assert.Empty(t, tok)
+	assert.Equal(t, oas.OAuth2ActorImpersonation, id, "required:false absent header falls back to impersonation")
+}
+
+func TestAcquireActorToken_CC_MissingBlockErrors(t *testing.T) {
+	m := newTestMiddleware()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	provider := &oas.OAuth2TokenExchangeProvider{
+		ActorToken: &oas.OAuth2ActorToken{Source: oas.OAuth2ActorSourceClientCredentials},
+	}
+
+	_, _, err := m.acquireActorToken(r, provider)
+	require.Error(t, err)
+}
+
+func TestGetOrAcquireActorTokenViaCC_FetchesCachesAndReuses(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_ = r.ParseForm()
+		assert.Equal(t, oas.OAuth2GrantTypeClientCredentials, r.Form.Get(oas.OAuth2FormGrantType))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"cc-actor-tok","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	m := newTestMiddleware()
+	cc := &oas.OAuth2ActorClientCredentials{
+		TokenEndpoint: srv.URL,
+		ClientID:      "tyk-gateway-actor",
+		ClientSecret:  "secret",
+		Scopes:        []string{"agent"},
+	}
+
+	tok1, err := m.getOrAcquireActorTokenViaCC(httptest.NewRequest(http.MethodGet, "/", nil).Context(), cc, 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, "cc-actor-tok", tok1)
+
+	tok2, err := m.getOrAcquireActorTokenViaCC(httptest.NewRequest(http.MethodGet, "/", nil).Context(), cc, 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, "cc-actor-tok", tok2)
+	assert.Equal(t, 1, calls, "second acquisition must be served from cache, not a second IdP call")
+}
+
+func TestGetOrAcquireActorTokenViaCC_IdPErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"server_error"}`))
+	}))
+	defer srv.Close()
+
+	m := newTestMiddleware()
+	cc := &oas.OAuth2ActorClientCredentials{TokenEndpoint: srv.URL, ClientID: "actor"}
+
+	_, err := m.getOrAcquireActorTokenViaCC(httptest.NewRequest(http.MethodGet, "/", nil).Context(), cc, 0, "")
+	require.Error(t, err)
+}

--- a/ee/middleware/oauth2tokenexchange/clientassertion.go
+++ b/ee/middleware/oauth2tokenexchange/clientassertion.go
@@ -1,0 +1,92 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+)
+
+// clientAssertionTTL is the lifetime of a private_key_jwt client assertion.
+// Short by design — the assertion is single-use against one token request.
+const clientAssertionTTL = 5 * time.Minute
+
+// buildClientAssertion mints a private_key_jwt client-authentication assertion
+// (RFC 7523 §2.2) signed with the certificate's RSA private key. The JOSE header
+// carries the SHA-256 certificate thumbprint (`x5t#S256`) so the IdP can select
+// the registered public key; Entra requires RS256 (or PS256) — no EC support.
+// Claims follow Microsoft's certificate-credentials contract: iss = sub =
+// clientID, aud = the token endpoint, a unique jti, and a short exp window.
+func buildClientAssertion(cert *tls.Certificate, clientID, tokenEndpoint, jti string, now time.Time) (string, error) {
+	if cert == nil || len(cert.Certificate) == 0 {
+		return "", fmt.Errorf("client assertion: certificate carries no DER bytes")
+	}
+	key, ok := cert.PrivateKey.(*rsa.PrivateKey)
+	if !ok {
+		return "", fmt.Errorf("client assertion: certificate private key is %T, want *rsa.PrivateKey", cert.PrivateKey)
+	}
+
+	sum := sha256.Sum256(cert.Certificate[0])
+	thumbprint := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": clientID,
+		"sub": clientID,
+		"aud": tokenEndpoint,
+		"jti": jti,
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+		"exp": now.Add(clientAssertionTTL).Unix(),
+	})
+	token.Header["x5t#S256"] = thumbprint
+
+	signed, err := token.SignedString(key)
+	if err != nil {
+		return "", fmt.Errorf("client assertion: signing failed: %w", err)
+	}
+	return signed, nil
+}
+
+// newJTI returns a random token identifier for a client assertion's jti claim.
+func newJTI() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("client assertion: generating jti: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// addClientAssertion signs a private_key_jwt assertion with the provider's
+// configured certificate and adds the client_id / client_assertion_type /
+// client_assertion form fields. The assertion authenticates the gateway to the
+// token endpoint in place of a shared secret.
+func (m *Middleware) addClientAssertion(form url.Values, provider *oas.OAuth2TokenExchangeProvider) error {
+	ca := provider.ClientAuth
+	cert, err := m.Base.GetClientCertificate(ca.CertID)
+	if err != nil {
+		return fmt.Errorf("private_key_jwt client auth: %w", err)
+	}
+	jti, err := newJTI()
+	if err != nil {
+		return err
+	}
+	assertion, err := buildClientAssertion(cert, ca.ClientID, provider.TokenEndpoint, jti, time.Now())
+	if err != nil {
+		return err
+	}
+	form.Set(oas.OAuth2FormClientID, ca.ClientID)
+	form.Set(oas.OAuth2FormClientAssertionType, oas.OAuth2ClientAssertionTypeJWTBearer)
+	form.Set(oas.OAuth2FormClientAssertion, assertion)
+	return nil
+}

--- a/ee/middleware/oauth2tokenexchange/clientassertion_test.go
+++ b/ee/middleware/oauth2tokenexchange/clientassertion_test.go
@@ -1,0 +1,171 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/model"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+// selfSignedRSACert returns a *tls.Certificate with a populated Leaf, backed by
+// a freshly generated RSA key — the shape CertificateManager.List hands back.
+func selfSignedRSACert(t *testing.T) *tls.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "tyk-obo"}}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return &tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}
+}
+
+func TestBuildClientAssertion(t *testing.T) {
+	cert := selfSignedRSACert(t)
+	now := time.Unix(1_700_000_000, 0)
+	const clientID = "11111111-2222-3333-4444-555555555555"
+	const endpoint = "https://login.microsoftonline.com/tenant/oauth2/v2.0/token"
+
+	// parser verifies the signature but skips exp/nbf checks so the fixed `now`
+	// above stays deterministic — these tests assert signing, not current validity.
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	keyFn := func(*jwt.Token) (interface{}, error) { return cert.Leaf.PublicKey, nil }
+
+	t.Run("produces an RS256 JWT that verifies against the certificate", func(t *testing.T) {
+		s, err := buildClientAssertion(cert, clientID, endpoint, "jti-1", now)
+		require.NoError(t, err)
+
+		parsed, err := parser.Parse(s, keyFn)
+		require.NoError(t, err)
+		assert.True(t, parsed.Valid)
+		assert.Equal(t, "RS256", parsed.Method.Alg())
+	})
+
+	t.Run("sets the JOSE header with the SHA-256 cert thumbprint (x5t#S256)", func(t *testing.T) {
+		s, err := buildClientAssertion(cert, clientID, endpoint, "jti-1", now)
+		require.NoError(t, err)
+
+		parsed, _ := parser.Parse(s, keyFn)
+		assert.Equal(t, "JWT", parsed.Header["typ"])
+		assert.Equal(t, "RS256", parsed.Header["alg"])
+
+		sum := sha256.Sum256(cert.Certificate[0])
+		want := base64.RawURLEncoding.EncodeToString(sum[:])
+		assert.Equal(t, want, parsed.Header["x5t#S256"], "thumbprint must be base64url(SHA-256(DER))")
+	})
+
+	t.Run("sets the assertion claims per RFC 7523 / Entra", func(t *testing.T) {
+		s, err := buildClientAssertion(cert, clientID, endpoint, "jti-unique", now)
+		require.NoError(t, err)
+
+		claims := jwt.MapClaims{}
+		_, err = parser.ParseWithClaims(s, claims, keyFn)
+		require.NoError(t, err)
+
+		assert.Equal(t, clientID, claims["iss"], "iss must be the client id")
+		assert.Equal(t, clientID, claims["sub"], "sub must equal iss")
+		assert.Equal(t, endpoint, claims["aud"], "aud must be the token endpoint")
+		assert.Equal(t, "jti-unique", claims["jti"])
+		assert.EqualValues(t, now.Unix(), claims["iat"])
+		assert.EqualValues(t, now.Unix(), claims["nbf"])
+		assert.EqualValues(t, now.Add(5*time.Minute).Unix(), claims["exp"], "exp is a short 5-minute window")
+	})
+
+	t.Run("rejects a certificate carrying no DER bytes", func(t *testing.T) {
+		_, err := buildClientAssertion(&tls.Certificate{PrivateKey: cert.PrivateKey}, clientID, endpoint, "j", now)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects a non-RSA private key (Entra cert auth is RSA-only)", func(t *testing.T) {
+		eckey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		ecCert := &tls.Certificate{Certificate: cert.Certificate, Leaf: cert.Leaf, PrivateKey: eckey}
+		_, err = buildClientAssertion(ecCert, clientID, endpoint, "j", now)
+		require.Error(t, err)
+	})
+}
+
+// TestExchangeAtIdP_PrivateKeyJWT proves the exchange call authenticates with a
+// signed client assertion (no shared secret) when the provider's clientAuth
+// method is private_key_jwt.
+func TestExchangeAtIdP_PrivateKeyJWT(t *testing.T) {
+	cert := selfSignedRSACert(t)
+	target := &oauth2common.Target{Audience: "api://acme", Scopes: []string{"api://acme/.default"}}
+
+	var got struct {
+		clientID, assertion, assertionType string
+		basicOK                            bool
+	}
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		got.clientID = r.PostForm.Get(oas.OAuth2FormClientID)
+		got.assertion = r.PostForm.Get(oas.OAuth2FormClientAssertion)
+		got.assertionType = r.PostForm.Get(oas.OAuth2FormClientAssertionType)
+		_, _, got.basicOK = r.BasicAuth()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "exchanged", "expires_in": 300})
+	}))
+	defer idp.Close()
+
+	m := &Middleware{Base: &fakeBase{cert: cert}, Spec: model.MergedAPI{OAS: &oas.OAS{}}}
+	provider := &oas.OAuth2TokenExchangeProvider{
+		Name:          "entra",
+		Flow:          oas.OAuth2FlowOnBehalfOf,
+		TokenEndpoint: idp.URL,
+		ClientAuth:    &oas.OAuth2ClientAuth{Method: oas.OAuth2ClientAuthPrivateKeyJWT, ClientID: "app-id", CertID: "cert-1"},
+	}
+
+	tok, _, err := m.exchangeAtIdP(context.Background(), provider, "inbound-user-token", "", target)
+	require.NoError(t, err)
+	assert.Equal(t, "exchanged", tok)
+
+	assert.Equal(t, "app-id", got.clientID)
+	assert.Equal(t, oas.OAuth2ClientAssertionTypeJWTBearer, got.assertionType)
+	assert.False(t, got.basicOK, "private_key_jwt must not send basic auth")
+	require.NotEmpty(t, got.assertion, "a signed client assertion must reach the IdP")
+
+	// the assertion the IdP received verifies against the configured certificate
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, err := parser.Parse(got.assertion, func(*jwt.Token) (interface{}, error) { return cert.Leaf.PublicKey, nil })
+	require.NoError(t, err)
+	assert.True(t, parsed.Valid)
+	claims := parsed.Claims.(jwt.MapClaims)
+	assert.Equal(t, "app-id", claims["iss"])
+	assert.Equal(t, idp.URL, claims["aud"])
+}
+
+// TestExchangeAtIdP_PrivateKeyJWT_CertError surfaces a missing/unloadable
+// certificate as an error before any IdP call.
+func TestExchangeAtIdP_PrivateKeyJWT_CertError(t *testing.T) {
+	m := &Middleware{Base: &fakeBase{certErr: assert.AnError}, Spec: model.MergedAPI{OAS: &oas.OAS{}}}
+	provider := &oas.OAuth2TokenExchangeProvider{
+		Name:          "entra",
+		TokenEndpoint: "https://idp.example/token",
+		ClientAuth:    &oas.OAuth2ClientAuth{Method: oas.OAuth2ClientAuthPrivateKeyJWT, ClientID: "app-id", CertID: "missing"},
+	}
+	_, _, err := m.exchangeAtIdP(context.Background(), provider, "inbound", "", &oauth2common.Target{Audience: "api://x", Scopes: []string{"api://x/.default"}})
+	require.Error(t, err)
+}

--- a/ee/middleware/oauth2tokenexchange/exchange.go
+++ b/ee/middleware/oauth2tokenexchange/exchange.go
@@ -5,6 +5,7 @@ package oauth2tokenexchange
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -321,6 +322,17 @@ func (m *Middleware) exchangeAtIdP(ctx context.Context, provider *oas.OAuth2Toke
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		idpErr, idpDesc := oauth2common.DecodeIdPError(body)
+		// Entra Conditional Access returns interaction_required with a claims
+		// challenge instead of a token. Branch before the generic failure path so
+		// it is re-emitted to the caller as a step-up, never collapsed to idp_error.
+		if provider.IsOnBehalfOf() && idpErr == oas.OAuth2ErrInteractionRequired {
+			claims, authURI := oauth2common.DecodeEntraClaimsChallenge(body)
+			return "", 0, &oauth2common.StepUpRequiredError{
+				Claims:           claims,
+				AuthorizationURI: authURI,
+				IdpError:         idpErr,
+			}
+		}
 		return "", 0, &oauth2common.ExchangeFailedError{
 			Status:      resp.StatusCode,
 			IdpError:    idpErr,
@@ -331,12 +343,17 @@ func (m *Middleware) exchangeAtIdP(ctx context.Context, provider *oas.OAuth2Toke
 	return parseExchangeResponse(body)
 }
 
-// buildExchangeForm builds the RFC 8693 token-exchange request form. When
-// actorToken is non-empty, actor_token and actor_token_type are added
-// (delegation intent). When the client-auth method is client_secret_post,
-// credentials are injected into the form here (basic-auth credentials are set
-// on the request header instead).
+// buildExchangeForm builds the token-exchange request form for the provider's
+// flow. RFC 8693 (the default) sends subject_token + optional actor_token;
+// On-Behalf-Of sends the inbound token as `assertion` with the jwt-bearer
+// grant. When the client-auth method is client_secret_post, credentials are
+// injected into the form here (basic-auth credentials are set on the request
+// header instead).
 func buildExchangeForm(provider *oas.OAuth2TokenExchangeProvider, subjectToken, actorToken string, target *oauth2common.Target, method string) url.Values {
+	if provider.IsOnBehalfOf() {
+		return buildOnBehalfOfForm(provider, subjectToken, target, method)
+	}
+
 	form := url.Values{}
 	form.Set(oas.OAuth2FormGrantType, oas.OAuth2GrantTypeTokenExchange)
 	form.Set(oas.OAuth2FormSubjectToken, subjectToken)
@@ -352,18 +369,47 @@ func buildExchangeForm(provider *oas.OAuth2TokenExchangeProvider, subjectToken, 
 	if len(target.Scopes) > 0 {
 		form.Set(oas.OAuth2FormScope, strings.Join(target.Scopes, " "))
 	}
+	addCustomParams(form, provider)
+	addPostClientCredentials(form, provider, method)
+	return form
+}
+
+// buildOnBehalfOfForm builds the Microsoft Entra On-Behalf-Of request: the
+// jwt-bearer grant, the inbound user token as `assertion`, the mandatory
+// requested_token_use flag, and the target folded into the Entra `scope`. There
+// is no actor token — the acting party is the gateway's own client login.
+func buildOnBehalfOfForm(provider *oas.OAuth2TokenExchangeProvider, subjectToken string, target *oauth2common.Target, method string) url.Values {
+	form := url.Values{}
+	form.Set(oas.OAuth2FormGrantType, oas.OAuth2GrantTypeJWTBearer)
+	form.Set(oas.OAuth2FormAssertion, subjectToken)
+	form.Set(oas.OAuth2FormRequestedTokenUse, oas.OAuth2RequestedTokenUseOBO)
+	if scope := oas.EntraScopeString(target.Audience, target.Scopes); scope != "" {
+		form.Set(oas.OAuth2FormScope, scope)
+	}
+	addCustomParams(form, provider)
+	addPostClientCredentials(form, provider, method)
+	return form
+}
+
+// addCustomParams appends the provider's operator-supplied form parameters.
+func addCustomParams(form url.Values, provider *oas.OAuth2TokenExchangeProvider) {
 	for k, v := range provider.CustomParams {
 		form.Set(k, v)
 	}
-	if method == oas.OAuth2ClientAuthPost && provider.ClientAuth != nil {
-		if provider.ClientAuth.ClientID != "" {
-			form.Set(oas.OAuth2FormClientID, provider.ClientAuth.ClientID)
-		}
-		if provider.ClientAuth.ClientSecret != "" {
-			form.Set(oas.OAuth2FormClientSecret, provider.ClientAuth.ClientSecret)
-		}
+}
+
+// addPostClientCredentials injects client_id/client_secret into the form for the
+// client_secret_post method; a no-op for basic (set on the request header).
+func addPostClientCredentials(form url.Values, provider *oas.OAuth2TokenExchangeProvider, method string) {
+	if method != oas.OAuth2ClientAuthPost || provider.ClientAuth == nil {
+		return
 	}
-	return form
+	if provider.ClientAuth.ClientID != "" {
+		form.Set(oas.OAuth2FormClientID, provider.ClientAuth.ClientID)
+	}
+	if provider.ClientAuth.ClientSecret != "" {
+		form.Set(oas.OAuth2FormClientSecret, provider.ClientAuth.ClientSecret)
+	}
 }
 
 // applyClientAuth sets the request-level client authentication for the exchange
@@ -465,6 +511,25 @@ func (m *Middleware) writeMissingActorTokenResponse(w http.ResponseWriter, r *ht
 		oas.OAuth2FieldError:            oas.OAuth2ErrInvalidToken,
 		oas.OAuth2FieldErrorDescription: e.Error(),
 	})
+}
+
+// writeStepUpRequiredResponse renders a 401 with a Bearer insufficient_claims
+// challenge when Entra returns a Conditional Access claims challenge. The claims
+// are base64-encoded with padding (Microsoft's convention) on the
+// WWW-Authenticate header; the upstream is never called and nothing is cached.
+func (m *Middleware) writeStepUpRequiredResponse(w http.ResponseWriter, r *http.Request, e *oauth2common.StepUpRequiredError) {
+	params := [][2]string{{oas.OAuth2FieldError, oas.OAuth2ErrInsufficientClaims}}
+	body := map[string]string{oas.OAuth2FieldError: oas.OAuth2ErrInsufficientClaims}
+	if e.Claims != "" {
+		encoded := base64.StdEncoding.EncodeToString([]byte(e.Claims))
+		params = append(params, [2]string{oas.OAuth2FieldClaims, encoded})
+		body[oas.OAuth2FieldClaims] = encoded
+	}
+	if e.AuthorizationURI != "" {
+		params = append(params, [2]string{oas.OAuth2FieldAuthorizationURI, e.AuthorizationURI})
+		body[oas.OAuth2FieldAuthorizationURI] = e.AuthorizationURI
+	}
+	m.writeJSONError(w, r, http.StatusUnauthorized, params, body)
 }
 
 // writeMisconfigResponse renders a 500 for an incomplete exchange configuration.

--- a/ee/middleware/oauth2tokenexchange/exchange.go
+++ b/ee/middleware/oauth2tokenexchange/exchange.go
@@ -52,8 +52,33 @@ func (m *Middleware) runExchange(r *http.Request, st *oauth2common.State) (oauth
 	out.Audience = target.Audience
 	out.Scopes = target.Scopes
 
+	if provider.ActorToken != nil {
+		out.ActorSource = provider.ActorToken.Source
+	}
+
+	// Optional defence-in-depth: verify the subject token authorizes this actor
+	// (RFC 8693 §4.4) BEFORE acquiring the actor token, so a rejection spends no
+	// IdP round-trip — the expected actor is the configured clientId for the
+	// client_credentials source, and header/static tokens are read without
+	// touching the IdP. No-op unless the operator set actorToken.requireMayAct.
+	if err := m.checkMayAct(st.Claims, provider.ActorToken, m.mayActActorToken(r, provider.ActorToken)); err != nil {
+		return out, err
+	}
+
+	// Acquire the actor token (if configured) before the cache key is built —
+	// the actor identity participates in the key so impersonation and
+	// delegation results for the same subject/target never collide.
+	actorToken, actorID, err := m.acquireActorToken(r, provider)
+	if err != nil {
+		return out, err
+	}
+	out.ActorID = actorID
+	if provider.ActorToken != nil {
+		out.ActorAzp = actorAzp(provider.ActorToken, actorToken)
+	}
+
 	start := time.Now()
-	exchanged, cacheHit, err := m.fetchExchangedToken(r, st, provider, target)
+	exchanged, cacheHit, err := m.fetchExchangedToken(r, st, provider, target, actorToken, actorID)
 	out.CacheHit = cacheHit
 	out.Duration = time.Since(start)
 	if err != nil {
@@ -64,6 +89,9 @@ func (m *Middleware) runExchange(r *http.Request, st *oauth2common.State) (oauth
 		}
 		return out, err
 	}
+	// Strip the actor header on success even on a cache hit, where
+	// acquireActorToken's strip branch wasn't reached.
+	m.maybeStripActorHeader(r, provider)
 	out.ExchangedToken = exchanged
 	r.Header.Set(header.Authorization, oas.OAuth2AuthSchemeBearer+" "+exchanged)
 	return out, nil
@@ -104,9 +132,9 @@ func inboundRemaining(st *oauth2common.State) time.Duration {
 // fetchExchangedToken returns an exchanged token, using the cache when configured
 // and enabled. It also reports whether the token was served from cache. The
 // caller times the call for the duration metric.
-func (m *Middleware) fetchExchangedToken(r *http.Request, st *oauth2common.State, provider *oas.OAuth2TokenExchangeProvider, target *oauth2common.Target) (string, bool, error) {
+func (m *Middleware) fetchExchangedToken(r *http.Request, st *oauth2common.State, provider *oas.OAuth2TokenExchangeProvider, target *oauth2common.Target, actorToken, actorID string) (string, bool, error) {
 	if m.Cache == nil || provider.Cache == nil || !provider.Cache.Enabled {
-		token, _, err := m.exchangeAtIdP(r.Context(), provider, st.RawToken, target)
+		token, _, err := m.exchangeAtIdP(r.Context(), provider, st.RawToken, actorToken, target)
 		return token, false, err
 	}
 
@@ -118,6 +146,7 @@ func (m *Middleware) fetchExchangedToken(r *http.Request, st *oauth2common.State
 		Audience:     target.Audience,
 		Scopes:       target.Scopes,
 		ProviderName: provider.Name,
+		ActorID:      actorID,
 	}.Build()
 
 	log := m.Logger()
@@ -129,7 +158,7 @@ func (m *Middleware) fetchExchangedToken(r *http.Request, st *oauth2common.State
 			"audience": target.Audience,
 		}).Info("token exchange cache miss")
 
-		tok, expiresIn, fetchErr := m.exchangeAtIdP(r.Context(), provider, st.RawToken, target)
+		tok, expiresIn, fetchErr := m.exchangeAtIdP(r.Context(), provider, st.RawToken, actorToken, target)
 		if fetchErr != nil {
 			return "", 0, fetchErr
 		}
@@ -234,9 +263,34 @@ func (m *Middleware) resolveExchangeTarget(st *oauth2common.State, provider *oas
 	return nil
 }
 
+// actorAzp resolves the actor client's authorized party for observability: the
+// CC client id for source=client_credentials, otherwise the azp claim of the
+// presented actor JWT (decoded unverified), or "" when opaque. Never the actor
+// subject identity.
+func actorAzp(at *oas.OAuth2ActorToken, actorToken string) string {
+	if at.Source == oas.OAuth2ActorSourceClientCredentials && at.ClientCredentials != nil {
+		return at.ClientCredentials.ClientID
+	}
+	if claims, err := oauth2common.ParseUnverifiedClaims(actorToken); err == nil {
+		return oauth2common.StringClaim(claims, oas.OAuth2ClaimAzp)
+	}
+	return ""
+}
+
+// resolveActorTokenType returns the actor_token_type URN to advertise: the
+// per-provider override when set, otherwise access_token (the interoperable
+// default; PingOne/PingAM reject :jwt on the actor token).
+func resolveActorTokenType(at *oas.OAuth2ActorToken) string {
+	if at != nil && at.ActorTokenType != "" {
+		return at.ActorTokenType
+	}
+	return oas.OAuth2TokenTypeAccessToken
+}
+
 // exchangeAtIdP posts the RFC 8693 exchange form to the provider's token endpoint.
 // Returns the exchanged access token and the expires_in value from the response (0 if not provided).
-func (m *Middleware) exchangeAtIdP(ctx context.Context, provider *oas.OAuth2TokenExchangeProvider, subjectToken string, target *oauth2common.Target) (string, time.Duration, error) {
+// When actorToken is non-empty, actor_token and actor_token_type are added (delegation intent).
+func (m *Middleware) exchangeAtIdP(ctx context.Context, provider *oas.OAuth2TokenExchangeProvider, subjectToken, actorToken string, target *oauth2common.Target) (string, time.Duration, error) {
 	if provider.TokenEndpoint == "" {
 		return "", 0, errors.New("provider tokenEndpoint is empty")
 	}
@@ -246,7 +300,7 @@ func (m *Middleware) exchangeAtIdP(ctx context.Context, provider *oas.OAuth2Toke
 		method = provider.ClientAuth.Method
 	}
 
-	form := buildExchangeForm(provider, subjectToken, target, method)
+	form := buildExchangeForm(provider, subjectToken, actorToken, target, method)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.TokenEndpoint, strings.NewReader(form.Encode()))
 	if err != nil {
@@ -277,14 +331,20 @@ func (m *Middleware) exchangeAtIdP(ctx context.Context, provider *oas.OAuth2Toke
 	return parseExchangeResponse(body)
 }
 
-// buildExchangeForm builds the RFC 8693 token-exchange request form. When the
-// client-auth method is client_secret_post, credentials are injected into the
-// form here (basic-auth credentials are set on the request header instead).
-func buildExchangeForm(provider *oas.OAuth2TokenExchangeProvider, subjectToken string, target *oauth2common.Target, method string) url.Values {
+// buildExchangeForm builds the RFC 8693 token-exchange request form. When
+// actorToken is non-empty, actor_token and actor_token_type are added
+// (delegation intent). When the client-auth method is client_secret_post,
+// credentials are injected into the form here (basic-auth credentials are set
+// on the request header instead).
+func buildExchangeForm(provider *oas.OAuth2TokenExchangeProvider, subjectToken, actorToken string, target *oauth2common.Target, method string) url.Values {
 	form := url.Values{}
 	form.Set(oas.OAuth2FormGrantType, oas.OAuth2GrantTypeTokenExchange)
 	form.Set(oas.OAuth2FormSubjectToken, subjectToken)
 	form.Set(oas.OAuth2FormSubjectTokenType, oas.OAuth2TokenTypeAccessToken)
+	if actorToken != "" {
+		form.Set(oas.OAuth2FormActorToken, actorToken)
+		form.Set(oas.OAuth2FormActorTokenType, resolveActorTokenType(provider.ActorToken))
+	}
 	if target.Audience != "" {
 		form.Set(oas.OAuth2FormAudience, target.Audience)
 		form.Set(oas.OAuth2FormResource, target.Audience)
@@ -380,6 +440,30 @@ func (m *Middleware) writeNoMatchingProviderResponse(w http.ResponseWriter, r *h
 		oas.OAuth2FieldError:            oas.OAuth2ErrNoMatchingProvider,
 		oas.OAuth2FieldErrorDescription: oe.Error(),
 		oas.OAuth2ClaimIss:              oe.Iss,
+	})
+}
+
+// writeActorNotAuthorizedResponse renders a 403 when requireMayAct is set and
+// the subject token's may_act does not authorize the configured actor.
+func (m *Middleware) writeActorNotAuthorizedResponse(w http.ResponseWriter, r *http.Request, e *oauth2common.ActorNotAuthorizedError) {
+	m.writeJSONError(w, r, http.StatusForbidden, [][2]string{
+		{oas.OAuth2FieldError, oas.OAuth2ErrActorNotAuthorized},
+		{oas.OAuth2FieldErrorDescription, e.Error()},
+	}, map[string]string{
+		oas.OAuth2FieldError:            oas.OAuth2ErrActorNotAuthorized,
+		oas.OAuth2FieldErrorDescription: e.Error(),
+	})
+}
+
+// writeMissingActorTokenResponse renders a 401 with an RFC 6750 invalid_token
+// Bearer challenge when a required actor-token header is absent.
+func (m *Middleware) writeMissingActorTokenResponse(w http.ResponseWriter, r *http.Request, e *oauth2common.MissingActorTokenError) {
+	m.writeJSONError(w, r, http.StatusUnauthorized, [][2]string{
+		{oas.OAuth2FieldError, oas.OAuth2ErrInvalidToken},
+		{oas.OAuth2FieldErrorDescription, e.Error()},
+	}, map[string]string{
+		oas.OAuth2FieldError:            oas.OAuth2ErrInvalidToken,
+		oas.OAuth2FieldErrorDescription: e.Error(),
 	})
 }
 

--- a/ee/middleware/oauth2tokenexchange/exchange.go
+++ b/ee/middleware/oauth2tokenexchange/exchange.go
@@ -52,8 +52,16 @@ func (m *Middleware) runExchange(r *http.Request, st *oauth2common.State) (oauth
 	out.Audience = target.Audience
 	out.Scopes = target.Scopes
 
-	exchanged, err := m.fetchExchangedToken(r, st, provider, target)
+	start := time.Now()
+	exchanged, cacheHit, err := m.fetchExchangedToken(r, st, provider, target)
+	out.CacheHit = cacheHit
+	out.Duration = time.Since(start)
 	if err != nil {
+		var fe *oauth2common.ExchangeFailedError
+		if errors.As(err, &fe) {
+			out.IdpErrorCode = fe.IdpError
+			out.IdpErrorDesc = fe.Description
+		}
 		return out, err
 	}
 	out.ExchangedToken = exchanged
@@ -93,11 +101,13 @@ func inboundRemaining(st *oauth2common.State) time.Duration {
 	return remaining
 }
 
-// fetchExchangedToken returns an exchanged token, using the cache when configured and enabled.
-func (m *Middleware) fetchExchangedToken(r *http.Request, st *oauth2common.State, provider *oas.OAuth2TokenExchangeProvider, target *oauth2common.Target) (string, error) {
+// fetchExchangedToken returns an exchanged token, using the cache when configured
+// and enabled. It also reports whether the token was served from cache. The
+// caller times the call for the duration metric.
+func (m *Middleware) fetchExchangedToken(r *http.Request, st *oauth2common.State, provider *oas.OAuth2TokenExchangeProvider, target *oauth2common.Target) (string, bool, error) {
 	if m.Cache == nil || provider.Cache == nil || !provider.Cache.Enabled {
 		token, _, err := m.exchangeAtIdP(r.Context(), provider, st.RawToken, target)
-		return token, err
+		return token, false, err
 	}
 
 	subjectID := subjectIDFromState(st)
@@ -126,7 +136,7 @@ func (m *Middleware) fetchExchangedToken(r *http.Request, st *oauth2common.State
 		return tok, cacheTTL(provider.Cache, expiresIn, inboundRemaining(st)), nil
 	})
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	if hit && ttlRemaining > 0 {
@@ -137,7 +147,7 @@ func (m *Middleware) fetchExchangedToken(r *http.Request, st *oauth2common.State
 		}).Debug("token exchange cache hit")
 	}
 
-	return token, nil
+	return token, hit, nil
 }
 
 // cacheTTL derives the cache entry lifetime for the provider's cache mode,

--- a/ee/middleware/oauth2tokenexchange/exchange.go
+++ b/ee/middleware/oauth2tokenexchange/exchange.go
@@ -303,6 +303,12 @@ func (m *Middleware) exchangeAtIdP(ctx context.Context, provider *oas.OAuth2Toke
 
 	form := buildExchangeForm(provider, subjectToken, actorToken, target, method)
 
+	if method == oas.OAuth2ClientAuthPrivateKeyJWT {
+		if err := m.addClientAssertion(form, provider); err != nil {
+			return "", 0, err
+		}
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.TokenEndpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		return "", 0, fmt.Errorf("building exchange request: %w", err)
@@ -417,8 +423,9 @@ func addPostClientCredentials(form url.Values, provider *oas.OAuth2TokenExchange
 // no-op for that method; basic (the default) sets the Authorization header.
 func applyClientAuth(req *http.Request, provider *oas.OAuth2TokenExchangeProvider, method string) error {
 	switch method {
-	case oas.OAuth2ClientAuthPost:
-		// credentials already injected into form
+	case oas.OAuth2ClientAuthPost, oas.OAuth2ClientAuthPrivateKeyJWT:
+		// credentials already injected into the form (client_secret_post or the
+		// signed private_key_jwt client_assertion).
 	case "", oas.OAuth2ClientAuthBasic:
 		if provider.ClientAuth != nil && provider.ClientAuth.ClientID != "" {
 			req.SetBasicAuth(provider.ClientAuth.ClientID, provider.ClientAuth.ClientSecret)

--- a/ee/middleware/oauth2tokenexchange/exchange_actor_test.go
+++ b/ee/middleware/oauth2tokenexchange/exchange_actor_test.go
@@ -1,0 +1,93 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+// formCapturingIdP returns a stub IdP that records the last exchange form body
+// and replies with a fixed exchanged token.
+func formCapturingIdP(t *testing.T, gotForm *url.Values) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		*gotForm = r.Form
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"exchanged","expires_in":300}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestExchangeAtIdP_SendsActorTokenWireShape(t *testing.T) {
+	var gotForm url.Values
+	srv := formCapturingIdP(t, &gotForm)
+	m := newTestMiddleware()
+	provider := &oas.OAuth2TokenExchangeProvider{TokenEndpoint: srv.URL}
+	target := &oauth2common.Target{Audience: "api.acme.internal"}
+	ctx := httptest.NewRequest(http.MethodGet, "/", nil).Context()
+
+	t.Run("with actor token sends actor_token + access_token type", func(t *testing.T) {
+		tok, _, err := m.exchangeAtIdP(ctx, provider, "subject-tok", "actor-tok", target)
+		require.NoError(t, err)
+		assert.Equal(t, "exchanged", tok)
+		assert.Equal(t, "actor-tok", gotForm.Get(oas.OAuth2FormActorToken))
+		assert.Equal(t, oas.OAuth2TokenTypeAccessToken, gotForm.Get(oas.OAuth2FormActorTokenType),
+			"default actor_token_type must be access_token for PingAM/PingOne compatibility")
+		assert.Equal(t, oas.OAuth2TokenTypeAccessToken, gotForm.Get(oas.OAuth2FormSubjectTokenType),
+			"subject_token_type is always access_token")
+	})
+
+	t.Run("impersonation omits actor fields", func(t *testing.T) {
+		_, _, err := m.exchangeAtIdP(ctx, provider, "subject-tok", "", target)
+		require.NoError(t, err)
+		assert.Empty(t, gotForm.Get(oas.OAuth2FormActorToken))
+		assert.Empty(t, gotForm.Get(oas.OAuth2FormActorTokenType))
+	})
+}
+
+func TestExchangeAtIdP_ActorTokenTypeJWTOverride(t *testing.T) {
+	var gotForm url.Values
+	srv := formCapturingIdP(t, &gotForm)
+	m := newTestMiddleware()
+	provider := &oas.OAuth2TokenExchangeProvider{
+		TokenEndpoint: srv.URL,
+		ActorToken: &oas.OAuth2ActorToken{
+			Source:         oas.OAuth2ActorSourceStatic,
+			ActorTokenType: oas.OAuth2TokenTypeJWT,
+			Static:         &oas.OAuth2ActorStatic{Token: "ignored-here"},
+		},
+	}
+	target := &oauth2common.Target{Audience: "aud"}
+	ctx := httptest.NewRequest(http.MethodGet, "/", nil).Context()
+
+	_, _, err := m.exchangeAtIdP(ctx, provider, "subject-tok", "actor-tok", target)
+	require.NoError(t, err)
+	assert.Equal(t, oas.OAuth2TokenTypeJWT, gotForm.Get(oas.OAuth2FormActorTokenType),
+		"actorTokenType override must reach the wire")
+	assert.Equal(t, oas.OAuth2TokenTypeAccessToken, gotForm.Get(oas.OAuth2FormSubjectTokenType),
+		"overriding actor_token_type must not change subject_token_type")
+}
+
+func TestAcquireActorToken_Header_RequiredAbsent_TypedMissingError(t *testing.T) {
+	m := newTestMiddleware()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	provider := &oas.OAuth2TokenExchangeProvider{
+		ActorToken: &oas.OAuth2ActorToken{Source: oas.OAuth2ActorSourceHeader},
+	}
+
+	_, _, err := m.acquireActorToken(r, provider)
+	require.Error(t, err)
+	assert.IsType(t, &oauth2common.MissingActorTokenError{}, err,
+		"a missing required actor header must be a typed error so it renders as 401 invalid_token")
+}

--- a/ee/middleware/oauth2tokenexchange/exchange_entra_obo_test.go
+++ b/ee/middleware/oauth2tokenexchange/exchange_entra_obo_test.go
@@ -1,0 +1,215 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+// errorIdP returns a stub IdP that replies with the given status and raw body.
+func errorIdP(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+const entraClaimsChallenge = `{"error":"interaction_required","error_description":"AADSTS50076 ...","claims":"{\"access_token\":{\"acrs\":{\"essential\":true,\"value\":\"c1\"}}}"}`
+
+// TestExchangeAtIdP_EntraOBO_StepUpChallenge pins that an Entra
+// interaction_required response becomes a typed StepUpRequiredError carrying the
+// raw claims challenge — not a generic exchange failure.
+func TestExchangeAtIdP_EntraOBO_StepUpChallenge(t *testing.T) {
+	srv := errorIdP(t, http.StatusBadRequest, entraClaimsChallenge)
+	m := newTestMiddleware()
+	provider := entraOBOProvider(srv.URL)
+	target := &oauth2common.Target{Audience: "api://orders", Scopes: []string{"Orders.Read"}}
+	ctx := httptest.NewRequest(http.MethodGet, "/", nil).Context()
+
+	_, _, err := m.exchangeAtIdP(ctx, provider, "user-assertion", "", target)
+	require.Error(t, err)
+	var stepUp *oauth2common.StepUpRequiredError
+	require.ErrorAs(t, err, &stepUp, "interaction_required must classify as step-up")
+	assert.Contains(t, stepUp.Claims, "acrs", "the raw claims challenge must be carried")
+}
+
+// TestExchangeAtIdP_EntraOBO_GenericErrorNotStepUp pins that an ordinary Entra
+// rejection (invalid_grant) is a normal exchange failure, not a step-up.
+func TestExchangeAtIdP_EntraOBO_GenericErrorNotStepUp(t *testing.T) {
+	srv := errorIdP(t, http.StatusBadRequest, `{"error":"invalid_grant","error_description":"expired"}`)
+	m := newTestMiddleware()
+	provider := entraOBOProvider(srv.URL)
+	target := &oauth2common.Target{Audience: "api://orders", Scopes: []string{"Orders.Read"}}
+	ctx := httptest.NewRequest(http.MethodGet, "/", nil).Context()
+
+	_, _, err := m.exchangeAtIdP(ctx, provider, "user-assertion", "", target)
+	require.Error(t, err)
+	var stepUp *oauth2common.StepUpRequiredError
+	assert.NotErrorAs(t, err, &stepUp, "invalid_grant must not be step-up")
+	var fe *oauth2common.ExchangeFailedError
+	assert.ErrorAs(t, err, &fe, "invalid_grant must be a normal exchange failure")
+}
+
+// TestExchangeAtIdP_RFC8693_InteractionRequiredIsExchangeFailed pins that the
+// step-up branch is Entra-only: an RFC 8693 provider seeing interaction_required
+// follows the normal failure path.
+func TestExchangeAtIdP_RFC8693_InteractionRequiredIsExchangeFailed(t *testing.T) {
+	srv := errorIdP(t, http.StatusBadRequest, entraClaimsChallenge)
+	m := newTestMiddleware()
+	provider := &oas.OAuth2TokenExchangeProvider{TokenEndpoint: srv.URL}
+	target := &oauth2common.Target{Audience: "aud"}
+	ctx := httptest.NewRequest(http.MethodGet, "/", nil).Context()
+
+	_, _, err := m.exchangeAtIdP(ctx, provider, "subject", "", target)
+	require.Error(t, err)
+	var stepUp *oauth2common.StepUpRequiredError
+	assert.NotErrorAs(t, err, &stepUp, "step-up detection must be scoped to the Entra flavour")
+}
+
+// TestParseExchangeResponse_IgnoresExtExpiresIn is a regression guard: Entra's
+// ext_expires_in (an outage-resilience window) must not drive the cache TTL —
+// only expires_in does.
+func TestParseExchangeResponse_IgnoresExtExpiresIn(t *testing.T) {
+	_, ttl, err := parseExchangeResponse([]byte(`{"access_token":"x","expires_in":60,"ext_expires_in":3600}`))
+	require.NoError(t, err)
+	assert.Equal(t, 60*time.Second, ttl, "ext_expires_in must not extend the cache TTL")
+}
+
+// TestWriteStepUpRequiredResponse pins the front-channel claims challenge: a 401
+// with a Bearer insufficient_claims challenge carrying the base64 (padded) claims
+// and the authorization_uri.
+func TestWriteStepUpRequiredResponse(t *testing.T) {
+	m := mwWithoutTykOps()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	claims := `{"access_token":{"acrs":{"essential":true,"value":"c1"}}}`
+
+	m.writeStepUpRequiredResponse(w, r, &oauth2common.StepUpRequiredError{
+		Claims:           claims,
+		AuthorizationURI: "https://login.microsoftonline.com/tid/oauth2/v2.0/authorize",
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	challenge := w.Header().Get(header.WWWAuthenticate)
+	assert.Contains(t, challenge, `error="insufficient_claims"`)
+	assert.Contains(t, challenge, `claims="`+base64.StdEncoding.EncodeToString([]byte(claims))+`"`)
+	assert.Contains(t, challenge, `authorization_uri="https://login.microsoftonline.com/tid/oauth2/v2.0/authorize"`)
+}
+
+func entraOBOProvider(tokenEndpoint string) *oas.OAuth2TokenExchangeProvider {
+	return &oas.OAuth2TokenExchangeProvider{
+		Flow:          oas.OAuth2FlowOnBehalfOf,
+		TokenEndpoint: tokenEndpoint,
+		ClientAuth:    &oas.OAuth2ClientAuth{Method: oas.OAuth2ClientAuthPost, ClientID: "app-id", ClientSecret: "app-secret"},
+	}
+}
+
+// TestExchangeAtIdP_EntraOBO_RequestShape pins the On-Behalf-Of wire shape: the
+// jwt-bearer grant, the inbound token as `assertion`, the requested_token_use
+// flag, the translated scope, and the absence of every RFC 8693-only parameter.
+func TestExchangeAtIdP_EntraOBO_RequestShape(t *testing.T) {
+	var gotForm url.Values
+	srv := formCapturingIdP(t, &gotForm)
+	m := newTestMiddleware()
+	provider := entraOBOProvider(srv.URL)
+	target := &oauth2common.Target{Audience: "api://orders", Scopes: []string{"Orders.Read"}}
+	ctx := httptest.NewRequest(http.MethodGet, "/", nil).Context()
+
+	tok, _, err := m.exchangeAtIdP(ctx, provider, "user-assertion", "", target)
+	require.NoError(t, err)
+	assert.Equal(t, "exchanged", tok)
+
+	// Present: the OBO parameters.
+	assert.Equal(t, oas.OAuth2GrantTypeJWTBearer, gotForm.Get(oas.OAuth2FormGrantType))
+	assert.Equal(t, "user-assertion", gotForm.Get(oas.OAuth2FormAssertion))
+	assert.Equal(t, oas.OAuth2RequestedTokenUseOBO, gotForm.Get(oas.OAuth2FormRequestedTokenUse))
+	assert.Equal(t, "api://orders/Orders.Read", gotForm.Get(oas.OAuth2FormScope))
+	assert.Equal(t, "app-id", gotForm.Get(oas.OAuth2FormClientID), "client_secret_post puts client_id in the body")
+	assert.Equal(t, "app-secret", gotForm.Get(oas.OAuth2FormClientSecret))
+
+	// Absent: every RFC 8693-only parameter.
+	assert.Empty(t, gotForm.Get(oas.OAuth2FormSubjectToken))
+	assert.Empty(t, gotForm.Get(oas.OAuth2FormSubjectTokenType))
+	assert.Empty(t, gotForm.Get(oas.OAuth2FormActorToken))
+	assert.Empty(t, gotForm.Get(oas.OAuth2FormActorTokenType))
+	assert.Empty(t, gotForm.Get(oas.OAuth2FormAudience))
+	assert.Empty(t, gotForm.Get(oas.OAuth2FormResource))
+}
+
+// TestExchangeAtIdP_EntraOBO_DefaultScope pins that an audience with no scopes
+// is sent as "<audience>/.default".
+func TestExchangeAtIdP_EntraOBO_DefaultScope(t *testing.T) {
+	var gotForm url.Values
+	srv := formCapturingIdP(t, &gotForm)
+	m := newTestMiddleware()
+	provider := entraOBOProvider(srv.URL)
+	target := &oauth2common.Target{Audience: "api://orders"}
+	ctx := httptest.NewRequest(http.MethodGet, "/", nil).Context()
+
+	_, _, err := m.exchangeAtIdP(ctx, provider, "user-assertion", "", target)
+	require.NoError(t, err)
+	assert.Equal(t, "api://orders/.default", gotForm.Get(oas.OAuth2FormScope))
+}
+
+// TestExchangeAtIdP_EntraOBO_BasicAuth pins that client_secret_basic sends the
+// gateway credentials in the Authorization header (not the body) under the OBO
+// flavour — the secret client-auth path is reused unchanged.
+func TestExchangeAtIdP_EntraOBO_BasicAuth(t *testing.T) {
+	var gotForm url.Values
+	var gotAuthUser, gotAuthPass string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.Form
+		gotAuthUser, gotAuthPass, _ = r.BasicAuth()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"exchanged","expires_in":300}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	m := newTestMiddleware()
+	provider := entraOBOProvider(srv.URL)
+	provider.ClientAuth.Method = oas.OAuth2ClientAuthBasic
+	target := &oauth2common.Target{Audience: "api://orders", Scopes: []string{"Orders.Read"}}
+	ctx := httptest.NewRequest(http.MethodGet, "/", nil).Context()
+
+	_, _, err := m.exchangeAtIdP(ctx, provider, "user-assertion", "", target)
+	require.NoError(t, err)
+	assert.Equal(t, "app-id", gotAuthUser)
+	assert.Equal(t, "app-secret", gotAuthPass)
+	assert.Empty(t, gotForm.Get(oas.OAuth2FormClientSecret), "basic auth must not also put the secret in the body")
+}
+
+// TestExchangeAtIdP_RFC8693_UnaffectedByFlavour is the regression guard: a
+// provider with no flavour still emits the RFC 8693 token-exchange grant.
+func TestExchangeAtIdP_RFC8693_UnaffectedByFlavour(t *testing.T) {
+	var gotForm url.Values
+	srv := formCapturingIdP(t, &gotForm)
+	m := newTestMiddleware()
+	provider := &oas.OAuth2TokenExchangeProvider{TokenEndpoint: srv.URL}
+	target := &oauth2common.Target{Audience: "api.acme.internal"}
+	ctx := httptest.NewRequest(http.MethodGet, "/", nil).Context()
+
+	_, _, err := m.exchangeAtIdP(ctx, provider, "subject-tok", "", target)
+	require.NoError(t, err)
+	assert.Equal(t, oas.OAuth2GrantTypeTokenExchange, gotForm.Get(oas.OAuth2FormGrantType))
+	assert.Equal(t, "subject-tok", gotForm.Get(oas.OAuth2FormSubjectToken))
+	assert.Equal(t, "api.acme.internal", gotForm.Get(oas.OAuth2FormAudience))
+	assert.Empty(t, gotForm.Get(oas.OAuth2FormAssertion))
+	assert.Empty(t, gotForm.Get(oas.OAuth2FormRequestedTokenUse))
+}

--- a/ee/middleware/oauth2tokenexchange/exchange_helpers_test.go
+++ b/ee/middleware/oauth2tokenexchange/exchange_helpers_test.go
@@ -69,38 +69,38 @@ func TestBuildExchangeForm(t *testing.T) {
 	target := &oauth2common.Target{Audience: "https://upstream", Scopes: []string{"read", "write"}}
 
 	t.Run("sets RFC 8693 grant + subject token fields", func(t *testing.T) {
-		form := buildExchangeForm(provider, "subject-token", target, oas.OAuth2ClientAuthBasic)
+		form := buildExchangeForm(provider, "subject-token", "", target, oas.OAuth2ClientAuthBasic)
 		assert.Equal(t, oas.OAuth2GrantTypeTokenExchange, form.Get(oas.OAuth2FormGrantType))
 		assert.Equal(t, "subject-token", form.Get(oas.OAuth2FormSubjectToken))
 		assert.Equal(t, oas.OAuth2TokenTypeAccessToken, form.Get(oas.OAuth2FormSubjectTokenType))
 	})
 
 	t.Run("audience populates both audience and resource", func(t *testing.T) {
-		form := buildExchangeForm(provider, "s", target, oas.OAuth2ClientAuthBasic)
+		form := buildExchangeForm(provider, "s", "", target, oas.OAuth2ClientAuthBasic)
 		assert.Equal(t, "https://upstream", form.Get(oas.OAuth2FormAudience))
 		assert.Equal(t, "https://upstream", form.Get(oas.OAuth2FormResource))
 	})
 
 	t.Run("scopes are space-joined and customParams included", func(t *testing.T) {
-		form := buildExchangeForm(provider, "s", target, oas.OAuth2ClientAuthBasic)
+		form := buildExchangeForm(provider, "s", "", target, oas.OAuth2ClientAuthBasic)
 		assert.Equal(t, "read write", form.Get(oas.OAuth2FormScope))
 		assert.Equal(t, "broker", form.Get("requested_issuer"))
 	})
 
 	t.Run("client_secret_post injects credentials into the form", func(t *testing.T) {
-		form := buildExchangeForm(provider, "s", target, oas.OAuth2ClientAuthPost)
+		form := buildExchangeForm(provider, "s", "", target, oas.OAuth2ClientAuthPost)
 		assert.Equal(t, "cid", form.Get(oas.OAuth2FormClientID))
 		assert.Equal(t, "secret", form.Get(oas.OAuth2FormClientSecret))
 	})
 
 	t.Run("basic auth keeps credentials out of the form", func(t *testing.T) {
-		form := buildExchangeForm(provider, "s", target, oas.OAuth2ClientAuthBasic)
+		form := buildExchangeForm(provider, "s", "", target, oas.OAuth2ClientAuthBasic)
 		assert.Empty(t, form.Get(oas.OAuth2FormClientID))
 		assert.Empty(t, form.Get(oas.OAuth2FormClientSecret))
 	})
 
 	t.Run("empty audience and scopes omit those fields", func(t *testing.T) {
-		form := buildExchangeForm(provider, "s", &oauth2common.Target{}, oas.OAuth2ClientAuthBasic)
+		form := buildExchangeForm(provider, "s", "", &oauth2common.Target{}, oas.OAuth2ClientAuthBasic)
 		assert.Empty(t, form.Get(oas.OAuth2FormAudience))
 		assert.Empty(t, form.Get(oas.OAuth2FormScope))
 	})
@@ -231,7 +231,7 @@ func TestExchangeAtIdP(t *testing.T) {
 			ClientAuth:    &oas.OAuth2ClientAuth{Method: oas.OAuth2ClientAuthBasic, ClientID: "cid", ClientSecret: "secret"},
 		}
 
-		tok, ttl, err := mwWithoutTykOps().exchangeAtIdP(context.Background(), provider, "inbound-token", target)
+		tok, ttl, err := mwWithoutTykOps().exchangeAtIdP(context.Background(), provider, "inbound-token", "", target)
 		require.NoError(t, err)
 		assert.Equal(t, "exchanged", tok)
 		assert.Equal(t, 120*time.Second, ttl)
@@ -250,7 +250,7 @@ func TestExchangeAtIdP(t *testing.T) {
 		defer idp.Close()
 
 		provider := &oas.OAuth2TokenExchangeProvider{Name: "p", TokenEndpoint: idp.URL}
-		_, _, err := mwWithoutTykOps().exchangeAtIdP(context.Background(), provider, "inbound", target)
+		_, _, err := mwWithoutTykOps().exchangeAtIdP(context.Background(), provider, "inbound", "", target)
 		require.Error(t, err)
 		var failed *oauth2common.ExchangeFailedError
 		require.ErrorAs(t, err, &failed)
@@ -259,7 +259,7 @@ func TestExchangeAtIdP(t *testing.T) {
 	})
 
 	t.Run("empty tokenEndpoint is rejected before any call", func(t *testing.T) {
-		_, _, err := mwWithoutTykOps().exchangeAtIdP(context.Background(), &oas.OAuth2TokenExchangeProvider{Name: "p"}, "inbound", target)
+		_, _, err := mwWithoutTykOps().exchangeAtIdP(context.Background(), &oas.OAuth2TokenExchangeProvider{Name: "p"}, "inbound", "", target)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "tokenEndpoint is empty")
 	})

--- a/ee/middleware/oauth2tokenexchange/exchange_helpers_test.go
+++ b/ee/middleware/oauth2tokenexchange/exchange_helpers_test.go
@@ -144,6 +144,14 @@ func TestApplyClientAuth(t *testing.T) {
 		assert.False(t, ok)
 	})
 
+	t.Run("private_key_jwt sets no Authorization header (assertion is in the form)", func(t *testing.T) {
+		req := newReq()
+		provider := &oas.OAuth2TokenExchangeProvider{ClientAuth: &oas.OAuth2ClientAuth{Method: oas.OAuth2ClientAuthPrivateKeyJWT, ClientID: "cid", CertID: "c1"}}
+		require.NoError(t, applyClientAuth(req, provider, oas.OAuth2ClientAuthPrivateKeyJWT))
+		_, _, ok := req.BasicAuth()
+		assert.False(t, ok, "private_key_jwt must not set basic auth")
+	})
+
 	t.Run("unsupported method is rejected", func(t *testing.T) {
 		req := newReq()
 		provider := &oas.OAuth2TokenExchangeProvider{ClientAuth: &oas.OAuth2ClientAuth{ClientID: "cid"}}

--- a/ee/middleware/oauth2tokenexchange/mayact.go
+++ b/ee/middleware/oauth2tokenexchange/mayact.go
@@ -1,0 +1,90 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+// mayActActorToken returns the actor-token value the may_act check needs to
+// resolve the actor identity WITHOUT touching the IdP: empty for the
+// client_credentials source (checkMayAct uses the configured clientId), the
+// request header value for header, the configured token for static. This lets
+// the may_act pre-flight run before the (possibly IdP-touching) acquisition.
+func (m *Middleware) mayActActorToken(r *http.Request, at *oas.OAuth2ActorToken) string {
+	if at == nil {
+		return ""
+	}
+	switch at.Source {
+	case oas.OAuth2ActorSourceHeader:
+		hdr, _, _ := actorHeaderSettings(at.Header)
+		return r.Header.Get(hdr)
+	case oas.OAuth2ActorSourceStatic:
+		if at.Static != nil {
+			return at.Static.Token
+		}
+	}
+	return ""
+}
+
+// checkMayAct enforces RFC 8693 §4.4 may_act when actorToken.requireMayAct is
+// true. It verifies the inbound subject token authorizes the configured actor
+// BEFORE the IdP call, returning an ActorNotAuthorizedError (rendered as 403)
+// on failure. A no-op when requireMayAct is unset/false or no actor is configured.
+//
+// The IdP remains the authoritative enforcement point — this is defence in
+// depth that turns an opaque IdP rejection into a clear gateway error. It only
+// fires when the operator opts in, because under central-policy delegation
+// (e.g. PingFederate TEPP) the subject token may legitimately carry no may_act.
+func (m *Middleware) checkMayAct(claims jwt.MapClaims, at *oas.OAuth2ActorToken, actorToken string) error {
+	if at == nil || at.RequireMayAct == nil || !*at.RequireMayAct {
+		return nil
+	}
+	expected := expectedActorID(at, actorToken)
+
+	raw, ok := claims[oas.OAuth2ClaimMayAct]
+	if !ok {
+		return &oauth2common.ActorNotAuthorizedError{
+			Reason: "subject token has no may_act claim; configured actor is not authorized to act on its behalf",
+		}
+	}
+	obj, ok := raw.(map[string]interface{})
+	if !ok {
+		return &oauth2common.ActorNotAuthorizedError{Reason: "subject token may_act claim is malformed"}
+	}
+	if expected == "" {
+		// Actor identity couldn't be determined (e.g. an opaque header/static
+		// actor token). Presence of may_act is the most we can assert.
+		return nil
+	}
+	for _, key := range []string{oas.OAuth2ClaimSub, oas.OAuth2ClaimClientID} {
+		if v, _ := obj[key].(string); v != "" && v == expected {
+			return nil
+		}
+	}
+	return &oauth2common.ActorNotAuthorizedError{
+		Reason: fmt.Sprintf("subject token may_act does not authorize actor %q", expected),
+	}
+}
+
+// expectedActorID resolves the identity the may_act claim must name. For the
+// client_credentials source it's the actor's client_id (what PingFederate /
+// PingAM record). For header/static it's the `sub` of the presented actor JWT,
+// decoded without signature verification — the IdP verifies it on the exchange.
+// Returns "" when the token isn't a parseable JWT (e.g. opaque).
+func expectedActorID(at *oas.OAuth2ActorToken, actorToken string) string {
+	if at.Source == oas.OAuth2ActorSourceClientCredentials && at.ClientCredentials != nil {
+		return at.ClientCredentials.ClientID
+	}
+	claims, err := oauth2common.ParseUnverifiedClaims(actorToken)
+	if err != nil {
+		return ""
+	}
+	return oauth2common.StringClaim(claims, oas.OAuth2ClaimSub)
+}

--- a/ee/middleware/oauth2tokenexchange/mayact_test.go
+++ b/ee/middleware/oauth2tokenexchange/mayact_test.go
@@ -1,0 +1,111 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+func ccActor(clientID string, requireMayAct *bool) *oas.OAuth2ActorToken {
+	return &oas.OAuth2ActorToken{
+		Source:            oas.OAuth2ActorSourceClientCredentials,
+		ClientCredentials: &oas.OAuth2ActorClientCredentials{ClientID: clientID},
+		RequireMayAct:     requireMayAct,
+	}
+}
+
+func signedJWT(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return s
+}
+
+func TestCheckMayAct_SkippedWhenNotRequired(t *testing.T) {
+	m := newTestMiddleware()
+	assert.NoError(t, m.checkMayAct(jwt.MapClaims{}, ccActor("gw-actor", nil), ""), "requireMayAct nil skips the check")
+	assert.NoError(t, m.checkMayAct(jwt.MapClaims{}, ccActor("gw-actor", boolPtr(false)), ""), "requireMayAct false skips the check")
+	assert.NoError(t, m.checkMayAct(jwt.MapClaims{}, nil, ""), "no actor block skips the check")
+}
+
+func TestCheckMayAct_CC_SubMatches(t *testing.T) {
+	m := newTestMiddleware()
+	claims := jwt.MapClaims{
+		oas.OAuth2ClaimMayAct: map[string]interface{}{oas.OAuth2ClaimSub: "tyk-gateway-actor"},
+	}
+	assert.NoError(t, m.checkMayAct(claims, ccActor("tyk-gateway-actor", boolPtr(true)), ""))
+}
+
+func TestCheckMayAct_CC_ClientIDMemberMatches(t *testing.T) {
+	m := newTestMiddleware()
+	claims := jwt.MapClaims{
+		oas.OAuth2ClaimMayAct: map[string]interface{}{oas.OAuth2ClaimClientID: "tyk-gateway-actor"},
+	}
+	assert.NoError(t, m.checkMayAct(claims, ccActor("tyk-gateway-actor", boolPtr(true)), ""))
+}
+
+func TestCheckMayAct_CC_AbsentClaimRejected(t *testing.T) {
+	m := newTestMiddleware()
+	err := m.checkMayAct(jwt.MapClaims{}, ccActor("tyk-gateway-actor", boolPtr(true)), "")
+	require.Error(t, err)
+	assert.IsType(t, &oauth2common.ActorNotAuthorizedError{}, err)
+}
+
+func TestCheckMayAct_CC_MismatchRejected(t *testing.T) {
+	m := newTestMiddleware()
+	claims := jwt.MapClaims{
+		oas.OAuth2ClaimMayAct: map[string]interface{}{oas.OAuth2ClaimSub: "some-other-actor"},
+	}
+	err := m.checkMayAct(claims, ccActor("tyk-gateway-actor", boolPtr(true)), "")
+	require.Error(t, err)
+	assert.IsType(t, &oauth2common.ActorNotAuthorizedError{}, err)
+}
+
+func TestCheckMayAct_MalformedClaimRejected(t *testing.T) {
+	m := newTestMiddleware()
+	claims := jwt.MapClaims{oas.OAuth2ClaimMayAct: "not-an-object"}
+	err := m.checkMayAct(claims, ccActor("tyk-gateway-actor", boolPtr(true)), "")
+	require.Error(t, err)
+	assert.IsType(t, &oauth2common.ActorNotAuthorizedError{}, err)
+}
+
+func TestCheckMayAct_HeaderSource_DecodesActorTokenSub(t *testing.T) {
+	m := newTestMiddleware()
+	actorTok := signedJWT(t, jwt.MapClaims{oas.OAuth2ClaimSub: "agent-7"})
+	at := &oas.OAuth2ActorToken{Source: oas.OAuth2ActorSourceHeader, RequireMayAct: boolPtr(true)}
+
+	ok := jwt.MapClaims{oas.OAuth2ClaimMayAct: map[string]interface{}{oas.OAuth2ClaimSub: "agent-7"}}
+	assert.NoError(t, m.checkMayAct(ok, at, actorTok), "may_act naming the actor token's sub authorizes it")
+
+	bad := jwt.MapClaims{oas.OAuth2ClaimMayAct: map[string]interface{}{oas.OAuth2ClaimSub: "agent-9"}}
+	assert.Error(t, m.checkMayAct(bad, at, actorTok))
+}
+
+func TestCheckMayAct_OpaqueActorToken_PresenceOnly(t *testing.T) {
+	m := newTestMiddleware()
+	at := &oas.OAuth2ActorToken{Source: oas.OAuth2ActorSourceHeader, RequireMayAct: boolPtr(true)}
+	// Opaque (non-JWT) actor token: actor id can't be resolved, so presence of
+	// may_act is accepted while absence is still rejected.
+	present := jwt.MapClaims{oas.OAuth2ClaimMayAct: map[string]interface{}{oas.OAuth2ClaimSub: "whoever"}}
+	assert.NoError(t, m.checkMayAct(present, at, "opaque-token"))
+	assert.Error(t, m.checkMayAct(jwt.MapClaims{}, at, "opaque-token"))
+}
+
+func TestExpectedActorID(t *testing.T) {
+	headerActor := &oas.OAuth2ActorToken{Source: oas.OAuth2ActorSourceHeader}
+	// client_credentials uses the configured client id, ignoring the token.
+	assert.Equal(t, "gw-actor", expectedActorID(ccActor("gw-actor", boolPtr(true)), ""))
+	// header/static decode the actor JWT's sub without verification.
+	assert.Equal(t, "alice", expectedActorID(headerActor, signedJWT(t, jwt.MapClaims{oas.OAuth2ClaimSub: "alice"})))
+	// opaque / unparseable tokens resolve to no identity.
+	assert.Empty(t, expectedActorID(headerActor, "not-a-jwt"))
+	assert.Empty(t, expectedActorID(headerActor, ""))
+}

--- a/ee/middleware/oauth2tokenexchange/middleware.go
+++ b/ee/middleware/oauth2tokenexchange/middleware.go
@@ -21,10 +21,13 @@ type Middleware struct {
 	Spec  model.MergedAPI
 	Base  BaseMiddleware
 	Cache *singleFlightCache
+	// actorCache holds client_credentials actor tokens for their own lifetime.
+	// Distinct from Cache (exchanged-token cache); see actor.go.
+	actorCache *actorTokenCache
 }
 
 func NewMiddleware(base BaseMiddleware, spec model.MergedAPI, cache oauth2common.ExchangeCache) *Middleware {
-	mw := &Middleware{Base: base, Spec: spec}
+	mw := &Middleware{Base: base, Spec: spec, actorCache: newActorTokenCache()}
 	if cache != nil {
 		mw.Cache = newSingleFlightCache(cache)
 	}
@@ -104,6 +107,10 @@ func (m *Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 		switch e := err.(type) {
 		case *oauth2common.NoMatchingProviderError:
 			m.writeNoMatchingProviderResponse(w, r, e)
+		case *oauth2common.ActorNotAuthorizedError:
+			m.writeActorNotAuthorizedResponse(w, r, e)
+		case *oauth2common.MissingActorTokenError:
+			m.writeMissingActorTokenResponse(w, r, e)
 		case *oauth2common.MisconfigError:
 			m.writeMisconfigResponse(w, r, e)
 		default:

--- a/ee/middleware/oauth2tokenexchange/middleware.go
+++ b/ee/middleware/oauth2tokenexchange/middleware.go
@@ -87,11 +87,19 @@ func (m *Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 	if st == nil || st.OASConfig == nil {
 		return nil, http.StatusOK
 	}
-	if st.OASConfig.TokenExchange == nil || !st.OASConfig.TokenExchange.Enabled {
+	cfg := st.OASConfig
+	if cfg.TokenExchange == nil || !cfg.TokenExchange.Enabled {
 		return nil, http.StatusOK
 	}
 
-	_, err := m.runExchange(r, st)
+	// No exchange fires for this request (no providers, or none targets it):
+	// a no-op with nothing to observe — no span, metric, log, or audit.
+	if len(cfg.TokenExchange.Providers) == 0 || !m.exchangeWouldFire(st, cfg) {
+		oauth2common.MarkExchangeDone(r)
+		return nil, http.StatusOK
+	}
+
+	_, err := m.runExchangeObserved(r, st)
 	if err != nil {
 		switch e := err.(type) {
 		case *oauth2common.NoMatchingProviderError:

--- a/ee/middleware/oauth2tokenexchange/middleware.go
+++ b/ee/middleware/oauth2tokenexchange/middleware.go
@@ -111,6 +111,8 @@ func (m *Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 			m.writeActorNotAuthorizedResponse(w, r, e)
 		case *oauth2common.MissingActorTokenError:
 			m.writeMissingActorTokenResponse(w, r, e)
+		case *oauth2common.StepUpRequiredError:
+			m.writeStepUpRequiredResponse(w, r, e)
 		case *oauth2common.MisconfigError:
 			m.writeMisconfigResponse(w, r, e)
 		default:

--- a/ee/middleware/oauth2tokenexchange/model.go
+++ b/ee/middleware/oauth2tokenexchange/model.go
@@ -4,6 +4,7 @@ package oauth2tokenexchange
 
 import (
 	"context"
+	"crypto/tls"
 	"time"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -38,6 +39,11 @@ type BaseMiddleware interface {
 	// histogram), labelled by outcome + provider. Cache-served actor tokens
 	// are not recorded — the counter reads actual IdP load.
 	RecordActorAcquisition(ctx context.Context, outcome, provider string, d time.Duration)
+
+	// GetClientCertificate returns the certificate (with private key) stored
+	// under certID, used to sign a private_key_jwt client assertion. Errors
+	// when the store is unavailable or the certificate is not found.
+	GetClientCertificate(certID string) (*tls.Certificate, error)
 }
 
 // EffectiveIdPTimeout returns d, falling back to DefaultIdPTimeout when d is zero.

--- a/ee/middleware/oauth2tokenexchange/model.go
+++ b/ee/middleware/oauth2tokenexchange/model.go
@@ -3,8 +3,10 @@
 package oauth2tokenexchange
 
 import (
+	"context"
 	"time"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/internal/model"
 )
 
@@ -19,6 +21,17 @@ const (
 // BaseMiddleware is the gateway.BaseMiddleware surface this package needs (avoids circular import).
 type BaseMiddleware interface {
 	model.LoggerProvider
+
+	// FireEvent emits a Tyk audit event for the request.
+	FireEvent(name apidef.TykEvent, meta interface{})
+
+	// RecordExchangeMetric records one exchange decision on the OTel
+	// instruments: the requests counter and the duration histogram, both
+	// labelled by outcome + provider.
+	RecordExchangeMetric(ctx context.Context, outcome, provider string, d time.Duration)
+
+	// RecordExchangeCacheHit increments the dedicated cache_hit counter.
+	RecordExchangeCacheHit(ctx context.Context, provider string)
 }
 
 // EffectiveIdPTimeout returns d, falling back to DefaultIdPTimeout when d is zero.

--- a/ee/middleware/oauth2tokenexchange/model.go
+++ b/ee/middleware/oauth2tokenexchange/model.go
@@ -32,6 +32,12 @@ type BaseMiddleware interface {
 
 	// RecordExchangeCacheHit increments the dedicated cache_hit counter.
 	RecordExchangeCacheHit(ctx context.Context, provider string)
+
+	// RecordActorAcquisition records one client-credentials actor-token
+	// acquisition on the actor instruments (requests counter + duration
+	// histogram), labelled by outcome + provider. Cache-served actor tokens
+	// are not recorded — the counter reads actual IdP load.
+	RecordActorAcquisition(ctx context.Context, outcome, provider string, d time.Duration)
 }
 
 // EffectiveIdPTimeout returns d, falling back to DefaultIdPTimeout when d is zero.

--- a/ee/middleware/oauth2tokenexchange/observability.go
+++ b/ee/middleware/oauth2tokenexchange/observability.go
@@ -26,6 +26,12 @@ const (
 	fieldAudience        = "oauth2_audience"
 	fieldScopesRequested = "oauth2_scopes_requested"
 
+	// Delegation (actor-token) fields. Carry only the actor's source and
+	// client/party azp — never the actor subject identity (act.sub) or token.
+	fieldActorSource        = "oauth2_actor_source"
+	fieldActorAzp           = "oauth2_actor_azp"
+	fieldDelegationObserved = "oauth2_delegation_observed"
+
 	truncatedSuffix = "...(truncated)"
 )
 
@@ -56,6 +62,14 @@ type EventPayload struct {
 	// Audience and ScopesRequested are the resolved exchange target.
 	Audience        string
 	ScopesRequested []string
+
+	// ActorSource is the configured actor-token source (client_credentials /
+	// header / static); empty for impersonation. ActorAzp is the actor client's
+	// authorized party. DelegationObserved is true when the exchanged token
+	// carried an RFC 8693 `act` claim (the IdP honoured delegation).
+	ActorSource        string
+	ActorAzp           string
+	DelegationObserved bool
 }
 
 // LogFields returns the structured log line for one exchange: the same bounded
@@ -96,6 +110,13 @@ func (p EventPayload) addOptional(m map[string]interface{}) {
 	}
 	if len(p.ScopesRequested) > 0 {
 		m[fieldScopesRequested] = p.ScopesRequested
+	}
+	if p.ActorSource != "" {
+		m[fieldActorSource] = p.ActorSource
+		m[fieldDelegationObserved] = p.DelegationObserved
+		if p.ActorAzp != "" {
+			m[fieldActorAzp] = p.ActorAzp
+		}
 	}
 	if p.Outcome == oauth2common.OutcomeIdPError {
 		if p.IdpError != "" {

--- a/ee/middleware/oauth2tokenexchange/observability.go
+++ b/ee/middleware/oauth2tokenexchange/observability.go
@@ -1,0 +1,133 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+// Observability field keys. These name the application, audience, scopes, and
+// outcome — never a person or a token. They are a cross-cut contract shared by
+// the structured log line and the audit-event meta, so they must not drift.
+const (
+	fieldTraceID         = "trace_id"
+	fieldAPIID           = "oauth2_api_id"
+	fieldProvider        = "oauth2_provider"
+	fieldOutcome         = "oauth2_exchange_outcome"
+	fieldCacheHit        = "oauth2_exchange_cache_hit"
+	fieldDurationMS      = "duration_ms"
+	fieldIdpError        = "oauth2_idp_error"
+	fieldIdpErrorDesc    = "oauth2_idp_error_description"
+	fieldSubjectAzp      = "oauth2_subject_azp"
+	fieldExchangedAzp    = "oauth2_exchanged_azp"
+	fieldAudience        = "oauth2_audience"
+	fieldScopesRequested = "oauth2_scopes_requested"
+
+	truncatedSuffix = "...(truncated)"
+)
+
+// EventPayload holds the bounded, non-PII signals describing one exchange
+// decision. Following the no-hashing identity model, it carries only the
+// client/party identifiers (which name an application, not a person) and never
+// the subject identity or token id (jti / sub / act.sub / the raw act map) —
+// those are dropped, not hashed. It holds no raw token material.
+type EventPayload struct {
+	TraceID  string
+	APIID    string
+	Provider string
+	Outcome  oauth2common.OutcomeKind
+	CacheHit bool
+	// DurationMS is the IdP round-trip latency in milliseconds; meaningful
+	// only when the outcome reached the IdP.
+	DurationMS int64
+
+	// IdpError / IdpErrorDesc are populated on an idp_error outcome. The
+	// description is length-capped before emission.
+	IdpError     string
+	IdpErrorDesc string
+
+	// SubjectAzp is the inbound token's authorized party (the calling app).
+	SubjectAzp string
+	// ExchangedAzp is the exchanged token's authorized party, when present.
+	ExchangedAzp string
+	// Audience and ScopesRequested are the resolved exchange target.
+	Audience        string
+	ScopesRequested []string
+}
+
+// LogFields returns the structured log line for one exchange: the same bounded
+// safe fields as the audit meta, plus the IdP round-trip duration. No subject
+// identity / token id / raw token is ever included.
+func (p EventPayload) LogFields() logrus.Fields {
+	f := logrus.Fields(p.AuditMeta())
+	f[fieldDurationMS] = p.DurationMS
+	return f
+}
+
+// AuditMeta returns the audit-event meta for one exchange — the same bounded
+// oauth2_-namespaced safe fields as the log line.
+func (p EventPayload) AuditMeta() map[string]interface{} {
+	m := map[string]interface{}{
+		fieldAPIID:    p.APIID,
+		fieldProvider: p.Provider,
+		fieldOutcome:  string(p.Outcome),
+		fieldCacheHit: p.CacheHit,
+	}
+	p.addOptional(m)
+	return m
+}
+
+// addOptional adds the present-only fields shared by LogFields and AuditMeta.
+func (p EventPayload) addOptional(m map[string]interface{}) {
+	if p.TraceID != "" {
+		m[fieldTraceID] = p.TraceID
+	}
+	if p.SubjectAzp != "" {
+		m[fieldSubjectAzp] = p.SubjectAzp
+	}
+	if p.ExchangedAzp != "" {
+		m[fieldExchangedAzp] = p.ExchangedAzp
+	}
+	if p.Audience != "" {
+		m[fieldAudience] = p.Audience
+	}
+	if len(p.ScopesRequested) > 0 {
+		m[fieldScopesRequested] = p.ScopesRequested
+	}
+	if p.Outcome == oauth2common.OutcomeIdPError {
+		if p.IdpError != "" {
+			m[fieldIdpError] = p.IdpError
+		}
+		if p.IdpErrorDesc != "" {
+			m[fieldIdpErrorDesc] = capIdPErrorDesc(p.IdpErrorDesc)
+		}
+	}
+}
+
+// AuditDecision returns the audit event type for this outcome and whether an
+// audit event is emitted at all. ok audits as OAuth2ExchangeSucceeded;
+// idp_error and no_matching_provider audit as OAuth2ExchangeFailed (the outcome
+// distinguishes them); misconfig is an operator fault, not an authorization
+// decision, so it is not audited (it still emits a metric and a log line).
+func (p EventPayload) AuditDecision() (event.Event, bool) {
+	switch p.Outcome {
+	case oauth2common.OutcomeOK:
+		return event.OAuth2ExchangeSucceeded, true
+	case oauth2common.OutcomeIdPError, oauth2common.OutcomeNoMatchingProvider:
+		return event.OAuth2ExchangeFailed, true
+	default:
+		return "", false
+	}
+}
+
+// capIdPErrorDesc bounds an IdP error description so an oversized (or hostile)
+// IdP body cannot bloat a log line or audit event.
+func capIdPErrorDesc(s string) string {
+	if len(s) <= oauth2common.MaxIdPErrorBodyBytes {
+		return s
+	}
+	return s[:oauth2common.MaxIdPErrorBodyBytes] + truncatedSuffix
+}

--- a/ee/middleware/oauth2tokenexchange/observability.go
+++ b/ee/middleware/oauth2tokenexchange/observability.go
@@ -99,10 +99,10 @@ func (p EventPayload) addOptional(m map[string]interface{}) {
 	}
 	if p.Outcome == oauth2common.OutcomeIdPError {
 		if p.IdpError != "" {
-			m[fieldIdpError] = p.IdpError
+			m[fieldIdpError] = capIdPErrorField(p.IdpError)
 		}
 		if p.IdpErrorDesc != "" {
-			m[fieldIdpErrorDesc] = capIdPErrorDesc(p.IdpErrorDesc)
+			m[fieldIdpErrorDesc] = capIdPErrorField(p.IdpErrorDesc)
 		}
 	}
 }
@@ -123,9 +123,9 @@ func (p EventPayload) AuditDecision() (event.Event, bool) {
 	}
 }
 
-// capIdPErrorDesc bounds an IdP error description so an oversized (or hostile)
-// IdP body cannot bloat a log line or audit event.
-func capIdPErrorDesc(s string) string {
+// capIdPErrorField bounds an IdP-supplied error code or description so an
+// oversized (or hostile) IdP body cannot bloat a log line or audit event.
+func capIdPErrorField(s string) string {
 	if len(s) <= oauth2common.MaxIdPErrorBodyBytes {
 		return s
 	}

--- a/ee/middleware/oauth2tokenexchange/observability_emit.go
+++ b/ee/middleware/oauth2tokenexchange/observability_emit.go
@@ -65,18 +65,21 @@ func (m *Middleware) emitObservability(ctx context.Context, st *oauth2common.Sta
 	}
 
 	payload := EventPayload{
-		TraceID:         tykotel.ExtractTraceID(ctx),
-		APIID:           st.APIID,
-		Provider:        out.ProviderName,
-		Outcome:         outcome,
-		CacheHit:        out.CacheHit,
-		DurationMS:      out.Duration.Milliseconds(),
-		IdpError:        out.IdpErrorCode,
-		IdpErrorDesc:    out.IdpErrorDesc,
-		SubjectAzp:      oauth2common.StringClaim(st.Claims, oas.OAuth2ClaimAzp),
-		ExchangedAzp:    exchangedAzp(out.ExchangedToken),
-		Audience:        out.Audience,
-		ScopesRequested: out.Scopes,
+		TraceID:            tykotel.ExtractTraceID(ctx),
+		APIID:              st.APIID,
+		Provider:           out.ProviderName,
+		Outcome:            outcome,
+		CacheHit:           out.CacheHit,
+		DurationMS:         out.Duration.Milliseconds(),
+		IdpError:           out.IdpErrorCode,
+		IdpErrorDesc:       out.IdpErrorDesc,
+		SubjectAzp:         oauth2common.StringClaim(st.Claims, oas.OAuth2ClaimAzp),
+		ExchangedAzp:       exchangedAzp(out.ExchangedToken),
+		Audience:           out.Audience,
+		ScopesRequested:    out.Scopes,
+		ActorSource:        out.ActorSource,
+		ActorAzp:           out.ActorAzp,
+		DelegationObserved: delegationObserved(out.ExchangedToken),
 	}
 
 	m.Logger().WithFields(payload.LogFields()).Info("oauth2 token exchange")
@@ -93,6 +96,24 @@ func cacheStatus(hit bool) string {
 	}
 	return cacheStatusMiss
 }
+
+// delegationObserved reports whether the exchanged token carries an RFC 8693
+// `act` claim — i.e. the IdP honoured delegation and recorded the actor in the
+// chain. Best-effort; false when the token is absent or unparseable.
+func delegationObserved(token string) bool {
+	if token == "" {
+		return false
+	}
+	claims, err := oauth2common.ParseUnverifiedClaims(token)
+	if err != nil {
+		return false
+	}
+	_, ok := claims[actClaim]
+	return ok
+}
+
+// actClaim is the RFC 8693 §4.1 delegation claim key on an exchanged token.
+const actClaim = "act"
 
 // exchangedAzp best-effort reads the authorized party of the exchanged token,
 // for the non-PII oauth2_exchanged_azp field. Returns "" when absent or

--- a/ee/middleware/oauth2tokenexchange/observability_emit.go
+++ b/ee/middleware/oauth2tokenexchange/observability_emit.go
@@ -1,0 +1,109 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"context"
+	"net/http"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+	tykotel "github.com/TykTechnologies/tyk/internal/otel"
+)
+
+// tracerName identifies this package's tracer in the OTel registry.
+const tracerName = "github.com/TykTechnologies/tyk/ee/middleware/oauth2tokenexchange"
+
+// exchangeSpanName is the dedicated span opened around the exchange step. It
+// joins the request's existing trace — it does not start a new one.
+const exchangeSpanName = "oauth2.exchange"
+
+// Span attribute keys and cache-status values. Attributes carry only bounded
+// provider / outcome / cache-status values — never a token or an identity
+// (client identifiers live on logs + audit, not on the span).
+const (
+	spanAttrProvider    = "oauth2.exchange.provider"
+	spanAttrOutcome     = "oauth2.exchange.outcome"
+	spanAttrCacheStatus = "oauth2.exchange.cache_status"
+
+	cacheStatusHit  = "hit"
+	cacheStatusMiss = "miss"
+)
+
+// runExchangeObserved opens the oauth2.exchange span around the exchange step,
+// runs it with the span's context (so the IdP round-trip nests as a child
+// client span on a cache miss), stamps the bounded span attributes, and emits
+// the metric / structured log / audit event. The span joins the request's
+// existing trace rather than starting a new one.
+func (m *Middleware) runExchangeObserved(r *http.Request, st *oauth2common.State) (oauth2common.Outcome, error) {
+	ctx, span := otel.Tracer(tracerName).Start(r.Context(), exchangeSpanName)
+	defer span.End()
+
+	out, err := m.runExchange(r.WithContext(ctx), st)
+	outcome := oauth2common.ClassifyExchangeOutcome(err)
+
+	span.SetAttributes(
+		attribute.String(spanAttrProvider, out.ProviderName),
+		attribute.String(spanAttrOutcome, string(outcome)),
+		attribute.String(spanAttrCacheStatus, cacheStatus(out.CacheHit)),
+	)
+
+	m.emitObservability(ctx, st, out, outcome)
+	return out, err
+}
+
+// emitObservability records the exchange metric, writes the structured log
+// line, and fires the audit event (when the outcome is audited).
+func (m *Middleware) emitObservability(ctx context.Context, st *oauth2common.State, out oauth2common.Outcome, outcome oauth2common.OutcomeKind) {
+	m.Base.RecordExchangeMetric(ctx, string(outcome), out.ProviderName, out.Duration)
+	if out.CacheHit {
+		m.Base.RecordExchangeCacheHit(ctx, out.ProviderName)
+	}
+
+	payload := EventPayload{
+		TraceID:         tykotel.ExtractTraceID(ctx),
+		APIID:           st.APIID,
+		Provider:        out.ProviderName,
+		Outcome:         outcome,
+		CacheHit:        out.CacheHit,
+		DurationMS:      out.Duration.Milliseconds(),
+		IdpError:        out.IdpErrorCode,
+		IdpErrorDesc:    out.IdpErrorDesc,
+		SubjectAzp:      oauth2common.StringClaim(st.Claims, oas.OAuth2ClaimAzp),
+		ExchangedAzp:    exchangedAzp(out.ExchangedToken),
+		Audience:        out.Audience,
+		ScopesRequested: out.Scopes,
+	}
+
+	m.Logger().WithFields(payload.LogFields()).Info("oauth2 token exchange")
+
+	if ev, audited := payload.AuditDecision(); audited {
+		m.Base.FireEvent(apidef.TykEvent(ev), payload.AuditMeta())
+	}
+}
+
+// cacheStatus maps the cache-hit flag to the span's cache_status value.
+func cacheStatus(hit bool) string {
+	if hit {
+		return cacheStatusHit
+	}
+	return cacheStatusMiss
+}
+
+// exchangedAzp best-effort reads the authorized party of the exchanged token,
+// for the non-PII oauth2_exchanged_azp field. Returns "" when absent or
+// unparseable — the field then stays absent rather than empty.
+func exchangedAzp(token string) string {
+	if token == "" {
+		return ""
+	}
+	claims, err := oauth2common.ParseUnverifiedClaims(token)
+	if err != nil {
+		return ""
+	}
+	return oauth2common.StringClaim(claims, oas.OAuth2ClaimAzp)
+}

--- a/ee/middleware/oauth2tokenexchange/observability_emit_test.go
+++ b/ee/middleware/oauth2tokenexchange/observability_emit_test.go
@@ -1,0 +1,316 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/model"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+// --- fakes ---
+
+type recordedMetric struct {
+	outcome  string
+	provider string
+	duration time.Duration
+}
+
+type recordedEvent struct {
+	name apidef.TykEvent
+	meta map[string]interface{}
+}
+
+type fakeBase struct {
+	logger    *logrus.Entry
+	metrics   []recordedMetric
+	cacheHits []string
+	events    []recordedEvent
+}
+
+func newFakeBase() *fakeBase {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return &fakeBase{logger: logrus.NewEntry(l)}
+}
+
+func (f *fakeBase) Logger() *logrus.Entry { return f.logger }
+
+func (f *fakeBase) FireEvent(name apidef.TykEvent, meta interface{}) {
+	m, _ := meta.(map[string]interface{})
+	f.events = append(f.events, recordedEvent{name: name, meta: m})
+}
+
+func (f *fakeBase) RecordExchangeMetric(_ context.Context, outcome, provider string, d time.Duration) {
+	f.metrics = append(f.metrics, recordedMetric{outcome: outcome, provider: provider, duration: d})
+}
+
+func (f *fakeBase) RecordExchangeCacheHit(_ context.Context, provider string) {
+	f.cacheHits = append(f.cacheHits, provider)
+}
+
+// --- helpers ---
+
+func installRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return sr
+}
+
+// idpToken returns a signed JWT carrying the given azp, so the exchanged-token
+// azp can be read back by the observability path.
+func idpToken(t *testing.T, azp string) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{oas.OAuth2ClaimAzp: azp})
+	s, err := tok.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return s
+}
+
+func okIdP(t *testing.T, delay time.Duration, azp string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(delay)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": idpToken(t, azp),
+			"expires_in":   3600,
+		})
+	}))
+}
+
+func erroringIdP() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "subject token expired",
+		})
+	}))
+}
+
+func provider(name, endpoint string, cacheEnabled bool) oas.OAuth2TokenExchangeProvider {
+	p := oas.OAuth2TokenExchangeProvider{
+		Name:          name,
+		Issuers:       []string{"https://issuer.example"},
+		TokenEndpoint: endpoint,
+		DefaultTarget: &oas.OAuth2DefaultTarget{Audience: "https://api.internal", Scopes: []string{"read"}},
+	}
+	if cacheEnabled {
+		p.Cache = &oas.OAuth2ExchangeCache{Enabled: true}
+	}
+	return p
+}
+
+func exchangeState(p oas.OAuth2TokenExchangeProvider) *oauth2common.State {
+	return &oauth2common.State{
+		Claims: jwt.MapClaims{
+			oas.OAuth2ClaimIss: "https://issuer.example",
+			oas.OAuth2ClaimAzp: "agent-app",
+		},
+		RawToken: "inbound-token",
+		OASConfig: &oas.OAuth2{
+			TokenExchange: &oas.OAuth2TokenExchange{Enabled: true, Providers: []oas.OAuth2TokenExchangeProvider{p}},
+		},
+		APIID: "api-1",
+	}
+}
+
+func newMiddleware(base BaseMiddleware, cache oauth2common.ExchangeCache) *Middleware {
+	spec := model.MergedAPI{
+		APIDefinition: &apidef.APIDefinition{},
+		OAS:           &oas.OAS{},
+	}
+	spec.APIDefinition.Proxy.ListenPath = "/api/"
+	return NewMiddleware(base, spec, cache)
+}
+
+// processInTrace drives ProcessRequest with the request already inside a trace,
+// returning the inbound trace id and the ended spans.
+func processInTrace(t *testing.T, m *Middleware, st *oauth2common.State, sr *tracetest.SpanRecorder) string {
+	t.Helper()
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "request")
+	r := httptest.NewRequest(http.MethodPost, "http://gw/api/tools", nil).WithContext(ctx)
+	oauth2common.SetState(r, st)
+
+	_, _ = m.ProcessRequest(httptest.NewRecorder(), r, nil)
+	parent.End()
+	return parent.SpanContext().TraceID().String()
+}
+
+func findSpan(spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	for _, s := range spans {
+		if s.Name() == name {
+			return s
+		}
+	}
+	return nil
+}
+
+func spanAttr(s sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// --- tests ---
+
+// TestProcessRequest_SuccessSpanMetricAudit pins TC2, TC7, TC10, TC11, TC15:
+// a cache-miss success opens a child oauth2.exchange span that joins the
+// request's trace, nests the IdP client span under it, records the requests
+// metric with an IdP-touching duration, and fires the Succeeded audit event —
+// with only bounded values on the span.
+func TestProcessRequest_SuccessSpanMetricAudit(t *testing.T) {
+	sr := installRecorder(t)
+	idp := okIdP(t, 60*time.Millisecond, "downstream-app")
+	t.Cleanup(idp.Close)
+
+	base := newFakeBase()
+	m := newMiddleware(base, nil)
+	traceID := processInTrace(t, m, exchangeState(provider("corpIdP", idp.URL, false)), sr)
+
+	spans := sr.Ended()
+	exch := findSpan(spans, exchangeSpanName)
+	require.NotNil(t, exch, "oauth2.exchange span must be opened")
+
+	// TC10: the span joined the request's trace, not a new one.
+	assert.Equal(t, traceID, exch.SpanContext().TraceID().String())
+
+	// TC11: a child IdP client span nests under the exchange span.
+	idpSpan := findSpan(spans, "oauth2.idp POST")
+	require.NotNil(t, idpSpan, "cache miss must emit a child IdP client span")
+	assert.Equal(t, exch.SpanContext().SpanID(), idpSpan.Parent().SpanID())
+
+	// TC15: only bounded provider/outcome/cache_status attributes; no identity.
+	gotProvider, _ := spanAttr(exch, spanAttrProvider)
+	gotOutcome, _ := spanAttr(exch, spanAttrOutcome)
+	gotCache, _ := spanAttr(exch, spanAttrCacheStatus)
+	assert.Equal(t, "corpIdP", gotProvider)
+	assert.Equal(t, "ok", gotOutcome)
+	assert.Equal(t, cacheStatusMiss, gotCache)
+	for _, kv := range exch.Attributes() {
+		assert.Contains(t, []string{spanAttrProvider, spanAttrOutcome, spanAttrCacheStatus}, string(kv.Key))
+	}
+
+	// TC2: one requests metric with a real (IdP) duration.
+	require.Len(t, base.metrics, 1)
+	assert.Equal(t, "ok", base.metrics[0].outcome)
+	assert.Equal(t, "corpIdP", base.metrics[0].provider)
+	assert.Greater(t, base.metrics[0].duration, time.Duration(0))
+	assert.Empty(t, base.cacheHits)
+
+	// TC7: one Succeeded audit event with the safe meta and no identity.
+	require.Len(t, base.events, 1)
+	assert.Equal(t, apidef.TykEvent(event.OAuth2ExchangeSucceeded), base.events[0].name)
+	meta := base.events[0].meta
+	assert.Equal(t, "ok", meta["oauth2_exchange_outcome"])
+	assert.Equal(t, "agent-app", meta["oauth2_subject_azp"])
+	assert.Equal(t, "downstream-app", meta["oauth2_exchanged_azp"])
+	assert.NotContains(t, meta, "oauth2_subject_jti")
+	assert.NotContains(t, meta, "sub")
+}
+
+// TestProcessRequest_IdPErrorEmitsFailed pins TC3/TC8: an IdP rejection records
+// the idp_error metric and fires the Failed audit event with the IdP code.
+func TestProcessRequest_IdPErrorEmitsFailed(t *testing.T) {
+	sr := installRecorder(t)
+	idp := erroringIdP()
+	t.Cleanup(idp.Close)
+
+	base := newFakeBase()
+	m := newMiddleware(base, nil)
+	processInTrace(t, m, exchangeState(provider("corpIdP", idp.URL, false)), sr)
+
+	require.Len(t, base.metrics, 1)
+	assert.Equal(t, "idp_error", base.metrics[0].outcome)
+
+	require.Len(t, base.events, 1)
+	assert.Equal(t, apidef.TykEvent(event.OAuth2ExchangeFailed), base.events[0].name)
+	assert.Equal(t, "idp_error", base.events[0].meta["oauth2_exchange_outcome"])
+	assert.Equal(t, "invalid_grant", base.events[0].meta["oauth2_idp_error"])
+
+	exch := findSpan(sr.Ended(), exchangeSpanName)
+	require.NotNil(t, exch)
+	gotOutcome, _ := spanAttr(exch, spanAttrOutcome)
+	assert.Equal(t, "idp_error", gotOutcome)
+}
+
+// TestProcessRequest_NoMatchingProvider pins TC4: a token from an unconfigured
+// issuer records the no_matching_provider metric and audits as Failed.
+func TestProcessRequest_NoMatchingProvider(t *testing.T) {
+	sr := installRecorder(t)
+	idp := okIdP(t, 0, "x")
+	t.Cleanup(idp.Close)
+
+	base := newFakeBase()
+	m := newMiddleware(base, nil)
+	st := exchangeState(provider("corpIdP", idp.URL, false))
+	st.Claims[oas.OAuth2ClaimIss] = "https://unconfigured.example"
+	processInTrace(t, m, st, sr)
+
+	require.Len(t, base.metrics, 1)
+	assert.Equal(t, "no_matching_provider", base.metrics[0].outcome)
+
+	require.Len(t, base.events, 1)
+	assert.Equal(t, apidef.TykEvent(event.OAuth2ExchangeFailed), base.events[0].name)
+	assert.Equal(t, "no_matching_provider", base.events[0].meta["oauth2_exchange_outcome"])
+}
+
+// TestProcessRequest_CacheHitOmitsIdPSpan pins TC9/TC12: a warm second request
+// is served from cache — no child IdP span, cache_status=hit, the dedicated
+// cache_hit counter increments, and it still audits as a success.
+func TestProcessRequest_CacheHitOmitsIdPSpan(t *testing.T) {
+	idp := okIdP(t, 0, "downstream-app")
+	t.Cleanup(idp.Close)
+
+	base := newFakeBase()
+	m := newMiddleware(base, &fakeCache{items: map[string]string{}})
+	p := provider("corpIdP", idp.URL, true)
+
+	// Warm the cache (miss), then a second identical request (hit).
+	sr1 := installRecorder(t)
+	processInTrace(t, m, exchangeState(p), sr1)
+	require.NotNil(t, findSpan(sr1.Ended(), "oauth2.idp POST"), "first request is a miss")
+
+	sr2 := installRecorder(t)
+	processInTrace(t, m, exchangeState(p), sr2)
+
+	// No IdP round-trip on the hit.
+	assert.Nil(t, findSpan(sr2.Ended(), "oauth2.idp POST"), "cache hit must not call the IdP")
+	exch := findSpan(sr2.Ended(), exchangeSpanName)
+	require.NotNil(t, exch)
+	gotCache, _ := spanAttr(exch, spanAttrCacheStatus)
+	assert.Equal(t, cacheStatusHit, gotCache)
+
+	// The hit incremented the dedicated cache_hit counter and audited success.
+	require.Len(t, base.cacheHits, 1)
+	assert.Equal(t, "corpIdP", base.cacheHits[0])
+	last := base.metrics[len(base.metrics)-1]
+	assert.Equal(t, "ok", last.outcome)
+	lastEvent := base.events[len(base.events)-1]
+	assert.Equal(t, apidef.TykEvent(event.OAuth2ExchangeSucceeded), lastEvent.name)
+	assert.Equal(t, true, lastEvent.meta["oauth2_exchange_cache_hit"])
+}

--- a/ee/middleware/oauth2tokenexchange/observability_emit_test.go
+++ b/ee/middleware/oauth2tokenexchange/observability_emit_test.go
@@ -40,10 +40,11 @@ type recordedEvent struct {
 }
 
 type fakeBase struct {
-	logger    *logrus.Entry
-	metrics   []recordedMetric
-	cacheHits []string
-	events    []recordedEvent
+	logger       *logrus.Entry
+	metrics      []recordedMetric
+	actorMetrics []recordedMetric
+	cacheHits    []string
+	events       []recordedEvent
 }
 
 func newFakeBase() *fakeBase {
@@ -65,6 +66,10 @@ func (f *fakeBase) RecordExchangeMetric(_ context.Context, outcome, provider str
 
 func (f *fakeBase) RecordExchangeCacheHit(_ context.Context, provider string) {
 	f.cacheHits = append(f.cacheHits, provider)
+}
+
+func (f *fakeBase) RecordActorAcquisition(_ context.Context, outcome, provider string, d time.Duration) {
+	f.actorMetrics = append(f.actorMetrics, recordedMetric{outcome: outcome, provider: provider, duration: d})
 }
 
 // --- helpers ---
@@ -313,4 +318,39 @@ func TestProcessRequest_CacheHitOmitsIdPSpan(t *testing.T) {
 	lastEvent := base.events[len(base.events)-1]
 	assert.Equal(t, apidef.TykEvent(event.OAuth2ExchangeSucceeded), lastEvent.name)
 	assert.Equal(t, true, lastEvent.meta["oauth2_exchange_cache_hit"])
+}
+
+// TestProcessRequest_ActorDelegation_MetricAndFields pins the actor-flow
+// observability: a client_credentials acquisition records the actor metric
+// once (ok), and the exchange's log/audit meta carries the delegation fields
+// (source + actor azp + delegation_observed) — never the actor's subject.
+func TestProcessRequest_ActorDelegation_MetricAndFields(t *testing.T) {
+	sr := installRecorder(t)
+	idp := okIdP(t, 0, "downstream-app")
+	t.Cleanup(idp.Close)
+
+	actorIdP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "actor-tok", "expires_in": 3600})
+	}))
+	t.Cleanup(actorIdP.Close)
+
+	base := newFakeBase()
+	m := newMiddleware(base, nil)
+	p := provider("corpIdP", idp.URL, false)
+	p.ActorToken = &oas.OAuth2ActorToken{
+		Source:            oas.OAuth2ActorSourceClientCredentials,
+		ClientCredentials: &oas.OAuth2ActorClientCredentials{TokenEndpoint: actorIdP.URL, ClientID: "tyk-gateway-actor"},
+	}
+	processInTrace(t, m, exchangeState(p), sr)
+
+	require.Len(t, base.actorMetrics, 1, "the CC actor acquisition must record one actor metric")
+	assert.Equal(t, "ok", base.actorMetrics[0].outcome)
+	assert.Equal(t, "corpIdP", base.actorMetrics[0].provider)
+
+	require.Len(t, base.events, 1)
+	meta := base.events[0].meta
+	assert.Equal(t, "client_credentials", meta["oauth2_actor_source"])
+	assert.Equal(t, "tyk-gateway-actor", meta["oauth2_actor_azp"])
+	assert.Equal(t, false, meta["oauth2_delegation_observed"], "the okIdP token carries no act claim")
+	assert.NotContains(t, meta, "oauth2_act_sub")
 }

--- a/ee/middleware/oauth2tokenexchange/observability_emit_test.go
+++ b/ee/middleware/oauth2tokenexchange/observability_emit_test.go
@@ -4,6 +4,7 @@ package oauth2tokenexchange
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/event"
 	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/internal/oauth2common"
@@ -110,6 +112,24 @@ func erroringIdP() *httptest.Server {
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"error":             "invalid_grant",
 			"error_description": "subject token expired",
+		})
+	}))
+}
+
+// stepUpClaims is the raw claims challenge an On-Behalf-Of IdP returns under a
+// Conditional Access policy.
+const stepUpClaims = `{"access_token":{"acrs":{"essential":true,"value":"c1"}}}`
+
+// stepUpIdP returns a stub that answers an On-Behalf-Of exchange with an
+// interaction_required claims challenge instead of a token.
+func stepUpIdP() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             oas.OAuth2ErrInteractionRequired,
+			"error_description": "AADSTS50076 multi-factor authentication required",
+			"claims":            stepUpClaims,
+			"authorization_uri": "https://login.microsoftonline.com/tid/oauth2/v2.0/authorize",
 		})
 	}))
 }
@@ -261,6 +281,48 @@ func TestProcessRequest_IdPErrorEmitsFailed(t *testing.T) {
 	require.NotNil(t, exch)
 	gotOutcome, _ := spanAttr(exch, spanAttrOutcome)
 	assert.Equal(t, "idp_error", gotOutcome)
+}
+
+// TestProcessRequest_StepUpRequired pins the On-Behalf-Of claims-challenge path
+// end to end: an interaction_required IdP response is rendered to the caller as a
+// terminal 401 insufficient_claims challenge (carrying the base64 claims), is
+// classified as step_up_required — not idp_error — and, with caching enabled, is
+// never written to the exchanged-token cache.
+func TestProcessRequest_StepUpRequired(t *testing.T) {
+	sr := installRecorder(t)
+	idp := stepUpIdP()
+	t.Cleanup(idp.Close)
+
+	base := newFakeBase()
+	fc := &fakeCache{items: map[string]string{}}
+	m := newMiddleware(base, fc)
+
+	p := provider("corpIdP", idp.URL, true)
+	p.Flow = oas.OAuth2FlowOnBehalfOf
+
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "http://gw/api/tools", nil)
+	oauth2common.SetState(r, exchangeState(p))
+
+	err, _ := m.ProcessRequest(rec, r, nil)
+
+	// Rendered as a terminal 401 challenge, not proxied upstream.
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	challenge := rec.Header().Get(header.WWWAuthenticate)
+	assert.Contains(t, challenge, `error="insufficient_claims"`)
+	assert.Contains(t, challenge, `claims="`+base64.StdEncoding.EncodeToString([]byte(stepUpClaims))+`"`)
+
+	// Classified as a control-flow event, not a failure.
+	require.Len(t, base.metrics, 1)
+	assert.Equal(t, "step_up_required", base.metrics[0].outcome)
+	exch := findSpan(sr.Ended(), exchangeSpanName)
+	require.NotNil(t, exch)
+	gotOutcome, _ := spanAttr(exch, spanAttrOutcome)
+	assert.Equal(t, "step_up_required", gotOutcome)
+
+	// The challenge is never cached.
+	assert.Empty(t, fc.items, "a claims challenge must never be written to the token cache")
 }
 
 // TestProcessRequest_NoMatchingProvider pins TC4: a token from an unconfigured

--- a/ee/middleware/oauth2tokenexchange/observability_emit_test.go
+++ b/ee/middleware/oauth2tokenexchange/observability_emit_test.go
@@ -4,8 +4,10 @@ package oauth2tokenexchange
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -47,6 +49,9 @@ type fakeBase struct {
 	actorMetrics []recordedMetric
 	cacheHits    []string
 	events       []recordedEvent
+	// cert is returned by GetClientCertificate; certErr overrides it when set.
+	cert    *tls.Certificate
+	certErr error
 }
 
 func newFakeBase() *fakeBase {
@@ -72,6 +77,16 @@ func (f *fakeBase) RecordExchangeCacheHit(_ context.Context, provider string) {
 
 func (f *fakeBase) RecordActorAcquisition(_ context.Context, outcome, provider string, d time.Duration) {
 	f.actorMetrics = append(f.actorMetrics, recordedMetric{outcome: outcome, provider: provider, duration: d})
+}
+
+func (f *fakeBase) GetClientCertificate(certID string) (*tls.Certificate, error) {
+	if f.certErr != nil {
+		return nil, f.certErr
+	}
+	if f.cert == nil {
+		return nil, fmt.Errorf("certificate %q not found", certID)
+	}
+	return f.cert, nil
 }
 
 // --- helpers ---

--- a/ee/middleware/oauth2tokenexchange/observability_test.go
+++ b/ee/middleware/oauth2tokenexchange/observability_test.go
@@ -60,6 +60,36 @@ func TestEventPayload_LogFields_SafeFields(t *testing.T) {
 	assertNoForbiddenKeys(t, f)
 }
 
+// TestEventPayload_DelegationFields pins the delegation signals: when an actor
+// token is attached the log line and audit meta carry oauth2_actor_source,
+// oauth2_actor_azp, and oauth2_delegation_observed — and never the actor's
+// subject identity. Impersonation (no actor source) emits none of them.
+func TestEventPayload_DelegationFields(t *testing.T) {
+	t.Parallel()
+
+	delegated := okPayload()
+	delegated.ActorSource = "client_credentials"
+	delegated.ActorAzp = "tyk-gateway-actor"
+	delegated.DelegationObserved = true
+
+	for name, m := range map[string]map[string]interface{}{
+		"log":   delegated.LogFields(),
+		"audit": delegated.AuditMeta(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, "client_credentials", m["oauth2_actor_source"])
+			assert.Equal(t, "tyk-gateway-actor", m["oauth2_actor_azp"])
+			assert.Equal(t, true, m["oauth2_delegation_observed"])
+			assertNoForbiddenKeys(t, m)
+		})
+	}
+
+	impersonation := okPayload().AuditMeta()
+	assert.NotContains(t, impersonation, "oauth2_actor_source")
+	assert.NotContains(t, impersonation, "oauth2_actor_azp")
+	assert.NotContains(t, impersonation, "oauth2_delegation_observed")
+}
+
 // TestEventPayload_LogFields_FailureCarriesIdPError pins TC6's failure variant.
 func TestEventPayload_LogFields_FailureCarriesIdPError(t *testing.T) {
 	t.Parallel()

--- a/ee/middleware/oauth2tokenexchange/observability_test.go
+++ b/ee/middleware/oauth2tokenexchange/observability_test.go
@@ -105,6 +105,23 @@ func TestEventPayload_LogFields_CapsIdPErrorDescription(t *testing.T) {
 	assert.LessOrEqual(t, len(desc), oauth2common.MaxIdPErrorBodyBytes+len("...(truncated)"))
 }
 
+// TestEventPayload_CapsIdPErrorCode pins that an oversized IdP error *code* is
+// length-capped on both the log line and the audit meta. The OAuth2 error code
+// is short by spec, but the IdP is untrusted and may return an arbitrary value.
+func TestEventPayload_CapsIdPErrorCode(t *testing.T) {
+	t.Parallel()
+
+	p := okPayload()
+	p.Outcome = oauth2common.OutcomeIdPError
+	p.IdpError = strings.Repeat("x", oauth2common.MaxIdPErrorBodyBytes+500)
+
+	logErr, _ := p.LogFields()["oauth2_idp_error"].(string)
+	assert.LessOrEqual(t, len(logErr), oauth2common.MaxIdPErrorBodyBytes+len("...(truncated)"))
+
+	auditErr, _ := p.AuditMeta()["oauth2_idp_error"].(string)
+	assert.LessOrEqual(t, len(auditErr), oauth2common.MaxIdPErrorBodyBytes+len("...(truncated)"))
+}
+
 // TestEventPayload_AuditMeta_Succeeded pins TC7: a successful exchange's audit
 // meta carries the oauth2_-namespaced safe fields and no identity/token.
 func TestEventPayload_AuditMeta_Succeeded(t *testing.T) {

--- a/ee/middleware/oauth2tokenexchange/observability_test.go
+++ b/ee/middleware/oauth2tokenexchange/observability_test.go
@@ -1,0 +1,213 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+// forbiddenIdentityKeys are the PII / token-id fields the no-hashing model
+// drops outright (never hashed, never emitted) from logs and audit meta.
+var forbiddenIdentityKeys = []string{
+	"oauth2_subject_jti",
+	"oauth2_subject_sub",
+	"oauth2_act_sub",
+	"oauth2_act",
+	"sub",
+	"jti",
+}
+
+func okPayload() EventPayload {
+	return EventPayload{
+		TraceID:         "0af7651916cd43dd8448eb211c80319c",
+		APIID:           "api-1",
+		Provider:        "corpIdP",
+		Outcome:         oauth2common.OutcomeOK,
+		CacheHit:        false,
+		DurationMS:      80,
+		SubjectAzp:      "agent-app",
+		ExchangedAzp:    "downstream-app",
+		Audience:        "https://api.internal",
+		ScopesRequested: []string{"read", "write"},
+	}
+}
+
+// TestEventPayload_LogFields_SafeFields pins TC6: the structured log line
+// carries the safe fields and none of the dropped identity / token fields.
+func TestEventPayload_LogFields_SafeFields(t *testing.T) {
+	t.Parallel()
+
+	f := okPayload().LogFields()
+
+	assert.Equal(t, "0af7651916cd43dd8448eb211c80319c", f["trace_id"])
+	assert.Equal(t, "api-1", f["oauth2_api_id"])
+	assert.Equal(t, "corpIdP", f["oauth2_provider"])
+	assert.Equal(t, "ok", f["oauth2_exchange_outcome"])
+	assert.Equal(t, false, f["oauth2_exchange_cache_hit"])
+	assert.Equal(t, int64(80), f["duration_ms"])
+	assert.Equal(t, "agent-app", f["oauth2_subject_azp"])
+	assert.Equal(t, "downstream-app", f["oauth2_exchanged_azp"])
+	assert.Equal(t, "https://api.internal", f["oauth2_audience"])
+	assert.Equal(t, []string{"read", "write"}, f["oauth2_scopes_requested"])
+
+	assertNoForbiddenKeys(t, f)
+}
+
+// TestEventPayload_LogFields_FailureCarriesIdPError pins TC6's failure variant.
+func TestEventPayload_LogFields_FailureCarriesIdPError(t *testing.T) {
+	t.Parallel()
+
+	p := okPayload()
+	p.Outcome = oauth2common.OutcomeIdPError
+	p.IdpError = "invalid_grant"
+	p.IdpErrorDesc = "subject token expired"
+
+	f := p.LogFields()
+	assert.Equal(t, "idp_error", f["oauth2_exchange_outcome"])
+	assert.Equal(t, "invalid_grant", f["oauth2_idp_error"])
+	assert.Equal(t, "subject token expired", f["oauth2_idp_error_description"])
+	assertNoForbiddenKeys(t, f)
+}
+
+// TestEventPayload_LogFields_OmitsEmptyParty pins that absent party identifiers
+// stay absent rather than emitting empty strings.
+func TestEventPayload_LogFields_OmitsEmptyParty(t *testing.T) {
+	t.Parallel()
+
+	p := okPayload()
+	p.ExchangedAzp = ""
+	p.TraceID = ""
+
+	f := p.LogFields()
+	assert.NotContains(t, f, "oauth2_exchanged_azp")
+	assert.NotContains(t, f, "trace_id")
+	assert.Contains(t, f, "oauth2_subject_azp")
+}
+
+// TestEventPayload_LogFields_CapsIdPErrorDescription pins that an oversized IdP
+// error description is length-capped before it reaches the log line.
+func TestEventPayload_LogFields_CapsIdPErrorDescription(t *testing.T) {
+	t.Parallel()
+
+	p := okPayload()
+	p.Outcome = oauth2common.OutcomeIdPError
+	p.IdpError = "server_error"
+	p.IdpErrorDesc = strings.Repeat("x", oauth2common.MaxIdPErrorBodyBytes+500)
+
+	desc, _ := p.LogFields()["oauth2_idp_error_description"].(string)
+	assert.LessOrEqual(t, len(desc), oauth2common.MaxIdPErrorBodyBytes+len("...(truncated)"))
+}
+
+// TestEventPayload_AuditMeta_Succeeded pins TC7: a successful exchange's audit
+// meta carries the oauth2_-namespaced safe fields and no identity/token.
+func TestEventPayload_AuditMeta_Succeeded(t *testing.T) {
+	t.Parallel()
+
+	meta := okPayload().AuditMeta()
+
+	assert.Equal(t, "api-1", meta["oauth2_api_id"])
+	assert.Equal(t, "corpIdP", meta["oauth2_provider"])
+	assert.Equal(t, "ok", meta["oauth2_exchange_outcome"])
+	assert.Equal(t, "https://api.internal", meta["oauth2_audience"])
+	assert.Equal(t, []string{"read", "write"}, meta["oauth2_scopes_requested"])
+	assert.Equal(t, "agent-app", meta["oauth2_subject_azp"])
+	assert.Equal(t, "downstream-app", meta["oauth2_exchanged_azp"])
+	assert.Equal(t, false, meta["oauth2_exchange_cache_hit"])
+
+	// duration_ms is a log-only field; it must not ride on the audit meta.
+	assert.NotContains(t, meta, "duration_ms")
+
+	assertNoForbiddenKeys(t, meta)
+}
+
+// TestEventPayload_AuditMeta_FailedCarriesIdPError pins TC8.
+func TestEventPayload_AuditMeta_FailedCarriesIdPError(t *testing.T) {
+	t.Parallel()
+
+	p := okPayload()
+	p.Outcome = oauth2common.OutcomeIdPError
+	p.IdpError = "invalid_grant"
+
+	meta := p.AuditMeta()
+	assert.Equal(t, "idp_error", meta["oauth2_exchange_outcome"])
+	assert.Equal(t, "invalid_grant", meta["oauth2_idp_error"])
+	assertNoForbiddenKeys(t, meta)
+}
+
+// TestEventPayload_AuditDecision pins TC7/TC8/TC14: ok → Succeeded; idp_error
+// and no_matching_provider → Failed; misconfig → no audit event.
+func TestEventPayload_AuditDecision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		outcome   oauth2common.OutcomeKind
+		wantEvent event.Event
+		wantAudit bool
+	}{
+		{oauth2common.OutcomeOK, event.OAuth2ExchangeSucceeded, true},
+		{oauth2common.OutcomeIdPError, event.OAuth2ExchangeFailed, true},
+		{oauth2common.OutcomeNoMatchingProvider, event.OAuth2ExchangeFailed, true},
+		{oauth2common.OutcomeMisconfig, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.outcome), func(t *testing.T) {
+			t.Parallel()
+			p := okPayload()
+			p.Outcome = tt.outcome
+			ev, audit := p.AuditDecision()
+			assert.Equal(t, tt.wantAudit, audit)
+			if tt.wantAudit {
+				assert.Equal(t, tt.wantEvent, ev)
+			}
+		})
+	}
+}
+
+// TestEventPayload_CacheHitFieldFlows pins TC9: a cache-hit success carries
+// oauth2_exchange_cache_hit=true on both the log line and the audit meta, and still
+// audits as a success.
+func TestEventPayload_CacheHitFieldFlows(t *testing.T) {
+	t.Parallel()
+
+	p := okPayload()
+	p.CacheHit = true
+
+	assert.Equal(t, true, p.LogFields()["oauth2_exchange_cache_hit"])
+	assert.Equal(t, true, p.AuditMeta()["oauth2_exchange_cache_hit"])
+	ev, audit := p.AuditDecision()
+	assert.True(t, audit)
+	assert.Equal(t, event.OAuth2ExchangeSucceeded, ev)
+}
+
+// TestEventPayload_NoRawTokenAnywhere pins that neither transform leaks the
+// raw inbound or exchanged token (the payload has no token field at all).
+func TestEventPayload_NoRawTokenAnywhere(t *testing.T) {
+	t.Parallel()
+
+	p := okPayload()
+	p.Outcome = oauth2common.OutcomeIdPError
+	p.IdpError = "invalid_grant"
+	p.IdpErrorDesc = "token rejected"
+
+	for _, m := range []map[string]interface{}{p.LogFields(), p.AuditMeta()} {
+		for k, v := range m {
+			s := strings.ToLower(fmt.Sprintf("%s=%v", k, v))
+			assert.NotContains(t, s, "bearer ")
+			assert.NotContains(t, s, "eyj") // base64url JWT header prefix
+		}
+	}
+}
+
+func assertNoForbiddenKeys(t *testing.T, m map[string]interface{}) {
+	t.Helper()
+	for _, k := range forbiddenIdentityKeys {
+		assert.NotContains(t, m, k, "field %q must never be emitted (no-hashing identity model)", k)
+	}
+}

--- a/gateway/mw_oauth2_actor_test.go
+++ b/gateway/mw_oauth2_actor_test.go
@@ -1,0 +1,263 @@
+package gateway
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+// capturedExchange records the actor fields of the last exchange form the IdP saw.
+type capturedExchange struct {
+	mu             sync.Mutex
+	calls          int32
+	actorToken     string
+	actorTokenType string
+}
+
+func (c *capturedExchange) snapshot() (string, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.actorToken, c.actorTokenType
+}
+
+// actorCapturingIdP mints an exchanged token and records the actor_token /
+// actor_token_type form fields the exchange request carried.
+func actorCapturingIdP(t *testing.T) (*httptest.Server, *capturedExchange) {
+	t.Helper()
+	cap := &capturedExchange{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		cap.mu.Lock()
+		atomic.AddInt32(&cap.calls, 1)
+		cap.actorToken = r.PostForm.Get(oas.OAuth2FormActorToken)
+		cap.actorTokenType = r.PostForm.Get(oas.OAuth2FormActorTokenType)
+		cap.mu.Unlock()
+
+		header64 := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+		payload64 := base64.RawURLEncoding.EncodeToString([]byte(`{"iss":"https://exchanged-idp","sub":"alice"}`))
+		w.Header().Set(header.ContentType, header.ApplicationJSON)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": header64 + "." + payload64 + ".sig",
+			"expires_in":   300,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, cap
+}
+
+// headerCapturingUpstream records every request header so a test can assert
+// the actor-token header was (or wasn't) forwarded upstream.
+type headerCapturingUpstream struct {
+	mu      sync.Mutex
+	headers http.Header
+}
+
+func (u *headerCapturingUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	u.mu.Lock()
+	u.headers = r.Header.Clone()
+	u.mu.Unlock()
+	w.Header().Set(header.ContentType, header.ApplicationJSON)
+	_, _ = w.Write([]byte(`{"ok":true}`))
+}
+
+func (u *headerCapturingUpstream) get(key string) string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.headers.Get(key)
+}
+
+// mintInboundJWTWithMayAct returns an unsigned inbound JWT carrying a may_act
+// claim naming the given actor sub.
+func mintInboundJWTWithMayAct(t *testing.T, iss, mayActSub string) string {
+	t.Helper()
+	payload := map[string]interface{}{
+		"iss": iss, "sub": "alice", "azp": "mcp-client",
+		"may_act": map[string]string{"sub": mayActSub},
+	}
+	pj, _ := json.Marshal(payload)
+	header64 := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	return header64 + "." + base64.RawURLEncoding.EncodeToString(pj) + ".sig"
+}
+
+// buildActorExchangeAPI is buildOAuth2ExchangeAPI with an actorToken block
+// injected into the provider.
+func buildActorExchangeAPI(idpIss, idpEndpoint, listenPath, actorBlockJSON string) string {
+	return fmt.Sprintf(`{
+		"openapi": "3.0.3",
+		"info": {"title": "story07", "version": "1.0.0"},
+		"paths": {"/mail": {"get": {"operationId": "getMail", "responses": {"200": {"description": "ok"}}}}},
+		"components": {"securitySchemes": {"corpOAuth": {"type": "oauth2", "flows": {"authorizationCode": {"authorizationUrl": "x", "tokenUrl": "x", "scopes": {}}}}}},
+		"security": [{"corpOAuth": []}],
+		"x-tyk-api-gateway": {
+			"info": {"name": "story07"},
+			"server": {
+				"listenPath": {"value": %q, "strip": true},
+				"authentication": {
+					"enabled": true,
+					"securitySchemes": {
+						"corpOAuth": {
+							"enabled": true,
+							"tokenExchange": {
+								"enabled": true,
+								"providers": [{
+									"name": "primary",
+									"issuers": [%q],
+									"tokenEndpoint": %q,
+									"clientAuth": {"method": "client_secret_basic", "clientId": "tyk-gateway", "clientSecret": "shh"},
+									"defaultTarget": {"audience": "upstream-api"},
+									"actorToken": %s
+								}]
+							}
+						}
+					}
+				}
+			},
+			"middleware": {"operations": {"getMail": {"exchange": {"enabled": true, "scopes": ["users:read"]}}}}
+		}
+	}`, listenPath, idpIss, idpEndpoint, actorBlockJSON)
+}
+
+func loadActorAPI(t *testing.T, ts *Test, oasJSON, listenPath, targetURL string) {
+	t.Helper()
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.IsOAS = true
+		require.NoError(t, spec.OAS.UnmarshalJSON([]byte(oasJSON)))
+		spec.OAS.ExtractTo(spec.APIDefinition)
+		spec.APIID = "story07-actor"
+		spec.Proxy.ListenPath = listenPath
+		spec.Proxy.TargetURL = targetURL
+		spec.Proxy.StripListenPath = true
+		spec.Name = "story07-actor"
+		spec.UseKeylessAccess = true
+	})
+}
+
+// TestOAuth2Actor_HeaderSource_SendsActorTokenAndStrips pins TC2: the header
+// actor token is sent to the IdP as actor_token (+ access_token type) and
+// stripped from the upstream request.
+func TestOAuth2Actor_HeaderSource_SendsActorTokenAndStrips(t *testing.T) {
+	if !oauth2BuildIsEE {
+		t.Skip("actor token is EE-only")
+	}
+	idp, cap := actorCapturingIdP(t)
+	upstream := &headerCapturingUpstream{}
+	upstreamSrv := httptest.NewServer(upstream)
+	t.Cleanup(upstreamSrv.Close)
+
+	ts := StartTest(nil)
+	t.Cleanup(ts.Close)
+
+	const listenPath = "/story07/"
+	oasJSON := buildActorExchangeAPI(idp.URL, idp.URL+"/token", listenPath, `{"source": "header"}`)
+	loadActorAPI(t, ts, oasJSON, listenPath, upstreamSrv.URL)
+
+	inbound := mintInboundUnverifiedJWT(t, idp.URL)
+	resp, err := ts.Run(t, test.TestCase{
+		Path:   "/story07/mail",
+		Method: http.MethodGet,
+		Headers: map[string]string{
+			header.Authorization: oas.OAuth2AuthSchemeBearer + " " + inbound,
+			"X-Actor-Token":      "header-actor-token",
+		},
+		Code: http.StatusOK,
+	})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	gotActor, gotType := cap.snapshot()
+	assert.Equal(t, "header-actor-token", gotActor, "the header actor token must be sent as actor_token")
+	assert.Equal(t, oas.OAuth2TokenTypeAccessToken, gotType, "actor_token_type defaults to access_token")
+	assert.Empty(t, upstream.get("X-Actor-Token"), "the actor header must be stripped from the upstream request")
+}
+
+// TestOAuth2Actor_HeaderRequiredMissing_401 pins TC4: a missing required actor
+// header is rejected with a 401 RFC 6750 invalid_token challenge, and the IdP
+// is never called.
+func TestOAuth2Actor_HeaderRequiredMissing_401(t *testing.T) {
+	if !oauth2BuildIsEE {
+		t.Skip("actor token is EE-only")
+	}
+	idp, cap := actorCapturingIdP(t)
+	upstream := &headerCapturingUpstream{}
+	upstreamSrv := httptest.NewServer(upstream)
+	t.Cleanup(upstreamSrv.Close)
+
+	ts := StartTest(nil)
+	t.Cleanup(ts.Close)
+
+	const listenPath = "/story07/"
+	oasJSON := buildActorExchangeAPI(idp.URL, idp.URL+"/token", listenPath, `{"source": "header"}`)
+	loadActorAPI(t, ts, oasJSON, listenPath, upstreamSrv.URL)
+
+	inbound := mintInboundUnverifiedJWT(t, idp.URL)
+	resp, err := ts.Run(t, test.TestCase{
+		Path:    "/story07/mail",
+		Method:  http.MethodGet,
+		Headers: map[string]string{header.Authorization: oas.OAuth2AuthSchemeBearer + " " + inbound},
+		Code:    http.StatusUnauthorized,
+	})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Contains(t, resp.Header.Get(header.WWWAuthenticate), `error="invalid_token"`)
+	assert.Contains(t, string(body), "invalid_token")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&cap.calls), "the exchange IdP must not be called when the required actor header is absent")
+}
+
+// TestOAuth2Actor_RequireMayAct_Mismatch_403 pins TC19/TC20: a subject token
+// whose may_act does not authorize the configured actor is rejected with 403
+// actor_not_authorized before any IdP call — including the actor-CC endpoint.
+func TestOAuth2Actor_RequireMayAct_Mismatch_403(t *testing.T) {
+	if !oauth2BuildIsEE {
+		t.Skip("actor token is EE-only")
+	}
+	idp, cap := actorCapturingIdP(t)
+	upstream := &headerCapturingUpstream{}
+	upstreamSrv := httptest.NewServer(upstream)
+	t.Cleanup(upstreamSrv.Close)
+
+	var actorCCCalls int32
+	actorCC := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&actorCCCalls, 1)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "cc-actor", "expires_in": 3600})
+	}))
+	t.Cleanup(actorCC.Close)
+
+	ts := StartTest(nil)
+	t.Cleanup(ts.Close)
+
+	const listenPath = "/story07/"
+	actorBlock := fmt.Sprintf(`{"source": "client_credentials", "requireMayAct": true, "clientCredentials": {"tokenEndpoint": %q, "clientId": "tyk-gateway-actor"}}`, actorCC.URL)
+	oasJSON := buildActorExchangeAPI(idp.URL, idp.URL+"/token", listenPath, actorBlock)
+	loadActorAPI(t, ts, oasJSON, listenPath, upstreamSrv.URL)
+
+	inbound := mintInboundJWTWithMayAct(t, idp.URL, "some-other-actor")
+	resp, err := ts.Run(t, test.TestCase{
+		Path:    "/story07/mail",
+		Method:  http.MethodGet,
+		Headers: map[string]string{header.Authorization: oas.OAuth2AuthSchemeBearer + " " + inbound},
+		Code:    http.StatusForbidden,
+	})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Contains(t, string(body), oas.OAuth2ErrActorNotAuthorized)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&cap.calls), "the exchange IdP must not be called on a may_act rejection")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&actorCCCalls), "the actor-CC endpoint must not be called on a may_act rejection")
+}

--- a/gateway/mw_oauth2_exchange_ee.go
+++ b/gateway/mw_oauth2_exchange_ee.go
@@ -3,11 +3,32 @@
 package gateway
 
 import (
+	"context"
+	"time"
+
 	"github.com/TykTechnologies/tyk/ee/middleware/oauth2tokenexchange"
 	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/internal/oauth2common"
 	"github.com/TykTechnologies/tyk/storage"
 )
+
+// RecordExchangeMetric records one token-exchange decision on the gateway's
+// OTel instruments. Safe to call when metrics are not initialised.
+func (t *BaseMiddleware) RecordExchangeMetric(ctx context.Context, outcome, provider string, d time.Duration) {
+	if t.Gw == nil || t.Gw.MetricInstruments == nil {
+		return
+	}
+	t.Gw.MetricInstruments.RecordExchange(ctx, outcome, provider, d)
+}
+
+// RecordExchangeCacheHit increments the gateway's token-exchange cache_hit
+// counter. Safe to call when metrics are not initialised.
+func (t *BaseMiddleware) RecordExchangeCacheHit(ctx context.Context, provider string) {
+	if t.Gw == nil || t.Gw.MetricInstruments == nil {
+		return
+	}
+	t.Gw.MetricInstruments.RecordCacheHit(ctx, provider)
+}
 
 func getOAuth2ExchangeMw(base *BaseMiddleware) TykMiddleware {
 	// OAS is required: the EE middleware reads per-operation exchange

--- a/gateway/mw_oauth2_exchange_ee.go
+++ b/gateway/mw_oauth2_exchange_ee.go
@@ -30,6 +30,15 @@ func (t *BaseMiddleware) RecordExchangeCacheHit(ctx context.Context, provider st
 	t.Gw.MetricInstruments.RecordCacheHit(ctx, provider)
 }
 
+// RecordActorAcquisition records one client-credentials actor-token acquisition
+// on the gateway's OTel instruments. Safe to call when metrics are not initialised.
+func (t *BaseMiddleware) RecordActorAcquisition(ctx context.Context, outcome, provider string, d time.Duration) {
+	if t.Gw == nil || t.Gw.MetricInstruments == nil {
+		return
+	}
+	t.Gw.MetricInstruments.RecordActorAcquisition(ctx, outcome, provider, d)
+}
+
 func getOAuth2ExchangeMw(base *BaseMiddleware) TykMiddleware {
 	// OAS is required: the EE middleware reads per-operation exchange
 	// overrides off Spec.OAS; nil OAS would panic on the first request.

--- a/gateway/mw_oauth2_exchange_ee.go
+++ b/gateway/mw_oauth2_exchange_ee.go
@@ -4,8 +4,11 @@ package gateway
 
 import (
 	"context"
+	"crypto/tls"
+	"fmt"
 	"time"
 
+	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/ee/middleware/oauth2tokenexchange"
 	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/internal/oauth2common"
@@ -37,6 +40,20 @@ func (t *BaseMiddleware) RecordActorAcquisition(ctx context.Context, outcome, pr
 		return
 	}
 	t.Gw.MetricInstruments.RecordActorAcquisition(ctx, outcome, provider, d)
+}
+
+// GetClientCertificate returns the certificate (with private key) registered
+// under certID in the gateway certificate store, used to sign a private_key_jwt
+// client assertion. Mirrors the upstream-certificate lookup (gateway/cert.go).
+func (t *BaseMiddleware) GetClientCertificate(certID string) (*tls.Certificate, error) {
+	if t.Gw == nil || t.Gw.CertificateManager == nil {
+		return nil, fmt.Errorf("certificate manager unavailable")
+	}
+	list := t.Gw.CertificateManager.List([]string{certID}, certs.CertificatePrivate)
+	if len(list) == 0 || list[0] == nil {
+		return nil, fmt.Errorf("certificate %q not found or has no private key", certID)
+	}
+	return list[0], nil
 }
 
 func getOAuth2ExchangeMw(base *BaseMiddleware) TykMiddleware {

--- a/go.mod
+++ b/go.mod
@@ -126,8 +126,10 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/warpstreamlabs/bento v1.16.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.67.0
 	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/mock v0.5.0
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa
@@ -569,7 +571,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0 // indirect
@@ -578,7 +579,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -52,6 +52,14 @@ const (
 	// OAuth2ScopeCheckFailed fires when an OAS-native scope check
 	// rejects a request (insufficient_scope per RFC 6750 §3.1).
 	OAuth2ScopeCheckFailed Event = "OAuth2ScopeCheckFailed"
+
+	// OAuth2ExchangeSucceeded fires when an RFC 8693 token exchange
+	// returns a token for the subject (cache miss or cache hit).
+	OAuth2ExchangeSucceeded Event = "OAuth2ExchangeSucceeded"
+	// OAuth2ExchangeFailed fires when an exchange is rejected. The
+	// oauth2_exchange_outcome meta field distinguishes an IdP error from a
+	// no-matching-provider rejection.
+	OAuth2ExchangeFailed Event = "OAuth2ExchangeFailed"
 )
 
 // Rate limiter events

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -27,6 +27,19 @@ func TestEventToString(t *testing.T) {
 	})
 }
 
+// TestOAuth2ExchangeEventTypes pins the exact wire strings of the
+// token-exchange audit events. These are a cross-repo contract: the dashboard
+// audit-event consumer keys off these literal type names, so they must not
+// drift. The exchange surface carries exactly two types — a no-matching-provider
+// outcome rides OAuth2ExchangeFailed via the oauth2_exchange_outcome meta field, not a
+// distinct event type.
+func TestOAuth2ExchangeEventTypes(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, Event("OAuth2ExchangeSucceeded"), OAuth2ExchangeSucceeded)
+	assert.Equal(t, Event("OAuth2ExchangeFailed"), OAuth2ExchangeFailed)
+}
+
 func TestAddEventToRequest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/oauth2common/cache_key.go
+++ b/internal/oauth2common/cache_key.go
@@ -2,6 +2,7 @@ package oauth2common
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
@@ -17,6 +18,10 @@ type CacheKeyInput struct {
 	Audience     string
 	Scopes       []string
 	ProviderName string
+	// ActorID discriminates delegation results from impersonation results for
+	// the same subject/target. The impersonation sentinel for non-delegated
+	// exchanges; the actor client id or a HashActorID otherwise.
+	ActorID string
 }
 
 // Build returns the cache key for this input as a hex-encoded SHA-256 with the oauth2:exchange: prefix.
@@ -25,9 +30,26 @@ func (k CacheKeyInput) Build() string {
 	copy(sorted, k.Scopes)
 	sort.Strings(sorted)
 	// Issuer scopes SubjectID: a "sub" is only unique within its issuer.
-	raw := fmt.Sprintf("%s|%s|%s|%s|%s|%s",
+	raw := fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
 		k.Issuer, k.SubjectID, k.APIID, k.Audience,
-		strings.Join(sorted, " "), k.ProviderName)
+		strings.Join(sorted, " "), k.ProviderName, k.ActorID)
 	h := sha256.Sum256([]byte(raw))
 	return fmt.Sprintf("%s%x", cacheKeyPrefix, h)
+}
+
+// ActorCacheKey keys a client_credentials actor-token cache entry. Built from
+// non-secret operator config (token endpoint + client id + sorted scopes).
+func ActorCacheKey(tokenEndpoint, clientID string, scopes []string) string {
+	sorted := append([]string(nil), scopes...)
+	sort.Strings(sorted)
+	return tokenEndpoint + "|" + clientID + "|" + strings.Join(sorted, ",")
+}
+
+// HashActorID returns a short stable id for a header/static actor token, used
+// only as a component of the exchange cache key (never logged). Truncated to
+// 8 bytes — full collision resistance isn't required because the subject/target
+// tuple already differs in another component.
+func HashActorID(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:8])
 }

--- a/internal/oauth2common/cache_key_actor_test.go
+++ b/internal/oauth2common/cache_key_actor_test.go
@@ -1,0 +1,36 @@
+package oauth2common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashActorID_StableAndDistinct(t *testing.T) {
+	a := HashActorID("actor-token")
+	assert.Equal(t, a, HashActorID("actor-token"), "same input must hash stably")
+	assert.NotEqual(t, a, HashActorID("other-token"), "distinct inputs must not collide")
+	assert.NotEmpty(t, a)
+}
+
+func TestActorCacheKey_KeyedOnEndpointClientScopes(t *testing.T) {
+	base := ActorCacheKey("https://idp/token", "actor", []string{"a", "b"})
+	assert.Equal(t, base, ActorCacheKey("https://idp/token", "actor", []string{"b", "a"}),
+		"scope order must not change the key")
+	assert.NotEqual(t, base, ActorCacheKey("https://idp/token", "other", []string{"a", "b"}),
+		"client id participates in the key")
+	assert.NotEqual(t, base, ActorCacheKey("https://other/token", "actor", []string{"a", "b"}),
+		"token endpoint participates in the key")
+}
+
+func TestCacheKeyInput_DelegationVsImpersonation(t *testing.T) {
+	base := CacheKeyInput{SubjectID: "alice", APIID: "api1", Audience: "aud", Scopes: []string{"r"}, ProviderName: "p"}
+
+	impersonation := base
+	impersonation.ActorID = "impersonation"
+	delegation := base
+	delegation.ActorID = HashActorID("actor-token")
+
+	assert.NotEqual(t, impersonation.Build(), delegation.Build(),
+		"delegation and impersonation must not share a cache entry for the same subject/target")
+}

--- a/internal/oauth2common/errors.go
+++ b/internal/oauth2common/errors.go
@@ -24,6 +24,26 @@ func (e *NoMatchingProviderError) Error() string {
 	return fmt.Sprintf("no token-exchange provider configured for issuer %s", e.Iss)
 }
 
+// ActorNotAuthorizedError is raised when actorToken.requireMayAct is set and
+// the inbound subject token's may_act claim (RFC 8693 §4.4) does not authorize
+// the configured actor. Rendered as HTTP 403 with no IdP call.
+type ActorNotAuthorizedError struct {
+	Reason string
+}
+
+func (e *ActorNotAuthorizedError) Error() string { return e.Reason }
+
+// MissingActorTokenError is raised when actorToken.source=header is required
+// but the configured header is absent. Rendered as HTTP 401 with an RFC 6750
+// invalid_token Bearer challenge; no fallback to impersonation.
+type MissingActorTokenError struct {
+	Header string
+}
+
+func (e *MissingActorTokenError) Error() string {
+	return fmt.Sprintf("missing actor token header %s", e.Header)
+}
+
 // ExchangeFailedError represents a non-2xx IdP token-endpoint response.
 type ExchangeFailedError struct {
 	Status      int

--- a/internal/oauth2common/errors.go
+++ b/internal/oauth2common/errors.go
@@ -44,6 +44,23 @@ func (e *MissingActorTokenError) Error() string {
 	return fmt.Sprintf("missing actor token header %s", e.Header)
 }
 
+// StepUpRequiredError is raised when an Entra On-Behalf-Of exchange returns a
+// Conditional Access claims challenge (error=interaction_required) instead of a
+// token. It is an expected control-flow event, not a failure: the gateway
+// re-emits it to the caller as an HTTP 401 with a WWW-Authenticate
+// insufficient_claims challenge, and it is never cached. Claims is the raw
+// challenge from the IdP (a JSON string); AuthorizationURI is the authorize
+// endpoint the caller completes the step-up against, when known.
+type StepUpRequiredError struct {
+	Claims           string
+	AuthorizationURI string
+	IdpError         string
+}
+
+func (e *StepUpRequiredError) Error() string {
+	return "step_up_required: Entra returned a claims challenge (interaction_required)"
+}
+
 // ExchangeFailedError represents a non-2xx IdP token-endpoint response.
 type ExchangeFailedError struct {
 	Status      int
@@ -56,6 +73,17 @@ func (e *ExchangeFailedError) Error() string {
 		return fmt.Sprintf("exchange_failed: idp_error=%s: %s", e.IdpError, e.Description)
 	}
 	return fmt.Sprintf("exchange_failed: idp_error=%s (status %d)", e.IdpError, e.Status)
+}
+
+// DecodeEntraClaimsChallenge extracts the `claims` challenge and optional
+// authorization_uri from an Entra interaction_required error body.
+func DecodeEntraClaimsChallenge(body []byte) (claims, authorizationURI string) {
+	var p struct {
+		Claims           string `json:"claims"`
+		AuthorizationURI string `json:"authorization_uri"`
+	}
+	_ = json.Unmarshal(body, &p)
+	return p.Claims, p.AuthorizationURI
 }
 
 // MaxIdPErrorBodyBytes caps the raw snippet captured from a non-JSON IdP error body.

--- a/internal/oauth2common/outcome.go
+++ b/internal/oauth2common/outcome.go
@@ -26,6 +26,10 @@ const (
 	// OutcomeActorNotAuthorized: the requireMayAct pre-flight rejected the
 	// configured actor before any IdP call (gateway-side policy refusal).
 	OutcomeActorNotAuthorized OutcomeKind = "actor_not_authorized"
+	// OutcomeMissingActorToken: a required header-source actor token was absent
+	// from the inbound request — a client-side failure that never reached the
+	// IdP, so it must not be counted as an idp_error.
+	OutcomeMissingActorToken OutcomeKind = "missing_actor_token"
 )
 
 // ClassifyExchangeOutcome maps an exchange result to its bounded OutcomeKind.
@@ -47,6 +51,10 @@ func ClassifyExchangeOutcome(err error) OutcomeKind {
 	var actorNotAuthorized *ActorNotAuthorizedError
 	if errors.As(err, &actorNotAuthorized) {
 		return OutcomeActorNotAuthorized
+	}
+	var missingActor *MissingActorTokenError
+	if errors.As(err, &missingActor) {
+		return OutcomeMissingActorToken
 	}
 	return OutcomeIdPError
 }

--- a/internal/oauth2common/outcome.go
+++ b/internal/oauth2common/outcome.go
@@ -23,6 +23,9 @@ const (
 	// OutcomeNoMatchingProvider: the inbound token's issuer matched no
 	// configured provider.
 	OutcomeNoMatchingProvider OutcomeKind = "no_matching_provider"
+	// OutcomeActorNotAuthorized: the requireMayAct pre-flight rejected the
+	// configured actor before any IdP call (gateway-side policy refusal).
+	OutcomeActorNotAuthorized OutcomeKind = "actor_not_authorized"
 )
 
 // ClassifyExchangeOutcome maps an exchange result to its bounded OutcomeKind.
@@ -41,6 +44,10 @@ func ClassifyExchangeOutcome(err error) OutcomeKind {
 	if errors.As(err, &misconfig) {
 		return OutcomeMisconfig
 	}
+	var actorNotAuthorized *ActorNotAuthorizedError
+	if errors.As(err, &actorNotAuthorized) {
+		return OutcomeActorNotAuthorized
+	}
 	return OutcomeIdPError
 }
 
@@ -48,6 +55,18 @@ func ClassifyExchangeOutcome(err error) OutcomeKind {
 type Outcome struct {
 	// ProviderName is the matched provider; empty when no exchange ran.
 	ProviderName string
+
+	// ActorID identifies the delegating actor used to discriminate the cache
+	// entry: the impersonation sentinel when no actor was attached, the actor
+	// client id for client_credentials, or a HashActorID for header/static.
+	ActorID string
+
+	// ActorSource is the configured actor-token source (client_credentials /
+	// header / static), empty for impersonation. ActorAzp is the actor client's
+	// authorized party. Both feed the delegation observability fields (never
+	// the actor's subject identity).
+	ActorSource string
+	ActorAzp    string
 
 	// Audience is the resolved audience sent to the IdP.
 	Audience string

--- a/internal/oauth2common/outcome.go
+++ b/internal/oauth2common/outcome.go
@@ -1,5 +1,49 @@
 package oauth2common
 
+import (
+	"errors"
+	"time"
+)
+
+// OutcomeKind is the bounded classification of one exchange decision. It is
+// safe as a metric label (a small fixed enum) and is the join key between the
+// metric label, the structured log line, and the audit event.
+type OutcomeKind string
+
+const (
+	// OutcomeOK: the exchange produced a token (whether freshly from the IdP
+	// or served from cache — cache status is a separate signal, not an
+	// outcome).
+	OutcomeOK OutcomeKind = "ok"
+	// OutcomeIdPError: the IdP rejected the exchange, or the call to it failed.
+	OutcomeIdPError OutcomeKind = "idp_error"
+	// OutcomeMisconfig: exchange is configured but the target is unresolvable
+	// at request time (e.g. an unresolvable client secret).
+	OutcomeMisconfig OutcomeKind = "misconfig"
+	// OutcomeNoMatchingProvider: the inbound token's issuer matched no
+	// configured provider.
+	OutcomeNoMatchingProvider OutcomeKind = "no_matching_provider"
+)
+
+// ClassifyExchangeOutcome maps an exchange result to its bounded OutcomeKind.
+// A nil error is ok; the typed rejections map to their kind; any other error
+// is treated as an IdP-side failure (it touched, or tried to touch, the IdP).
+// The check sees through wrapping (errors.As).
+func ClassifyExchangeOutcome(err error) OutcomeKind {
+	if err == nil {
+		return OutcomeOK
+	}
+	var noProvider *NoMatchingProviderError
+	if errors.As(err, &noProvider) {
+		return OutcomeNoMatchingProvider
+	}
+	var misconfig *MisconfigError
+	if errors.As(err, &misconfig) {
+		return OutcomeMisconfig
+	}
+	return OutcomeIdPError
+}
+
 // Outcome captures the result of one RFC 8693 exchange attempt for structured logging.
 type Outcome struct {
 	// ProviderName is the matched provider; empty when no exchange ran.
@@ -13,4 +57,16 @@ type Outcome struct {
 
 	// ExchangedToken is the IdP's exchanged access token; empty on failure.
 	ExchangedToken string
+
+	// CacheHit reports whether the token was served from cache (no IdP round-trip).
+	CacheHit bool
+
+	// Duration is the IdP round-trip latency; meaningful only when the outcome
+	// reached the IdP (a cache hit leaves it zero).
+	Duration time.Duration
+
+	// IdpErrorCode and IdpErrorDesc carry the IdP's error code and (capped)
+	// description on an idp_error outcome. Never metric labels — logs/audit only.
+	IdpErrorCode string
+	IdpErrorDesc string
 }

--- a/internal/oauth2common/outcome.go
+++ b/internal/oauth2common/outcome.go
@@ -30,6 +30,10 @@ const (
 	// from the inbound request — a client-side failure that never reached the
 	// IdP, so it must not be counted as an idp_error.
 	OutcomeMissingActorToken OutcomeKind = "missing_actor_token"
+	// OutcomeStepUpRequired: an Entra On-Behalf-Of exchange returned a
+	// Conditional Access claims challenge. An expected control-flow event re-emitted
+	// to the caller as a 401 insufficient_claims challenge — not an idp_error.
+	OutcomeStepUpRequired OutcomeKind = "step_up_required"
 )
 
 // ClassifyExchangeOutcome maps an exchange result to its bounded OutcomeKind.
@@ -55,6 +59,10 @@ func ClassifyExchangeOutcome(err error) OutcomeKind {
 	var missingActor *MissingActorTokenError
 	if errors.As(err, &missingActor) {
 		return OutcomeMissingActorToken
+	}
+	var stepUp *StepUpRequiredError
+	if errors.As(err, &stepUp) {
+		return OutcomeStepUpRequired
 	}
 	return OutcomeIdPError
 }

--- a/internal/oauth2common/outcome_test.go
+++ b/internal/oauth2common/outcome_test.go
@@ -22,6 +22,7 @@ func TestClassifyExchangeOutcome(t *testing.T) {
 		{"idp rejection", &ExchangeFailedError{Status: 400, IdpError: "invalid_grant"}, OutcomeIdPError},
 		{"actor not authorized", &ActorNotAuthorizedError{Reason: "may_act mismatch"}, OutcomeActorNotAuthorized},
 		{"missing actor token", &MissingActorTokenError{Header: "X-Actor"}, OutcomeMissingActorToken},
+		{"step up required", &StepUpRequiredError{Claims: "{}"}, OutcomeStepUpRequired},
 		{"generic error treated as idp_error", errors.New("dial tcp: connection refused"), OutcomeIdPError},
 	}
 	for _, tt := range tests {
@@ -53,4 +54,5 @@ func TestOutcomeKind_WireValues(t *testing.T) {
 	assert.Equal(t, OutcomeKind("no_matching_provider"), OutcomeNoMatchingProvider)
 	assert.Equal(t, OutcomeKind("actor_not_authorized"), OutcomeActorNotAuthorized)
 	assert.Equal(t, OutcomeKind("missing_actor_token"), OutcomeMissingActorToken)
+	assert.Equal(t, OutcomeKind("step_up_required"), OutcomeStepUpRequired)
 }

--- a/internal/oauth2common/outcome_test.go
+++ b/internal/oauth2common/outcome_test.go
@@ -20,6 +20,7 @@ func TestClassifyExchangeOutcome(t *testing.T) {
 		{"no matching provider", &NoMatchingProviderError{Iss: "https://idp.example"}, OutcomeNoMatchingProvider},
 		{"misconfig", &MisconfigError{Reason: "audience unresolvable"}, OutcomeMisconfig},
 		{"idp rejection", &ExchangeFailedError{Status: 400, IdpError: "invalid_grant"}, OutcomeIdPError},
+		{"actor not authorized", &ActorNotAuthorizedError{Reason: "may_act mismatch"}, OutcomeActorNotAuthorized},
 		{"generic error treated as idp_error", errors.New("dial tcp: connection refused"), OutcomeIdPError},
 	}
 	for _, tt := range tests {
@@ -49,4 +50,5 @@ func TestOutcomeKind_WireValues(t *testing.T) {
 	assert.Equal(t, OutcomeKind("idp_error"), OutcomeIdPError)
 	assert.Equal(t, OutcomeKind("misconfig"), OutcomeMisconfig)
 	assert.Equal(t, OutcomeKind("no_matching_provider"), OutcomeNoMatchingProvider)
+	assert.Equal(t, OutcomeKind("actor_not_authorized"), OutcomeActorNotAuthorized)
 }

--- a/internal/oauth2common/outcome_test.go
+++ b/internal/oauth2common/outcome_test.go
@@ -1,0 +1,52 @@
+package oauth2common
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyExchangeOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want OutcomeKind
+	}{
+		{"nil is ok", nil, OutcomeOK},
+		{"no matching provider", &NoMatchingProviderError{Iss: "https://idp.example"}, OutcomeNoMatchingProvider},
+		{"misconfig", &MisconfigError{Reason: "audience unresolvable"}, OutcomeMisconfig},
+		{"idp rejection", &ExchangeFailedError{Status: 400, IdpError: "invalid_grant"}, OutcomeIdPError},
+		{"generic error treated as idp_error", errors.New("dial tcp: connection refused"), OutcomeIdPError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ClassifyExchangeOutcome(tt.err))
+		})
+	}
+}
+
+// TestClassifyExchangeOutcome_Wrapped pins that the classifier sees through
+// a wrapped typed error (the exchange path may annotate errors with %w).
+func TestClassifyExchangeOutcome_Wrapped(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("exchange step: %w", &NoMatchingProviderError{Iss: "x"})
+	assert.Equal(t, OutcomeNoMatchingProvider, ClassifyExchangeOutcome(wrapped))
+}
+
+// TestOutcomeKind_WireValues pins the exact label strings — they are the join
+// key across the metric label, the structured log line, and the audit event,
+// and are asserted by downstream consumers, so they must not drift.
+func TestOutcomeKind_WireValues(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, OutcomeKind("ok"), OutcomeOK)
+	assert.Equal(t, OutcomeKind("idp_error"), OutcomeIdPError)
+	assert.Equal(t, OutcomeKind("misconfig"), OutcomeMisconfig)
+	assert.Equal(t, OutcomeKind("no_matching_provider"), OutcomeNoMatchingProvider)
+}

--- a/internal/oauth2common/outcome_test.go
+++ b/internal/oauth2common/outcome_test.go
@@ -21,6 +21,7 @@ func TestClassifyExchangeOutcome(t *testing.T) {
 		{"misconfig", &MisconfigError{Reason: "audience unresolvable"}, OutcomeMisconfig},
 		{"idp rejection", &ExchangeFailedError{Status: 400, IdpError: "invalid_grant"}, OutcomeIdPError},
 		{"actor not authorized", &ActorNotAuthorizedError{Reason: "may_act mismatch"}, OutcomeActorNotAuthorized},
+		{"missing actor token", &MissingActorTokenError{Header: "X-Actor"}, OutcomeMissingActorToken},
 		{"generic error treated as idp_error", errors.New("dial tcp: connection refused"), OutcomeIdPError},
 	}
 	for _, tt := range tests {
@@ -51,4 +52,5 @@ func TestOutcomeKind_WireValues(t *testing.T) {
 	assert.Equal(t, OutcomeKind("misconfig"), OutcomeMisconfig)
 	assert.Equal(t, OutcomeKind("no_matching_provider"), OutcomeNoMatchingProvider)
 	assert.Equal(t, OutcomeKind("actor_not_authorized"), OutcomeActorNotAuthorized)
+	assert.Equal(t, OutcomeKind("missing_actor_token"), OutcomeMissingActorToken)
 }

--- a/internal/oauth2common/transport.go
+++ b/internal/oauth2common/transport.go
@@ -3,15 +3,26 @@ package oauth2common
 import (
 	"net/http"
 	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // MaxIdPResponseBytes caps the response body read from the IdP to prevent memory abuse.
 const MaxIdPResponseBytes = 1 << 20
 
 // NewIdPHTTPClient returns an HTTP client for IdP calls with the given timeout.
+// The transport is wrapped with otelhttp so that, when the request carries an
+// active span, the IdP round-trip is emitted as a child client span — present
+// on a cache miss, absent on a cache hit (which never builds a request). When
+// tracing is disabled the wrap is a cheap no-op.
 func NewIdPHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{
-		Timeout:   timeout,
-		Transport: http.DefaultTransport,
+		Timeout: timeout,
+		Transport: otelhttp.NewTransport(
+			http.DefaultTransport,
+			otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+				return "oauth2.idp " + r.Method
+			}),
+		),
 	}
 }

--- a/internal/oauth2common/transport_test.go
+++ b/internal/oauth2common/transport_test.go
@@ -1,0 +1,88 @@
+package oauth2common
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// TestNewIdPHTTPClient_EmitsChildClientSpan pins TC11: when the request context
+// carries an active span, the IdP round-trip is emitted as a child client span
+// (named for the IdP call) nested under the parent. otelhttp builds the span
+// from the propagated context — no manual span code in the exchange path.
+func TestNewIdPHTTPClient_EmitsChildClientSpan(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, parent := tp.Tracer("test").Start(context.Background(), "parent")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := NewIdPHTTPClient(5 * time.Second).Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	parent.End()
+
+	var client sdktrace.ReadOnlySpan
+	for _, s := range sr.Ended() {
+		if s.SpanKind() == oteltrace.SpanKindClient {
+			client = s
+		}
+	}
+	require.NotNil(t, client, "expected an otelhttp client span for the IdP round-trip")
+	assert.Equal(t, "oauth2.idp POST", client.Name())
+	assert.Equal(t, parent.SpanContext().SpanID(), client.Parent().SpanID(),
+		"IdP client span must nest under the request's active span")
+
+	// No token / credential value belongs on the client span attributes.
+	for _, kv := range client.Attributes() {
+		key := strings.ToLower(string(kv.Key))
+		assert.NotContains(t, key, "token")
+		assert.NotContains(t, key, "authorization")
+	}
+}
+
+// TestNewIdPHTTPClient_TracingDisabled pins that the otelhttp wrap is a safe
+// no-op when tracing is disabled (the global provider is the default noop):
+// the request still succeeds and nothing is exported.
+func TestNewIdPHTTPClient_TracingDisabled(t *testing.T) {
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(noop.NewTracerProvider())
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	var gotResp bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		gotResp = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, nil)
+	require.NoError(t, err)
+
+	// With tracing off the otelhttp wrap is a no-op: the IdP call still works.
+	resp, err := NewIdPHTTPClient(5 * time.Second).Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, gotResp, "IdP request must reach the server with tracing disabled")
+}

--- a/internal/otel/metrics_instrument.go
+++ b/internal/otel/metrics_instrument.go
@@ -51,6 +51,12 @@ type MetricInstruments struct {
 	exchangeRequests *tykmetric.Counter
 	exchangeDuration *tykmetric.Histogram
 	exchangeCacheHit *tykmetric.Counter
+
+	// Actor-token (client_credentials) acquisition metrics. A distinct IdP
+	// dependency with its own cache, so it gets its own instruments; a
+	// cache-served actor token does not re-increment actorRequests.
+	actorRequests *tykmetric.Counter
+	actorDuration *tykmetric.Histogram
 }
 
 // NewMetricInstruments creates gateway metric instruments from an existing provider.
@@ -129,6 +135,25 @@ func NewMetricInstruments(provider tykmetric.Provider, logger *logrus.Logger) *M
 		logger.Errorf("Creating exchange cache_hit counter: %s", err)
 	}
 
+	actorRequests, err := provider.NewCounter(
+		"tyk.oauth2.actor.requests",
+		"Total client-credentials actor-token acquisitions, by outcome and provider",
+		"1",
+	)
+	if err != nil {
+		logger.Errorf("Creating actor requests counter: %s", err)
+	}
+
+	actorDuration, err := provider.NewHistogram(
+		"tyk.oauth2.actor.duration",
+		"IdP round-trip latency for actor-token acquisition (IdP-touching calls only)",
+		"s",
+		exchangeDurationBuckets,
+	)
+	if err != nil {
+		logger.Errorf("Creating actor duration histogram: %s", err)
+	}
+
 	return &MetricInstruments{
 		provider:         provider,
 		requestCounter:   requestCounter,
@@ -139,6 +164,8 @@ func NewMetricInstruments(provider tykmetric.Provider, logger *logrus.Logger) *M
 		exchangeRequests: exchangeRequests,
 		exchangeDuration: exchangeDuration,
 		exchangeCacheHit: exchangeCacheHit,
+		actorRequests:    actorRequests,
+		actorDuration:    actorDuration,
 	}
 }
 
@@ -160,6 +187,20 @@ func (i *MetricInstruments) RecordExchange(ctx context.Context, outcome, provide
 // provider only). Cache hits are a separate signal, never a requests outcome.
 func (i *MetricInstruments) RecordCacheHit(ctx context.Context, provider string) {
 	i.exchangeCacheHit.Add(ctx, 1, attribute.String(exchangeAttrProvider, provider))
+}
+
+// RecordActorAcquisition records one client-credentials actor-token
+// acquisition: it increments the actor requests counter and records the actor
+// duration histogram, both labelled by outcome + provider. Callers invoke it
+// only for a real IdP acquisition — a cache-served actor token is not recorded,
+// so the counter reads actual IdP load.
+func (i *MetricInstruments) RecordActorAcquisition(ctx context.Context, outcome, provider string, duration time.Duration) {
+	attrs := []attribute.KeyValue{
+		attribute.String(exchangeAttrOutcome, outcome),
+		attribute.String(exchangeAttrProvider, provider),
+	}
+	i.actorRequests.Add(ctx, 1, attrs...)
+	i.actorDuration.Record(ctx, duration.Seconds(), attrs...)
 }
 
 // RecordRequest increments the request counter.

--- a/internal/otel/metrics_instrument.go
+++ b/internal/otel/metrics_instrument.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
 
 	tykmetric "github.com/TykTechnologies/opentelemetry/metric"
 
@@ -15,6 +16,19 @@ import (
 // configuration reload durations. Reloads typically range from sub-second to
 // tens of seconds under heavy load.
 var reloadDurationBuckets = []float64{0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0}
+
+// exchangeDurationBuckets defines histogram bucket boundaries (in seconds) for
+// IdP round-trip latency on a token exchange.
+var exchangeDurationBuckets = []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0}
+
+// Metric attribute keys for the token-exchange instruments. Both are bounded —
+// `outcome` is a small enum and `provider` is operator-defined and few — so
+// both are safe as labels. Unbounded fields (idp error code, any token-derived
+// value) stay out of labels and live only on logs/audit.
+const (
+	exchangeAttrOutcome  = "outcome"
+	exchangeAttrProvider = "provider"
+)
 
 // MetricInstruments encapsulates the OTel metrics provider and all gateway instruments.
 // All methods are safe to call even when the provider is disabled (noop).
@@ -30,6 +44,13 @@ type MetricInstruments struct {
 	// Reload event metrics.
 	reloadCounter  *tykmetric.Counter
 	reloadDuration *tykmetric.Histogram
+
+	// Token-exchange (RFC 8693) metrics. The duration histogram records every
+	// attempt; cache hits are additionally counted on the separate cache_hit
+	// counter, never as a requests outcome.
+	exchangeRequests *tykmetric.Counter
+	exchangeDuration *tykmetric.Histogram
+	exchangeCacheHit *tykmetric.Counter
 }
 
 // NewMetricInstruments creates gateway metric instruments from an existing provider.
@@ -80,14 +101,65 @@ func NewMetricInstruments(provider tykmetric.Provider, logger *logrus.Logger) *M
 		logger.Errorf("Creating reload duration histogram: %s", err)
 	}
 
-	return &MetricInstruments{
-		provider:       provider,
-		requestCounter: requestCounter,
-		apisLoaded:     apisLoaded,
-		policiesLoaded: policiesLoaded,
-		reloadCounter:  reloadCounter,
-		reloadDuration: reloadDuration,
+	exchangeRequests, err := provider.NewCounter(
+		"tyk.oauth2.exchange.requests",
+		"Total RFC 8693 token exchange decisions, by outcome and provider",
+		"1",
+	)
+	if err != nil {
+		logger.Errorf("Creating exchange requests counter: %s", err)
 	}
+
+	exchangeDuration, err := provider.NewHistogram(
+		"tyk.oauth2.exchange.duration",
+		"IdP round-trip latency for token exchange (IdP-touching calls only)",
+		"s",
+		exchangeDurationBuckets,
+	)
+	if err != nil {
+		logger.Errorf("Creating exchange duration histogram: %s", err)
+	}
+
+	exchangeCacheHit, err := provider.NewCounter(
+		"tyk.oauth2.exchange.cache_hit",
+		"Total token-exchange requests served from the cache, by provider",
+		"1",
+	)
+	if err != nil {
+		logger.Errorf("Creating exchange cache_hit counter: %s", err)
+	}
+
+	return &MetricInstruments{
+		provider:         provider,
+		requestCounter:   requestCounter,
+		apisLoaded:       apisLoaded,
+		policiesLoaded:   policiesLoaded,
+		reloadCounter:    reloadCounter,
+		reloadDuration:   reloadDuration,
+		exchangeRequests: exchangeRequests,
+		exchangeDuration: exchangeDuration,
+		exchangeCacheHit: exchangeCacheHit,
+	}
+}
+
+// RecordExchange records one token-exchange decision: it increments the
+// requests counter and records the duration histogram (both labelled by
+// outcome + provider) on every attempt. Cache hits land sub-millisecond and
+// live IdP round-trips dominate the upper buckets, so the histogram reads as
+// IdP latency in practice while still making the cache speedup visible.
+func (i *MetricInstruments) RecordExchange(ctx context.Context, outcome, provider string, duration time.Duration) {
+	attrs := []attribute.KeyValue{
+		attribute.String(exchangeAttrOutcome, outcome),
+		attribute.String(exchangeAttrProvider, provider),
+	}
+	i.exchangeRequests.Add(ctx, 1, attrs...)
+	i.exchangeDuration.Record(ctx, duration.Seconds(), attrs...)
+}
+
+// RecordCacheHit increments the dedicated cache_hit counter (labelled by
+// provider only). Cache hits are a separate signal, never a requests outcome.
+func (i *MetricInstruments) RecordCacheHit(ctx context.Context, provider string) {
+	i.exchangeCacheHit.Add(ctx, 1, attribute.String(exchangeAttrProvider, provider))
 }
 
 // RecordRequest increments the request counter.

--- a/internal/otel/metrics_instrument_test.go
+++ b/internal/otel/metrics_instrument_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/TykTechnologies/opentelemetry/metric/metrictest"
 
@@ -308,6 +309,93 @@ func TestSetRegistry(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- Token-exchange (RFC 8693) instruments ---
+
+func TestRecordExchange_Noop(t *testing.T) {
+	inst := noopProvider(t)
+	require.NotPanics(t, func() {
+		inst.RecordExchange(context.Background(), "ok", "corpIdP", 80*time.Millisecond)
+		inst.RecordCacheHit(context.Background(), "corpIdP")
+	})
+}
+
+// TestRecordExchange_RequestsLabelledByOutcomeAndProvider pins TC1/TC5: the
+// requests counter increments per call, carrying exactly the bounded
+// `outcome` and `provider` labels — no token-derived label ever appears.
+func TestRecordExchange_RequestsLabelledByOutcomeAndProvider(t *testing.T) {
+	inst, tp := activeProvider(t)
+	ctx := context.Background()
+
+	inst.RecordExchange(ctx, "ok", "corpIdP", 80*time.Millisecond)
+
+	m := tp.FindMetric(t, "tyk.oauth2.exchange.requests")
+	metrictest.AssertSumWithAttrs(t, m, int64(1),
+		attribute.String("outcome", "ok"),
+		attribute.String("provider", "corpIdP"),
+	)
+	// TC5: a single record yields a single datapoint — any extra (e.g.
+	// token-derived) label would split it into more.
+	metrictest.AssertDataPointCount(t, m, 1)
+}
+
+// TestRecordExchange_DurationRecordedEveryAttempt pins TC2: the duration
+// histogram records on every attempt — both the cache miss (IdP latency) and
+// the cache hit (sub-millisecond) — so the cache speedup is visible.
+func TestRecordExchange_DurationRecordedEveryAttempt(t *testing.T) {
+	inst, tp := activeProvider(t)
+	ctx := context.Background()
+
+	inst.RecordExchange(ctx, "ok", "corpIdP", 80*time.Millisecond) // miss → IdP latency
+	inst.RecordExchange(ctx, "ok", "corpIdP", 0)                   // hit → sub-millisecond
+
+	metrictest.AssertSumWithAttrs(t, tp.FindMetric(t, "tyk.oauth2.exchange.requests"), int64(2),
+		attribute.String("outcome", "ok"), attribute.String("provider", "corpIdP"))
+	metrictest.AssertHistogramCount(t, tp.FindMetric(t, "tyk.oauth2.exchange.duration"), uint64(2))
+}
+
+// TestRecordCacheHit_SeparateCounter pins TC13: a cache hit is recorded on the
+// dedicated `cache_hit` counter (labelled by provider only), NOT as a
+// `cache_hit` outcome on the requests counter.
+func TestRecordCacheHit_SeparateCounter(t *testing.T) {
+	inst, tp := activeProvider(t)
+	ctx := context.Background()
+
+	inst.RecordExchange(ctx, "ok", "corpIdP", 80*time.Millisecond) // miss (ok)
+	inst.RecordExchange(ctx, "ok", "corpIdP", 0)                   // hit (ok, served from cache)
+	inst.RecordCacheHit(ctx, "corpIdP")                            // the warm request only
+
+	// requests{outcome=ok,provider=corpIdP} counted twice; one datapoint
+	// (no separate cache_hit outcome).
+	reqs := tp.FindMetric(t, "tyk.oauth2.exchange.requests")
+	metrictest.AssertSumWithAttrs(t, reqs, int64(2),
+		attribute.String("outcome", "ok"), attribute.String("provider", "corpIdP"))
+	metrictest.AssertDataPointCount(t, reqs, 1)
+
+	// cache_hit{provider=corpIdP} incremented once, labelled by provider only.
+	ch := tp.FindMetric(t, "tyk.oauth2.exchange.cache_hit")
+	metrictest.AssertSumWithAttrs(t, ch, int64(1), attribute.String("provider", "corpIdP"))
+	metrictest.AssertDataPointCount(t, ch, 1)
+}
+
+func TestExchangeMetricNames_Registered(t *testing.T) {
+	inst, tp := activeProvider(t)
+	ctx := context.Background()
+
+	inst.RecordExchange(ctx, "ok", "corpIdP", time.Millisecond)
+	inst.RecordCacheHit(ctx, "corpIdP")
+
+	names := tp.MetricNames()
+	for _, name := range []string{
+		"tyk.oauth2.exchange.requests",
+		"tyk.oauth2.exchange.duration",
+		"tyk.oauth2.exchange.cache_hit",
+	} {
+		assert.Contains(t, names, name)
+	}
+	// Actor metrics belong to a separate story — they must not appear here.
+	assert.NotContains(t, names, "tyk.oauth2.actor.requests")
 }
 
 func TestAllMetricNames_Registered(t *testing.T) {

--- a/internal/otel/metrics_instrument_test.go
+++ b/internal/otel/metrics_instrument_test.go
@@ -379,23 +379,47 @@ func TestRecordCacheHit_SeparateCounter(t *testing.T) {
 	metrictest.AssertDataPointCount(t, ch, 1)
 }
 
+// TestRecordActorAcquisition_RequestsAndDuration pins that a CC actor-token
+// acquisition increments the requests counter and records the duration
+// histogram, both labelled by the bounded outcome + provider only.
+func TestRecordActorAcquisition_RequestsAndDuration(t *testing.T) {
+	inst, tp := activeProvider(t)
+	ctx := context.Background()
+
+	inst.RecordActorAcquisition(ctx, "ok", "corpIdP", 40*time.Millisecond)
+
+	reqs := tp.FindMetric(t, "tyk.oauth2.actor.requests")
+	metrictest.AssertSumWithAttrs(t, reqs, int64(1),
+		attribute.String("outcome", "ok"), attribute.String("provider", "corpIdP"))
+	metrictest.AssertDataPointCount(t, reqs, 1)
+	metrictest.AssertHistogramCount(t, tp.FindMetric(t, "tyk.oauth2.actor.duration"), uint64(1))
+}
+
+func TestRecordActorAcquisition_Noop(t *testing.T) {
+	inst := noopProvider(t)
+	require.NotPanics(t, func() {
+		inst.RecordActorAcquisition(context.Background(), "idp_error", "corpIdP", 0)
+	})
+}
+
 func TestExchangeMetricNames_Registered(t *testing.T) {
 	inst, tp := activeProvider(t)
 	ctx := context.Background()
 
 	inst.RecordExchange(ctx, "ok", "corpIdP", time.Millisecond)
 	inst.RecordCacheHit(ctx, "corpIdP")
+	inst.RecordActorAcquisition(ctx, "ok", "corpIdP", time.Millisecond)
 
 	names := tp.MetricNames()
 	for _, name := range []string{
 		"tyk.oauth2.exchange.requests",
 		"tyk.oauth2.exchange.duration",
 		"tyk.oauth2.exchange.cache_hit",
+		"tyk.oauth2.actor.requests",
+		"tyk.oauth2.actor.duration",
 	} {
 		assert.Contains(t, names, name)
 	}
-	// Actor metrics belong to a separate story — they must not appear here.
-	assert.NotContains(t, names, "tyk.oauth2.actor.requests")
 }
 
 func TestAllMetricNames_Registered(t *testing.T) {


### PR DESCRIPTION
Adds Microsoft Entra **On-Behalf-Of (OBO)** as a delegation flavour of the existing token-exchange feature, so customers whose IdP is Entra (which rejects RFC 8693 with `AADSTS70003`) can use it.

A new optional `flow` discriminator on token-exchange providers (`token-exchange` default | `on-behalf-of`) selects the behaviour. **Purely additive** — `flow` defaults to `token-exchange`, so every existing provider is unchanged.

Under `on-behalf-of` the gateway:
- sends the jwt-bearer grant with the inbound user token as `assertion` and `requested_token_use=on_behalf_of`;
- folds target audience+scopes into an Entra `scope` string (`<audience>/.default` or a qualified scope), reusing the existing secret client-auth path; no actor token;
- validates OBO config (rejects `actorToken`, requires a single resolvable target, forbids mixing `.default` with discrete scopes, reserves the `assertion` / `requested_token_use` keys);
- detects an Entra Conditional Access claims challenge (`interaction_required`) and re-emits it as a `401` with `WWW-Authenticate: Bearer error="insufficient_claims"`, classified as a new `step_up_required` outcome (never `idp_error`, never cached).

Built behind the `ee || dev` flavour like the rest of token exchange. Verified end-to-end against a live Entra tenant.

**Tests:** `apidef/oas/oauth2_entra_obo_test.go`, `ee/middleware/oauth2tokenexchange/exchange_entra_obo_test.go`, plus outcome/observability coverage.

Stacks on the actor-token branch (Story 07); base will retarget to `master` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update — certificate client auth (`private_key_jwt`).** This branch now also adds the `private_key_jwt` client-authentication method (OIDC Core §9), alongside `client_secret_basic` / `client_secret_post`. It signs a short-lived RS256 client-assertion JWT (`x5t#S256` thumbprint; `iss=sub=clientId`, `aud=token endpoint`, unique `jti`, 5-min `exp`) from a certificate in the gateway store, referenced by a new `clientAuth.certId`. This is the method Microsoft Entra requires for certificate login, and a standard IANA-registered method usable with any compatible IdP (generic, not Entra-only).

Config validation requires a `certId` for `private_key_jwt` and now rejects an unknown `clientAuth.method` at load (was a runtime-only failure). The method enum and `certId` are added to the OAS/strict/MCP/streams schemas. Tests: `clientassertion_test.go`, `oauth2_clientauth_test.go`, plus exchange-path coverage.