### PR TITLE
TT-5486: Fix session cache access rights race

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -669,7 +669,7 @@ func (t *BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey string, 
 		// If exists, assume it has been authorized and pass on
 		// cache it
 		if !t.Spec.GlobalConfig.LocalSessionCache.DisableCacheSessionState {
-			t.Gw.SessionCache.Set(cacheKey, session, cache.DefaultExpiration)
+			t.Gw.SessionCache.Set(cacheKey, session.Clone(), cache.DefaultExpiration)
 		}
 
 		// Check for a policy, if there is a policy, pull it and overwrite the session values
@@ -701,7 +701,7 @@ func (t *BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey string, 
 
 		// cache it
 		if !t.Spec.GlobalConfig.LocalSessionCache.DisableCacheSessionState {
-			go t.Gw.SessionCache.Set(cacheKey, session, cache.DefaultExpiration)
+			go t.Gw.SessionCache.Set(cacheKey, session.Clone(), cache.DefaultExpiration)
 		}
 
 		// Check for a policy, if there is a policy, pull it and overwrite the session values

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/TykTechnologies/tyk/internal/otel"
 	"github.com/TykTechnologies/tyk/internal/otel/apimetrics"
 	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -200,6 +201,60 @@ func TestCheckSessionAndIdentityForValidKey_CachesSessionWithoutSharingAccessRig
 
 	cached := cachedVal.(user.SessionState)
 	require.Empty(t, cached.AccessRights[api.APIID].AllowanceScope)
+}
+
+func TestCheckSessionAndIdentityForValidKey_AuthStorePath_CachesClonedSession(t *testing.T) {
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.HashKeys = false
+		globalConf.LocalSessionCache.DisableCacheSessionState = false
+	})
+	defer ts.Close()
+
+	api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = uuid.New()
+		spec.UseKeylessAccess = false
+		spec.UseOauth2 = true
+		spec.Auth.AuthHeaderName = "authorization"
+	})[0]
+
+	key := "auth-store-" + uuid.New()
+	session := CreateStandardSession()
+	session.AccessRights = map[string]user.AccessDefinition{
+		api.APIID: {
+			APIID:    api.APIID,
+			Versions: []string{"Default"},
+			Limit: user.APILimit{
+				RateLimit: user.RateLimit{
+					Rate: 100,
+					Per:  60,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, api.AuthManager.UpdateSession(key, session, 60, false))
+	defer api.AuthManager.RemoveSession(session.OrgID, key, false)
+
+	baseMid := NewBaseMiddleware(ts.Gw, api, nil, nil)
+	got, ok := baseMid.CheckSessionAndIdentityForValidKey(key, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.True(t, ok, "session should be found in auth store")
+
+	require.Equal(t, api.APIID, got.AccessRights[api.APIID].AllowanceScope)
+
+	time.Sleep(100 * time.Millisecond)
+
+	cacheKey := key
+	if ts.Gw.GetConfig().HashKeys {
+		cacheKey = storage.HashStr(key, storage.HashMurmur64)
+	}
+
+	cachedVal, found := ts.Gw.SessionCache.Get(cacheKey)
+	require.True(t, found, "session should be cached after auth store lookup")
+
+	cached := cachedVal.(user.SessionState)
+	require.Empty(t, cached.AccessRights[api.APIID].AllowanceScope, "cached session should not have AllowanceScope set by policy application")
+
+	ts.Gw.SessionCache.Delete(cacheKey)
 }
 
 func TestBaseMiddleware_getAuthToken(t *testing.T) {

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -159,6 +159,49 @@ func TestBaseMiddleware_getAuthType(t *testing.T) {
 	assert.Equal(t, "t7", getToken(oidc.getAuthType(), oidc.getAuthToken))
 }
 
+func TestCheckSessionAndIdentityForValidKey_CachesSessionWithoutSharingAccessRights(t *testing.T) {
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.HashKeys = false
+		globalConf.LocalSessionCache.DisableCacheSessionState = false
+	})
+	defer ts.Close()
+
+	api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = uuid.New()
+		spec.UseKeylessAccess = false
+		spec.Auth.AuthHeaderName = "authorization"
+	})[0]
+
+	key := "cache-isolation-" + uuid.New()
+	session := CreateStandardSession()
+	session.AccessRights = map[string]user.AccessDefinition{
+		api.APIID: {
+			APIID:    api.APIID,
+			Versions: []string{"Default"},
+			Limit: user.APILimit{
+				RateLimit: user.RateLimit{
+					Rate: 100,
+					Per:  60,
+				},
+			},
+		},
+	}
+	require.NoError(t, ts.Gw.GlobalSessionManager.UpdateSession(key, session, 60, false))
+	defer ts.Gw.GlobalSessionManager.RemoveSession(session.OrgID, key, false)
+	defer ts.Gw.SessionCache.Delete(key)
+
+	baseMid := NewBaseMiddleware(ts.Gw, api, nil, nil)
+	got, ok := baseMid.CheckSessionAndIdentityForValidKey(key, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.True(t, ok)
+	require.Equal(t, api.APIID, got.AccessRights[api.APIID].AllowanceScope)
+
+	cachedVal, found := ts.Gw.SessionCache.Get(key)
+	require.True(t, found)
+
+	cached := cachedVal.(user.SessionState)
+	require.Empty(t, cached.AccessRights[api.APIID].AllowanceScope)
+}
+
 func TestBaseMiddleware_getAuthToken(t *testing.T) {
 	t.Run("should get token from cookie", func(t *testing.T) {
 		spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}

--- a/gateway/session_cache_race_repro_test.go
+++ b/gateway/session_cache_race_repro_test.go
@@ -1,0 +1,123 @@
+package gateway
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/internal/policy"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+const (
+	runSessionCacheRaceReproEnv   = "TYK_RUN_SESSION_CACHE_RACE_REPRO"
+	childSessionCacheRaceReproEnv = "TYK_SESSION_CACHE_RACE_REPRO_CHILD"
+)
+
+func TestOnDemandReproduceSessionCacheAccessRightsConcurrentMapCrash(t *testing.T) {
+	if os.Getenv(runSessionCacheRaceReproEnv) != "1" {
+		t.Skipf("set %s=1 to run this on-demand crash reproducer", runSessionCacheRaceReproEnv)
+	}
+
+	if os.Getenv(childSessionCacheRaceReproEnv) == "1" {
+		runSessionCacheAccessRightsRaceReproChild(t)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestOnDemandReproduceSessionCacheAccessRightsConcurrentMapCrash$", "-test.v")
+	cmd.Env = append(os.Environ(), childSessionCacheRaceReproEnv+"=1")
+
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, "child test process should abort with the Go runtime map-concurrency fatal")
+	require.NoError(t, ctx.Err(), "child test process timed out instead of reproducing the map-concurrency fatal")
+
+	out := string(output)
+	require.Contains(t, out, "fatal error: concurrent map")
+	require.Contains(t, out, "github.com/TykTechnologies/tyk/user.SessionState.Clone")
+
+	t.Logf("reproduced runtime crash in child process:\n%s", sessionCacheRaceReproExcerpt(out))
+}
+
+func runSessionCacheAccessRightsRaceReproChild(t *testing.T) {
+	t.Helper()
+
+	runtime.GOMAXPROCS(max(runtime.GOMAXPROCS(0), 4))
+
+	session := user.SessionState{
+		Rate:         1000000,
+		Per:          60,
+		QuotaMax:     -1,
+		OrgID:        "default",
+		AccessRights: make(map[string]user.AccessDefinition, 50000),
+	}
+	for i := 0; i < 50000; i++ {
+		apiID := "api-" + strconv.Itoa(i)
+		session.AccessRights[apiID] = user.AccessDefinition{
+			APIID:    apiID,
+			Versions: []string{"Default"},
+			Limit: user.APILimit{
+				RateLimit: user.RateLimit{
+					Rate: 1000,
+					Per:  60,
+				},
+			},
+		}
+	}
+
+	// This shallow copy mirrors the old SessionCache.Set(cacheKey, session, ...)
+	// behavior: the cached value and request-local value share AccessRights.
+	cachedSession := session
+
+	done := make(chan struct{})
+	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = cachedSession.Clone()
+				}
+			}
+		}()
+	}
+
+	apply := policy.New(nil, nil, logrus.New())
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			close(done)
+			t.Fatal("race reproducer did not trigger the runtime map-concurrency fatal")
+		default:
+			require.NoError(t, apply.Apply(&session))
+		}
+	}
+}
+
+func sessionCacheRaceReproExcerpt(output string) string {
+	var excerpt []string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "fatal error:") ||
+			strings.Contains(line, "user.SessionState.Clone") ||
+			strings.Contains(line, "internal/policy.(*Service).Apply") {
+
+			excerpt = append(excerpt, line)
+		}
+		if len(excerpt) == 8 {
+			break
+		}
+	}
+	return strings.Join(excerpt, "\n")
+}


### PR DESCRIPTION
## Summary

This fixes the gateway panic seen under high authentication load:

```text
fatal error: concurrent map iteration and map write
fatal error: concurrent map clone and map write
```

The fix stores cloned `SessionState` values in the local session cache, so cached entries do not share `AccessRights` map internals with request-local sessions that policy application mutates.

Changes:

- Store `session.Clone()` in `SessionCache.Set(...)` on both session-store and auth-store cache write paths.
- Add a regression test proving the cached session does not share `AccessRights` with the request-local session.
- Add an opt-in child-process reproducer that demonstrates the original Go runtime fatal without breaking normal CI.

## Root Cause

`SessionState` is a struct, but several of its fields are reference types. In particular, `AccessRights` is a map.

Before this PR, the gateway could cache a `SessionState` value before policy application finished:

```go
t.Gw.SessionCache.Set(cacheKey, session, cache.DefaultExpiration)
```

That stores a struct copy, but not a deep copy of the maps. As a result, the cached session and the request-local session could share the same `AccessRights` map.

The request-local session is then mutated by policy application and MCP normalization. At the same time, another request can load the cached value and clone it. That means one goroutine can iterate/clone `AccessRights` while another goroutine writes to the same underlying map, which Go treats as a fatal runtime error.

## Request And Cache Lifecycle

For each authenticated request, the gateway looks up a session from either:

- the local in-memory session cache,
- the global/session backing store,
- or the auth store fallback path.

The session is cloned into a request-local `SessionState`. That local copy can then be safely modified for the duration of that request by policy application, endpoint normalization, key hash setup, `Touch()`, and other request-scoped work.

The important boundary is ownership:

- The cache may hold shared data reused by future requests.
- The active request should mutate only its own detached copy.
- The cached value must not share map internals with an in-flight request.

This PR keeps that model by cloning before storing in the cache.

## Why The Local Cache Is Still Needed

The local session cache avoids repeatedly hitting the backing session/auth stores on every request. That matters on the hot authentication path, especially under high request concurrency.

The cache is still valid here; the bug was not the existence of the cache. The bug was that the cached value and request-local value were accidentally sharing mutable map internals.

## Stale Data Considerations

There is always some existing stale-data behavior with a local cache: cached session fields can remain in memory until cache expiry or explicit invalidation.

This PR does not increase that stale-data window. It preserves the existing cache-hit behavior: cache hits still clone the cached session and apply policies during request validation.

That means policy changes are still evaluated on the request-local copy, while the cached raw session remains isolated from request mutations.

## Why This Fix Is Narrow

An alternative approach is to add locking inside `SessionState`, but that is a larger ownership change and is risky because `SessionState` is copied by value in many places.

Putting a `sync.RWMutex` directly inside `SessionState` makes `Clone()` and other value copies vulnerable to copying a live lock. That can introduce deadlocks and `go vet -copylocks` failures unless the entire type ownership model is redesigned.

For this bug, we do not need to make all `SessionState` map access globally synchronized. We only need to ensure that the local cache never stores maps that are still owned by an active request.

## Reproduction

The opt-in test intentionally recreates the old shallow-copy behavior:

1. Create a session with a large `AccessRights` map.
2. Make a shallow cached copy, matching the old `SessionCache.Set(cacheKey, session, ...)` behavior.
3. Clone the cached session concurrently.
4. Apply policies to the request-local session concurrently.
5. Assert that the child process hits the Go runtime concurrent-map fatal.

It is skipped by default and only runs when explicitly requested:

```sh
TYK_RUN_SESSION_CACHE_RACE_REPRO=1 GOCACHE=/private/tmp/tyk-go-cache go test ./gateway -run '^TestOnDemandReproduceSessionCacheAccessRightsConcurrentMapCrash$' -count=1 -v
```

Observed output includes:

```text
fatal error: concurrent map clone and map write
github.com/TykTechnologies/tyk/user.SessionState.Clone
github.com/TykTechnologies/tyk/internal/policy.(*Service).Apply
```

## Validation

Normal focused regression path:

```sh
GOCACHE=/private/tmp/tyk-go-cache go test ./gateway -run '^(TestCheckSessionAndIdentityForValidKey_CachesSessionWithoutSharingAccessRights|TestOnDemandReproduceSessionCacheAccessRightsConcurrentMapCrash)$' -count=1 -v
```

Result:

- `TestCheckSessionAndIdentityForValidKey_CachesSessionWithoutSharingAccessRights`: passed.
- `TestOnDemandReproduceSessionCacheAccessRightsConcurrentMapCrash`: skipped by default.

Opt-in reproducer:

```sh
TYK_RUN_SESSION_CACHE_RACE_REPRO=1 GOCACHE=/private/tmp/tyk-go-cache go test ./gateway -run '^TestOnDemandReproduceSessionCacheAccessRightsConcurrentMapCrash$' -count=1 -v
```

Result:

- Parent test passed.
- Child process reproduced the original Go runtime fatal.

Pre-push hook:

- Passed lint.
- Passed codegen checks.
- Passed build.
- Passed gateway test compile.
