### PR TITLE
TT-17508: Add restriction to absolute paths when base_path is provided

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1480,13 +1480,11 @@ type TykError struct {
 
 // FileConfig configures the file-based KV provider.
 type FileConfig struct {
-	// BasePath is the directory that $secret_file.<key> references are resolved
-	// relative to. When set, <key> must be a relative path that stays within
-	// this directory (absolute paths and ".." traversal are rejected).
-	// When empty, <key> is used as a literal file path with no restrictions.
-	//
-	// For file:// URI references, absolute paths are used as-is.
-	// Relative paths are still resolved relative to this directory.
+	// BasePath is the directory that file:// and $secret_file.<key> references are
+	// resolved relative to. It is a mandatory security boundary: when set, <key>
+	// must be a relative path that stays within this directory (absolute paths and
+	// ".." traversal are rejected). When empty, file:// references are disabled and
+	// every key is rejected.
 	BasePath string `json:"base_path"`
 }
 

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1728,6 +1728,30 @@ func TestReplaceSecretsFileScheme(t *testing.T) {
 		assert.Equal(t, "key-from-mount", api.JWTSource)
 	})
 
+	t.Run("absolute path in API definition is rejected when base_path is set", func(t *testing.T) {
+		baseDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(baseDir, "jwt-secret"), []byte("allowed-value"), 0600))
+
+		outsideDir := t.TempDir()
+		secret := filepath.Join(outsideDir, "passwd")
+		require.NoError(t, os.WriteFile(secret, []byte("root:x:0:0:secret"), 0600))
+
+		ts := StartTest(func(conf *config.Config) {
+			conf.KV.File.BasePath = baseDir
+		})
+		defer ts.Close()
+
+		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+			spec.APIID = "file-kv-abs-reject"
+			spec.JWTSource = "file://" + secret
+		})
+
+		api := ts.Gw.getApiSpec("file-kv-abs-reject")
+		require.NotNil(t, api)
+		assert.NotContains(t, api.JWTSource, "root:x:0:0", "absolute-path file contents must not be injected")
+		assert.Equal(t, "file://"+secret, api.JWTSource, "raw file:// reference should be left unresolved")
+	})
+
 	t.Run("multi-line PEM content is valid JSON after substitution", func(t *testing.T) {
 		dir := t.TempDir()
 		pem := "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJ\n-----END CERTIFICATE-----"

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1670,11 +1670,11 @@ func TestReplaceSecrets(t *testing.T) {
 }
 
 func TestReplaceSecretsFileScheme(t *testing.T) {
-	t.Run("absolute path without base_path", func(t *testing.T) {
+	t.Run("file:// references rejected without base_path", func(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		t.Run("replaces file:// reference with file contents", func(t *testing.T) {
+		t.Run("absolute file:// reference left unresolved", func(t *testing.T) {
 			dir := t.TempDir()
 			f := filepath.Join(dir, "jwt-secret")
 			require.NoError(t, os.WriteFile(f, []byte("my-jwt-signing-key\n"), 0600))
@@ -1686,26 +1686,19 @@ func TestReplaceSecretsFileScheme(t *testing.T) {
 
 			api := ts.Gw.getApiSpec("file-kv-1")
 			require.NotNil(t, api)
-			assert.Equal(t, "my-jwt-signing-key", api.JWTSource)
+			assert.NotContains(t, api.JWTSource, "my-jwt-signing-key", "file contents must not be injected without base_path")
+			assert.Equal(t, "file://"+f, api.JWTSource, "raw file:// reference should be left unresolved")
 		})
 
-		t.Run("multiple file:// references in one definition are all replaced", func(t *testing.T) {
-			dir := t.TempDir()
-			f1 := filepath.Join(dir, "source")
-			f2 := filepath.Join(dir, "method")
-			require.NoError(t, os.WriteFile(f1, []byte("source-value"), 0600))
-			require.NoError(t, os.WriteFile(f2, []byte("method-value"), 0600))
-
+		t.Run("relative file:// reference left unresolved", func(t *testing.T) {
 			ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 				spec.APIID = "file-kv-2"
-				spec.JWTSource = "file://" + f1
-				spec.JWTSigningMethod = "file://" + f2
+				spec.JWTSource = "file://jwt-secret"
 			})
 
 			api := ts.Gw.getApiSpec("file-kv-2")
 			require.NotNil(t, api)
-			assert.Equal(t, "source-value", api.JWTSource)
-			assert.Equal(t, "method-value", api.JWTSigningMethod)
+			assert.Equal(t, "file://jwt-secret", api.JWTSource, "raw file:// reference should be left unresolved")
 		})
 	})
 

--- a/gateway/kv_file.go
+++ b/gateway/kv_file.go
@@ -73,6 +73,10 @@ func resolveKeyPath(basePath, key string) (string, error) {
 		)
 	}
 
+	if key == "" {
+		return "", fmt.Errorf("file KV: file:// reference has an empty key; specify a path relative to base_path")
+	}
+
 	if filepath.IsAbs(key) {
 		return "", fmt.Errorf(
 			"file KV: absolute path %q rejected because kv.file.base_path is configured; "+

--- a/gateway/kv_file.go
+++ b/gateway/kv_file.go
@@ -79,7 +79,6 @@ func resolveKeyPath(basePath, key string) (string, error) {
 
 	joined := filepath.Join(basePath, key)
 	if !confined(basePath, joined) {
-
 		return "", fmt.Errorf("file KV: path traversal detected in key %q", key)
 	}
 

--- a/gateway/kv_file.go
+++ b/gateway/kv_file.go
@@ -79,8 +79,7 @@ func resolveKeyPath(basePath, key string) (string, error) {
 
 	if filepath.IsAbs(key) {
 		return "", fmt.Errorf(
-			"file KV: absolute path %q rejected because kv.file.base_path is configured; "+
-				"use a path relative to base_path",
+			"file KV: absolute path %q rejected; file:// references must be relative to kv.file.base_path",
 			key,
 		)
 	}

--- a/gateway/kv_file.go
+++ b/gateway/kv_file.go
@@ -16,31 +16,9 @@ import (
 // When basePath is empty no boundary is configured, so only absolute keys are
 // accepted; a relative key has no base to resolve against and is rejected.
 func ResolveFileKV(basePath, key string) (string, error) {
-	var path string
-
-	if basePath == "" {
-		if !filepath.IsAbs(key) {
-			return "", fmt.Errorf(
-				"file KV: key %q is a relative path but kv.file.base_path is not configured; "+
-					"set kv.file.base_path or use an absolute path",
-				key,
-			)
-		}
-		path = key
-	} else {
-		if filepath.IsAbs(key) {
-			return "", fmt.Errorf(
-				"file KV: absolute path %q rejected because kv.file.base_path is configured; "+
-					"use a path relative to base_path",
-				key,
-			)
-		}
-		joined := filepath.Join(basePath, key)
-		rel, err := filepath.Rel(basePath, joined)
-		if err != nil || !filepath.IsLocal(rel) {
-			return "", fmt.Errorf("file KV: path traversal detected in key %q", key)
-		}
-		path = joined
+	path, err := resolveKeyPath(basePath, key)
+	if err != nil {
+		return "", err
 	}
 
 	// Resolve K8s AtomicWriter symlinks (e.g. ..data -> ..2024_01_01_00_00_00).
@@ -58,9 +36,13 @@ func ResolveFileKV(basePath, key string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("file KV: cannot resolve base_path %q: %w", basePath, err)
 		}
-		rel, err := filepath.Rel(canonicalBase, resolved)
-		if err != nil || !filepath.IsLocal(rel) {
-			return "", fmt.Errorf("file KV: symlink escape detected for key %q: resolved to %q which is outside base_path", key, resolved)
+
+		if !confined(canonicalBase, resolved) {
+			return "", fmt.Errorf(
+				"file KV: symlink escape detected for key %q: resolved to %q which is outside base_path",
+				key,
+				resolved,
+			)
 		}
 	}
 
@@ -70,4 +52,43 @@ func ResolveFileKV(basePath, key string) (string, error) {
 	}
 
 	return strings.TrimRight(string(data), "\r\n"), nil
+}
+
+// resolveKeyPath applies the base_path boundary policy and returns the
+// candidate file path.
+func resolveKeyPath(basePath, key string) (string, error) {
+	if basePath == "" {
+		if !filepath.IsAbs(key) {
+			return "", fmt.Errorf(
+				"file KV: key %q is a relative path but kv.file.base_path is not configured; "+
+					"set kv.file.base_path or use an absolute path",
+				key,
+			)
+		}
+
+		return key, nil
+	}
+
+	if filepath.IsAbs(key) {
+		return "", fmt.Errorf(
+			"file KV: absolute path %q rejected because kv.file.base_path is configured; "+
+				"use a path relative to base_path",
+			key,
+		)
+	}
+
+	joined := filepath.Join(basePath, key)
+	if !confined(basePath, joined) {
+
+		return "", fmt.Errorf("file KV: path traversal detected in key %q", key)
+	}
+
+	return joined, nil
+}
+
+// confined reports whether target resolves to a location within base,
+// using lexical analysis only.
+func confined(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	return err == nil && filepath.IsLocal(rel)
 }

--- a/gateway/kv_file.go
+++ b/gateway/kv_file.go
@@ -9,31 +9,38 @@ import (
 
 // ResolveFileKV reads the file at key and returns its contents trimmed of trailing newlines.
 //
-// Absolute keys are used as-is; basePath is ignored for them.
-// Callers that enforce a security boundary (e.g. runtime middleware where
-// API-designer-level input is untrusted) must reject absolute keys before
-// calling this function when basePath is configured.
+// basePath, when set, is a security boundary: only relative keys are accepted
+// and they are joined to basePath and confined within it. Absolute keys are
+// rejected so that untrusted input cannot escape the boundary to read arbitrary files.
 //
-// Relative keys require basePath to be set; they are joined and confined to it.
+// When basePath is empty no boundary is configured, so only absolute keys are
+// accepted; a relative key has no base to resolve against and is rejected.
 func ResolveFileKV(basePath, key string) (string, error) {
 	var path string
 
-	switch {
-	case filepath.IsAbs(key):
+	if basePath == "" {
+		if !filepath.IsAbs(key) {
+			return "", fmt.Errorf(
+				"file KV: key %q is a relative path but kv.file.base_path is not configured; "+
+					"set kv.file.base_path or use an absolute path",
+				key,
+			)
+		}
 		path = key
-	case basePath != "":
+	} else {
+		if filepath.IsAbs(key) {
+			return "", fmt.Errorf(
+				"file KV: absolute path %q rejected because kv.file.base_path is configured; "+
+					"use a path relative to base_path",
+				key,
+			)
+		}
 		joined := filepath.Join(basePath, key)
 		rel, err := filepath.Rel(basePath, joined)
 		if err != nil || !filepath.IsLocal(rel) {
 			return "", fmt.Errorf("file KV: path traversal detected in key %q", key)
 		}
 		path = joined
-	default:
-		return "", fmt.Errorf(
-			"file KV: key %q is a relative path but kv.file.base_path is not configured; "+
-				"set kv.file.base_path or use an absolute path",
-			key,
-		)
 	}
 
 	// Resolve K8s AtomicWriter symlinks (e.g. ..data -> ..2024_01_01_00_00_00).
@@ -44,7 +51,7 @@ func ResolveFileKV(basePath, key string) (string, error) {
 
 	// Re-verify after symlink resolution: a symlink inside basePath can point
 	// outside (symlink escape).
-	if basePath != "" && !filepath.IsAbs(key) {
+	if basePath != "" {
 		canonicalBase, err := filepath.EvalSymlinks(basePath)
 		// EvalSymlinks failure here requires a race (basePath symlink broken between
 		// resolving the file path above and this call). Not worth a flaky test.

--- a/gateway/kv_file.go
+++ b/gateway/kv_file.go
@@ -29,21 +29,19 @@ func ResolveFileKV(basePath, key string) (string, error) {
 
 	// Re-verify after symlink resolution: a symlink inside basePath can point
 	// outside (symlink escape).
-	if basePath != "" {
-		canonicalBase, err := filepath.EvalSymlinks(basePath)
-		// EvalSymlinks failure here requires a race (basePath symlink broken between
-		// resolving the file path above and this call). Not worth a flaky test.
-		if err != nil {
-			return "", fmt.Errorf("file KV: cannot resolve base_path %q: %w", basePath, err)
-		}
+	canonicalBase, err := filepath.EvalSymlinks(basePath)
+	// EvalSymlinks failure here requires a race (basePath symlink broken between
+	// resolving the file path above and this call). Not worth a flaky test.
+	if err != nil {
+		return "", fmt.Errorf("file KV: cannot resolve base_path %q: %w", basePath, err)
+	}
 
-		if !confined(canonicalBase, resolved) {
-			return "", fmt.Errorf(
-				"file KV: symlink escape detected for key %q: resolved to %q which is outside base_path",
-				key,
-				resolved,
-			)
-		}
+	if !confined(canonicalBase, resolved) {
+		return "", fmt.Errorf(
+			"file KV: symlink escape detected for key %q: resolved to %q which is outside base_path",
+			key,
+			resolved,
+		)
 	}
 
 	data, err := os.ReadFile(resolved)

--- a/gateway/kv_file.go
+++ b/gateway/kv_file.go
@@ -63,6 +63,16 @@ func resolveKeyPath(basePath, key string) (string, error) {
 		)
 	}
 
+	// A relative base_path resolves against the process working directory, which
+	// is non-deterministic across deployments and defeats the purpose of a fixed
+	// boundary.
+	if !filepath.IsAbs(basePath) {
+		return "", fmt.Errorf(
+			"file KV: kv.file.base_path %q must be an absolute path",
+			basePath,
+		)
+	}
+
 	if filepath.IsAbs(key) {
 		return "", fmt.Errorf(
 			"file KV: absolute path %q rejected because kv.file.base_path is configured; "+

--- a/gateway/kv_file.go
+++ b/gateway/kv_file.go
@@ -9,12 +9,12 @@ import (
 
 // ResolveFileKV reads the file at key and returns its contents trimmed of trailing newlines.
 //
-// basePath, when set, is a security boundary: only relative keys are accepted
-// and they are joined to basePath and confined within it. Absolute keys are
-// rejected so that untrusted input cannot escape the boundary to read arbitrary files.
+// basePath is a mandatory security boundary: file:// references resolve only when
+// it is configured. Keys must be relative; they are joined to basePath and confined
+// within it, so untrusted input cannot escape the boundary to read arbitrary files.
+// Absolute keys are rejected.
 //
-// When basePath is empty no boundary is configured, so only absolute keys are
-// accepted; a relative key has no base to resolve against and is rejected.
+// When basePath is empty no boundary is configured, so every key is rejected.
 func ResolveFileKV(basePath, key string) (string, error) {
 	path, err := resolveKeyPath(basePath, key)
 	if err != nil {
@@ -58,15 +58,11 @@ func ResolveFileKV(basePath, key string) (string, error) {
 // candidate file path.
 func resolveKeyPath(basePath, key string) (string, error) {
 	if basePath == "" {
-		if !filepath.IsAbs(key) {
-			return "", fmt.Errorf(
-				"file KV: key %q is a relative path but kv.file.base_path is not configured; "+
-					"set kv.file.base_path or use an absolute path",
-				key,
-			)
-		}
-
-		return key, nil
+		return "", fmt.Errorf(
+			"file KV: cannot resolve key %q because kv.file.base_path is not configured; "+
+				"set kv.file.base_path to enable file:// references",
+			key,
+		)
 	}
 
 	if filepath.IsAbs(key) {

--- a/gateway/kv_file_test.go
+++ b/gateway/kv_file_test.go
@@ -189,6 +189,12 @@ func TestResolveFileKV(t *testing.T) {
 		assert.Contains(t, err.Error(), "base_path")
 	})
 
+	t.Run("rejects relative basePath", func(t *testing.T) {
+		_, err := ResolveFileKV("relative/base", "secret.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be an absolute path")
+	})
+
 	t.Run("resolves key relative to basePath", func(t *testing.T) {
 		dir := t.TempDir()
 		f := filepath.Join(dir, "api-key")

--- a/gateway/kv_file_test.go
+++ b/gateway/kv_file_test.go
@@ -60,11 +60,21 @@ func TestKVStoreFileScheme(t *testing.T) {
 			assert.Equal(t, "my-node-secret", val)
 		})
 
-		t.Run("absolute path still works when base_path is set", func(t *testing.T) {
+		t.Run("absolute path rejected when base_path is set", func(t *testing.T) {
 			f := filepath.Join(dir, "node-secret")
-			val, err := ts.Gw.kvStore("file://" + f)
-			require.NoError(t, err)
-			assert.Equal(t, "my-node-secret", val)
+			_, err := ts.Gw.kvStore("file://" + f)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "absolute path")
+		})
+
+		t.Run("absolute path to file outside base_path is rejected", func(t *testing.T) {
+			outside := t.TempDir()
+			secret := filepath.Join(outside, "passwd")
+			require.NoError(t, os.WriteFile(secret, []byte("root:x:0:0"), 0600))
+
+			_, err := ts.Gw.kvStore("file://" + secret)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "absolute path")
 		})
 
 		t.Run("dotdot traversal rejected even when base_path is set", func(t *testing.T) {
@@ -188,14 +198,24 @@ func TestResolveFileKV(t *testing.T) {
 		assert.Equal(t, "the-api-key", val)
 	})
 
-	t.Run("absolute path works even when basePath is set", func(t *testing.T) {
+	t.Run("rejects absolute path when basePath is set", func(t *testing.T) {
 		dir := t.TempDir()
 		f := filepath.Join(dir, "secret")
 		require.NoError(t, os.WriteFile(f, []byte("abs-value"), 0600))
 
-		val, err := ResolveFileKV("/some/other/base", f)
-		require.NoError(t, err)
-		assert.Equal(t, "abs-value", val)
+		_, err := ResolveFileKV("/some/other/base", f)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute path")
+	})
+
+	t.Run("rejects absolute path even when it points inside basePath", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "secret")
+		require.NoError(t, os.WriteFile(f, []byte("abs-value"), 0600))
+
+		_, err := ResolveFileKV(dir, f)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute path")
 	})
 
 	t.Run("rejects dotdot traversal when basePath is set", func(t *testing.T) {

--- a/gateway/kv_file_test.go
+++ b/gateway/kv_file_test.go
@@ -195,6 +195,13 @@ func TestResolveFileKV(t *testing.T) {
 		assert.Contains(t, err.Error(), "must be an absolute path")
 	})
 
+	t.Run("rejects empty key", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := ResolveFileKV(dir, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty key")
+	})
+
 	t.Run("resolves key relative to basePath", func(t *testing.T) {
 		dir := t.TempDir()
 		f := filepath.Join(dir, "api-key")

--- a/gateway/kv_file_test.go
+++ b/gateway/kv_file_test.go
@@ -13,26 +13,21 @@ import (
 
 // TestKVStoreFileScheme tests that kvStore() resolves file:// URIs (Context 1).
 func TestKVStoreFileScheme(t *testing.T) {
-	t.Run("absolute path without base_path", func(t *testing.T) {
+	t.Run("no base_path configured", func(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		t.Run("resolves absolute file:// to file contents", func(t *testing.T) {
+		t.Run("absolute file:// rejected without base_path", func(t *testing.T) {
 			dir := t.TempDir()
 			f := filepath.Join(dir, "secret")
 			require.NoError(t, os.WriteFile(f, []byte("super-secret\n"), 0600))
 
-			val, err := ts.Gw.kvStore("file://" + f)
-			require.NoError(t, err)
-			assert.Equal(t, "super-secret", val)
+			_, err := ts.Gw.kvStore("file://" + f)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "base_path")
 		})
 
-		t.Run("returns error for missing file", func(t *testing.T) {
-			_, err := ts.Gw.kvStore("file:///nonexistent/file")
-			assert.Error(t, err)
-		})
-
-		t.Run("relative key without base_path returns error", func(t *testing.T) {
+		t.Run("relative file:// rejected without base_path", func(t *testing.T) {
 			_, err := ts.Gw.kvStore("file://just-a-name")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "base_path")
@@ -96,18 +91,22 @@ func TestFileKVHotReload(t *testing.T) {
 	require.NoError(t, os.WriteFile(keyFile, []byte("key-v1"), 0600))
 	require.NoError(t, os.WriteFile(caFile, []byte("ca-v1"), 0600))
 
-	gw := NewGateway(config.Config{
+	// file:// references require base_path; keys are relative to it.
+	cfg := config.Config{
 		ExternalServices: config.ExternalServiceConfig{
 			OAuth: config.ServiceConfig{
 				MTLS: config.MTLSConfig{
 					Enabled:  true,
-					CertFile: "file://" + certFile,
-					KeyFile:  "file://" + keyFile,
-					CAFile:   "file://" + caFile,
+					CertFile: "file://tls.crt",
+					KeyFile:  "file://tls.key",
+					CAFile:   "file://ca.crt",
 				},
 			},
 		},
-	}, t.Context())
+	}
+	cfg.KV.File.BasePath = dir
+
+	gw := NewGateway(cfg, t.Context())
 
 	require.NoError(t, gw.afterConfSetup())
 
@@ -137,53 +136,55 @@ func TestFileKVHotReload(t *testing.T) {
 func TestResolveFileKV(t *testing.T) {
 	t.Run("reads plain file contents", func(t *testing.T) {
 		dir := t.TempDir()
-		f := filepath.Join(dir, "secret.txt")
-		require.NoError(t, os.WriteFile(f, []byte("my-secret-value"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("my-secret-value"), 0600))
 
-		val, err := ResolveFileKV("", f)
+		val, err := ResolveFileKV(dir, "secret.txt")
 		require.NoError(t, err)
 		assert.Equal(t, "my-secret-value", val)
 	})
 
 	t.Run("strips trailing newline by default", func(t *testing.T) {
 		dir := t.TempDir()
-		f := filepath.Join(dir, "secret.txt")
-		require.NoError(t, os.WriteFile(f, []byte("my-secret-value\n"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("my-secret-value\n"), 0600))
 
-		val, err := ResolveFileKV("", f)
+		val, err := ResolveFileKV(dir, "secret.txt")
 		require.NoError(t, err)
 		assert.Equal(t, "my-secret-value", val)
 	})
 
 	t.Run("strips trailing newline CRLF", func(t *testing.T) {
 		dir := t.TempDir()
-		f := filepath.Join(dir, "secret.txt")
-		require.NoError(t, os.WriteFile(f, []byte("my-secret-value\r\n"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("my-secret-value\r\n"), 0600))
 
-		val, err := ResolveFileKV("", f)
+		val, err := ResolveFileKV(dir, "secret.txt")
 		require.NoError(t, err)
 		assert.Equal(t, "my-secret-value", val)
 	})
 
 	t.Run("preserves multi-line content except trailing newline", func(t *testing.T) {
 		dir := t.TempDir()
-		f := filepath.Join(dir, "cert.pem")
 		pem := "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJ\n-----END CERTIFICATE-----\n"
-		require.NoError(t, os.WriteFile(f, []byte(pem), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cert.pem"), []byte(pem), 0600))
 
-		val, err := ResolveFileKV("", f)
+		val, err := ResolveFileKV(dir, "cert.pem")
 		require.NoError(t, err)
 		assert.Equal(t, "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJ\n-----END CERTIFICATE-----", val)
 	})
 
-	t.Run("returns error for non-existent file", func(t *testing.T) {
-		_, err := ResolveFileKV("", "/nonexistent/path/secret.txt")
+	t.Run("returns error for non-existent file under basePath", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := ResolveFileKV(dir, "nonexistent.txt")
 		assert.Error(t, err)
 	})
 
 	t.Run("relative key without basePath returns descriptive error", func(t *testing.T) {
-		// A short name like "my-cert" makes no sense without a base directory.
 		_, err := ResolveFileKV("", "my-cert")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_path")
+	})
+
+	t.Run("absolute key without basePath returns descriptive error", func(t *testing.T) {
+		_, err := ResolveFileKV("", "/etc/passwd")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "base_path")
 	})
@@ -245,14 +246,14 @@ func TestResolveFileKV(t *testing.T) {
 		assert.Contains(t, err.Error(), "symlink escape")
 	})
 
-	t.Run("allows absolute path when basePath is empty", func(t *testing.T) {
+	t.Run("rejects absolute path when basePath is empty", func(t *testing.T) {
 		dir := t.TempDir()
 		f := filepath.Join(dir, "secret")
 		require.NoError(t, os.WriteFile(f, []byte("value"), 0600))
 
-		val, err := ResolveFileKV("", f)
-		require.NoError(t, err)
-		assert.Equal(t, "value", val)
+		_, err := ResolveFileKV("", f)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_path")
 	})
 
 	t.Run("follows k8s AtomicWriter symlinks", func(t *testing.T) {

--- a/gateway/kv_file_test.go
+++ b/gateway/kv_file_test.go
@@ -297,3 +297,26 @@ func TestResolveFileKV(t *testing.T) {
 		assert.Equal(t, "new-secret", val)
 	})
 }
+
+func TestConfined(t *testing.T) {
+	cases := []struct {
+		name   string
+		base   string
+		target string
+		want   bool
+	}{
+		{"direct child", "/base", "/base/secret", true},
+		{"nested child", "/base", "/base/sub/dir/secret", true},
+		{"base itself", "/base", "/base", true},
+		{"cleaned dotdot stays inside", "/base", "/base/sub/../secret", true},
+		{"parent escape", "/base", "/base/../secret", false},
+		{"sibling escape", "/base", "/other", false},
+		{"prefix confusion is not confinement", "/base", "/base-evil", false},
+		{"absolute outside", "/base", "/etc/passwd", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, confined(tc.base, tc.target))
+		})
+	}
+}

--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -8,7 +8,6 @@ import (
 	"net/textproto"
 	"net/url"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -341,16 +340,7 @@ func (gw *Gateway) replaceVariables(in string, vars []string, vals map[string]in
 
 		case fileLabel:
 
-			bp := gw.GetConfig().KV.File.BasePath
-			// When base_path is configured it acts as a security boundary:
-			// reject absolute paths so API designers cannot bypass the boundary
-			// to read files outside the configured mount directory.
-			if bp != "" && filepath.IsAbs(key) {
-				log.Warnf("file KV: absolute path rejected for $secret_file key %q - base_path is configured", key)
-				in = emptyStringFn(key, in, v)
-				continue
-			}
-			val, err := ResolveFileKV(bp, key)
+			val, err := ResolveFileKV(gw.GetConfig().KV.File.BasePath, key)
 			if err != nil {
 				in = emptyStringFn(key, in, v)
 				continue

--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -342,6 +342,7 @@ func (gw *Gateway) replaceVariables(in string, vars []string, vals map[string]in
 
 			val, err := ResolveFileKV(gw.GetConfig().KV.File.BasePath, key)
 			if err != nil {
+				log.WithError(err).Debug("file KV: $secret_file resolution failed")
 				in = emptyStringFn(key, in, v)
 				continue
 			}

--- a/gateway/mw_url_rewrite_test.go
+++ b/gateway/mw_url_rewrite_test.go
@@ -1469,7 +1469,8 @@ func TestReplaceTykVariablesFileSecret(t *testing.T) {
 	pemFile := filepath.Join(dir, "cert.pem")
 	require.NoError(t, os.WriteFile(pemFile, []byte("-----BEGIN CERT-----\nABC\n-----END CERT-----\n"), 0600))
 
-	// No base_path configured — keys are used as literal file paths.
+	// No base_path configured — file:// resolution is disabled, so $secret_file.
+	// references resolve to an empty string while other providers are unaffected.
 	t.Run("no base_path", func(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
@@ -1482,19 +1483,14 @@ func TestReplaceTykVariablesFileSecret(t *testing.T) {
 			expected string
 		}{
 			{
-				name:     "resolves $secret_file. with absolute path",
+				name:     "absolute $secret_file. rejected, resolves to empty",
 				input:    "$secret_file." + secretFile,
-				expected: "file-secret-value",
+				expected: "",
 			},
 			{
-				name:     "trailing newline stripped",
-				input:    "Bearer $secret_file." + secretFile,
-				expected: "Bearer file-secret-value",
-			},
-			{
-				name:     "PEM cert content preserved except trailing newline",
-				input:    "$secret_file." + pemFile,
-				expected: "-----BEGIN CERT-----\nABC\n-----END CERT-----",
+				name:     "relative $secret_file. rejected, resolves to empty",
+				input:    "$secret_file.api-key",
+				expected: "",
 			},
 			{
 				name:     "non-existent file resolves to empty string",
@@ -1502,9 +1498,9 @@ func TestReplaceTykVariablesFileSecret(t *testing.T) {
 				expected: "",
 			},
 			{
-				name:     "mixed with other secret providers",
+				name:     "other secret providers unaffected; file resolves to empty",
 				input:    "env=$secret_env.TEST_FILE_KV_VAR file=$secret_file." + secretFile,
-				expected: "env=env-test-val file=file-secret-value",
+				expected: "env=env-test-val file=",
 			},
 		}
 
@@ -1515,13 +1511,6 @@ func TestReplaceTykVariablesFileSecret(t *testing.T) {
 				assert.Equal(t, tt.expected, result)
 			})
 		}
-
-		t.Run("not URL-encoded when escape=true", func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/", nil)
-			result := ts.Gw.ReplaceTykVariables(req, "$secret_file."+secretFile, true)
-			assert.Equal(t, "file-secret-value", result)
-			assert.NotContains(t, result, "%")
-		})
 	})
 
 	t.Run("with base_path configured", func(t *testing.T) {
@@ -1534,6 +1523,19 @@ func TestReplaceTykVariablesFileSecret(t *testing.T) {
 			req := httptest.NewRequest("GET", "/", nil)
 			result := ts.Gw.ReplaceTykVariables(req, "$secret_file.api-key", false)
 			assert.Equal(t, "file-secret-value", result)
+		})
+
+		t.Run("multi-line PEM resolved under base_path", func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			result := ts.Gw.ReplaceTykVariables(req, "$secret_file.cert.pem", false)
+			assert.Equal(t, "-----BEGIN CERT-----\nABC\n-----END CERT-----", result)
+		})
+
+		t.Run("not URL-encoded when escape=true", func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			result := ts.Gw.ReplaceTykVariables(req, "$secret_file.api-key", true)
+			assert.Equal(t, "file-secret-value", result)
+			assert.NotContains(t, result, "%")
 		})
 
 		t.Run("absolute path rejected when base_path is set", func(t *testing.T) {

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -42,6 +42,32 @@ import (
 )
 
 func TestGateway_afterConfSetup(t *testing.T) {
+	// file:// references require base_path, so the file-backend case below resolves
+	// relative keys under this directory. Hoisted here so expectedConfig can carry
+	// the same base_path (KV is an anonymous struct and can't be set in a literal).
+	fileKVDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(fileKVDir, "cert.pem"), []byte("/file/path/to/cert.pem"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(fileKVDir, "key.pem"), []byte("/file/path/to/key.pem"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(fileKVDir, "ca.pem"), []byte("/file/path/to/ca.pem"), 0o600))
+
+	fileBackendExpected := config.Config{
+		ExternalServices: config.ExternalServiceConfig{
+			OAuth: config.ServiceConfig{
+				MTLS: config.MTLSConfig{
+					Enabled:  true,
+					CertFile: "/file/path/to/cert.pem",
+					KeyFile:  "/file/path/to/key.pem",
+					CAFile:   "/file/path/to/ca.pem",
+				},
+			},
+		},
+		AnalyticsConfig: config.AnalyticsConfigConfig{
+			PurgeInterval: 10,
+		},
+		HealthCheckEndpointName:    "hello",
+		ReadinessCheckEndpointName: "ready",
+	}
+	fileBackendExpected.KV.File.BasePath = fileKVDir
 
 	tests := []struct {
 		name            string
@@ -302,37 +328,16 @@ func TestGateway_afterConfSetup(t *testing.T) {
 			initialConfig: config.Config{},
 			setup: func(t *testing.T, gw *Gateway) {
 				t.Helper()
-				dir := t.TempDir()
-				certFile := filepath.Join(dir, "cert.pem")
-				keyFile := filepath.Join(dir, "key.pem")
-				caFile := filepath.Join(dir, "ca.pem")
-				require.NoError(t, os.WriteFile(certFile, []byte("/file/path/to/cert.pem"), 0o600))
-				require.NoError(t, os.WriteFile(keyFile, []byte("/file/path/to/key.pem"), 0o600))
-				require.NoError(t, os.WriteFile(caFile, []byte("/file/path/to/ca.pem"), 0o600))
+
 				conf := gw.GetConfig()
+				conf.KV.File.BasePath = fileKVDir
 				conf.ExternalServices.OAuth.MTLS.Enabled = true
-				conf.ExternalServices.OAuth.MTLS.CertFile = "file://" + certFile
-				conf.ExternalServices.OAuth.MTLS.KeyFile = "file://" + keyFile
-				conf.ExternalServices.OAuth.MTLS.CAFile = "file://" + caFile
+				conf.ExternalServices.OAuth.MTLS.CertFile = "file://cert.pem"
+				conf.ExternalServices.OAuth.MTLS.KeyFile = "file://key.pem"
+				conf.ExternalServices.OAuth.MTLS.CAFile = "file://ca.pem"
 				gw.SetConfig(conf)
 			},
-			expectedConfig: config.Config{
-				ExternalServices: config.ExternalServiceConfig{
-					OAuth: config.ServiceConfig{
-						MTLS: config.MTLSConfig{
-							Enabled:  true,
-							CertFile: "/file/path/to/cert.pem",
-							KeyFile:  "/file/path/to/key.pem",
-							CAFile:   "/file/path/to/ca.pem",
-						},
-					},
-				},
-				AnalyticsConfig: config.AnalyticsConfigConfig{
-					PurgeInterval: 10,
-				},
-				HealthCheckEndpointName:    "hello",
-				ReadinessCheckEndpointName: "ready",
-			},
+			expectedConfig: fileBackendExpected,
 		},
 		{
 			name: "error - secret key missing from kv store",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Ticket: [Link](https://tyktech.atlassian.net/browse/TT-17508)

`file://` KV references are now restricted to **relative paths confined within a configured
`kv.file.base_path`**, and `base_path` is **required**:

- `base_path` **not set** → `file://` references are disabled; every key (absolute or
  relative) is rejected and no file contents are read.
- `base_path` **set** → only relative keys resolve; they are joined to `base_path` and
  confined within it. Absolute paths and `..` traversal are rejected.

`base_path` is the security boundary that pins all `file://` lookups to a single directory.
Previously it was optional and absolute keys bypassed it entirely, so the boundary wasn't
actually enforced. This change makes it mandatory and authoritative: no `base_path`, no
`file://`; with `base_path`, only relative, confined paths are allowed.

The `file://` KV option is not yet released, so making `base_path` mandatory carries no
backward-compatibility impact.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

https://tyktech.atlassian.net/browse/TT-17508

## Motivation and Context

The `file://` KV option allowed absolute paths to bypass `base_path`. In a multi-tenant
setup, an untrusted API designer could inject `file:///etc/passwd` into an API definition
(e.g. a mock body or custom header) and have the gateway read that file and inject its
contents back — arbitrary file disclosure.

The root cause was that `ResolveFileKV` treated absolute keys as an escape hatch and left
boundary enforcement to each caller. One caller (`mw_url_rewrite`) did it; two others
(`replaceFileSecrets`, `kvStore`) did not — so the boundary was enforced by convention and
silently missed in two places.

The fix moves enforcement into a single chokepoint (`ResolveFileKV`) and goes further than
just rejecting absolute keys: it requires `base_path` to be configured for `file://` to work
at all. With the policy centralized, all three callers are covered automatically and the
boundary can no longer be silently bypassed.

## How This Has Been Tested
- Unit tests
- Manual testing

## Demo
_When base_path is not set, the file:// references are restricted; absolute paths are restricted no matter what_

https://github.com/user-attachments/assets/e8a8469c-6dbb-419b-a570-6817016e5fe2





## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
