### PR TITLE
[TT-17515] Sub-second enforced timeout for Tyk Classic (duration field + round-up)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -231,7 +231,24 @@ type HardTimeoutMeta struct {
 	Method   string `bson:"method" json:"method"`
 	// Deprecated: Use TimeoutDuration instead.
 	TimeOut         int                      `bson:"timeout" json:"timeout"`
-	TimeoutDuration tyktime.ReadableDuration `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty"`
+	TimeoutDuration tyktime.ReadableDuration `bson:"duration,omitempty" json:"duration,omitempty"`
+}
+
+// FillHardTimeoutDeprecatedFields synchronises the deprecated whole-second timeout
+// (TimeOut) from the sub-second TimeoutDuration for every hard timeout, rounding up
+// to the nearest second. When a duration is set it takes precedence and overwrites
+// the deprecated value, mirroring the OAS EnforceTimeout.ExtractTo behaviour, so
+// that older Gateways (which only read the deprecated field) still enforce a timeout.
+// It is a no-op for entries without a duration.
+func (a *APIDefinition) FillHardTimeoutDeprecatedFields() {
+	for _, version := range a.VersionData.Versions {
+		for i := range version.ExtendedPaths.HardTimeouts {
+			meta := &version.ExtendedPaths.HardTimeouts[i]
+			if meta.TimeoutDuration != 0 {
+				meta.TimeOut = int(meta.TimeoutDuration.SecondsCeil())
+			}
+		}
+	}
 }
 
 type TrackEndpointMeta struct {

--- a/apidef/hard_timeout_test.go
+++ b/apidef/hard_timeout_test.go
@@ -1,0 +1,100 @@
+package apidef
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	tyktime "github.com/TykTechnologies/tyk/internal/time"
+)
+
+func TestAPIDefinition_FillHardTimeoutDeprecatedFields(t *testing.T) {
+	makeAPI := func(metas ...HardTimeoutMeta) *APIDefinition {
+		return &APIDefinition{
+			VersionData: VersionData{
+				Versions: map[string]VersionInfo{
+					"Default": {
+						ExtendedPaths: ExtendedPathsSet{HardTimeouts: metas},
+					},
+				},
+			},
+		}
+	}
+
+	get := func(a *APIDefinition) HardTimeoutMeta {
+		return a.VersionData.Versions["Default"].ExtendedPaths.HardTimeouts[0]
+	}
+
+	t.Run("rounds duration up and overwrites legacy timeout", func(t *testing.T) {
+		api := makeAPI(HardTimeoutMeta{
+			Path:            "/get",
+			Method:          http.MethodGet,
+			TimeOut:         5,
+			TimeoutDuration: tyktime.ReadableDuration(1200 * time.Millisecond),
+		})
+		api.FillHardTimeoutDeprecatedFields()
+		assert.Equal(t, 2, get(api).TimeOut)
+		assert.Equal(t, tyktime.ReadableDuration(1200*time.Millisecond), get(api).TimeoutDuration)
+	})
+
+	t.Run("sub-second duration rounds up to one second", func(t *testing.T) {
+		api := makeAPI(HardTimeoutMeta{
+			Path:            "/get",
+			Method:          http.MethodGet,
+			TimeoutDuration: tyktime.ReadableDuration(500 * time.Millisecond),
+		})
+		api.FillHardTimeoutDeprecatedFields()
+		assert.Equal(t, 1, get(api).TimeOut)
+	})
+
+	t.Run("no duration leaves legacy timeout untouched", func(t *testing.T) {
+		api := makeAPI(HardTimeoutMeta{
+			Path:    "/get",
+			Method:  http.MethodGet,
+			TimeOut: 3,
+		})
+		api.FillHardTimeoutDeprecatedFields()
+		assert.Equal(t, 3, get(api).TimeOut)
+		assert.Equal(t, tyktime.ReadableDuration(0), get(api).TimeoutDuration)
+	})
+
+	t.Run("exact whole-second duration is not rounded further", func(t *testing.T) {
+		api := makeAPI(HardTimeoutMeta{
+			Path:            "/get",
+			Method:          http.MethodGet,
+			TimeOut:         9,
+			TimeoutDuration: tyktime.ReadableDuration(2 * time.Second),
+		})
+		api.FillHardTimeoutDeprecatedFields()
+		assert.Equal(t, 2, get(api).TimeOut, "exact 2s must stay 2, not round to 3")
+	})
+
+	t.Run("applies per entry across multiple versions, leaving no-duration entries untouched", func(t *testing.T) {
+		api := &APIDefinition{
+			VersionData: VersionData{
+				Versions: map[string]VersionInfo{
+					"v1": {
+						ExtendedPaths: ExtendedPathsSet{HardTimeouts: []HardTimeoutMeta{
+							{Path: "/a", Method: http.MethodGet, TimeoutDuration: tyktime.ReadableDuration(1200 * time.Millisecond)},
+							{Path: "/b", Method: http.MethodGet, TimeOut: 7},
+						}},
+					},
+					"v2": {
+						ExtendedPaths: ExtendedPathsSet{HardTimeouts: []HardTimeoutMeta{
+							{Path: "/c", Method: http.MethodGet, TimeoutDuration: tyktime.ReadableDuration(500 * time.Millisecond)},
+						}},
+					},
+				},
+			},
+		}
+
+		api.FillHardTimeoutDeprecatedFields()
+
+		v1 := api.VersionData.Versions["v1"].ExtendedPaths.HardTimeouts
+		assert.Equal(t, 2, v1[0].TimeOut, "v1 /a 1.2s rounds up to 2 (mutation must persist through the map)")
+		assert.Equal(t, 7, v1[1].TimeOut, "v1 /b without duration must be left untouched")
+		assert.Equal(t, 1, api.VersionData.Versions["v2"].ExtendedPaths.HardTimeouts[0].TimeOut, "v2 /c 500ms rounds up to 1")
+	})
+}

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1323,7 +1323,7 @@ type EnforceTimeout struct {
 
 	// Duration is the configured timeout duration. Supports sub-second values (e.g. "500ms", "5s").
 	//
-	// Tyk classic API definition: `version_data.versions.extended_paths.hard_timeouts[].timeout_duration`.
+	// Tyk classic API definition: `version_data.versions.extended_paths.hard_timeouts[].duration`.
 	Duration tyktime.ReadableDuration `bson:"duration,omitempty" json:"duration,omitempty"`
 }
 

--- a/apidef/schema.json
+++ b/apidef/schema.json
@@ -642,7 +642,7 @@
                           "timeout": {
                             "type": "integer"
                           },
-                          "timeout_duration": {
+                          "duration": {
                             "type": "string",
                             "pattern": "^(\\d+(?:\\.\\d+)?m)?(\\d+(?:\\.\\d+)?s)?(\\d+(?:\\.\\d+)?ms)?$"
                           }

--- a/apidef/validator_test.go
+++ b/apidef/validator_test.go
@@ -413,6 +413,62 @@ func TestRuleValidateEnforceTimeout_Validate(t *testing.T) {
 				Errors:  nil,
 			},
 		},
+		{
+			name: "sub-second duration is valid",
+			apiDef: getAPIDef([]HardTimeoutMeta{
+				{
+					Path:            "/get",
+					Method:          http.MethodGet,
+					TimeoutDuration: tyktime.ReadableDuration(1500 * time.Millisecond),
+				},
+			}),
+			result: ValidationResult{
+				IsValid: true,
+				Errors:  nil,
+			},
+		},
+		{
+			name: "1ms duration is valid (boundary)",
+			apiDef: getAPIDef([]HardTimeoutMeta{
+				{
+					Path:            "/get",
+					Method:          http.MethodGet,
+					TimeoutDuration: tyktime.ReadableDuration(time.Millisecond),
+				},
+			}),
+			result: ValidationResult{
+				IsValid: true,
+				Errors:  nil,
+			},
+		},
+		{
+			name: "negative duration is invalid",
+			apiDef: getAPIDef([]HardTimeoutMeta{
+				{
+					Path:            "/get",
+					Method:          http.MethodGet,
+					TimeoutDuration: tyktime.ReadableDuration(-3 * time.Second),
+				},
+			}),
+			result: ValidationResult{
+				IsValid: false,
+				Errors:  []error{ErrInvalidTimeoutValue},
+			},
+		},
+		{
+			name: "zero duration with enabled entry is valid (no timeout)",
+			apiDef: getAPIDef([]HardTimeoutMeta{
+				{
+					Disabled: false,
+					Path:     "/get",
+					Method:   http.MethodGet,
+				},
+			}),
+			result: ValidationResult{
+				IsValid: true,
+				Errors:  nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1381,6 +1381,10 @@ func (gw *Gateway) handleAddApi(r *http.Request, fs afero.Fs, oasEndpoint bool) 
 	} else {
 		newDef.IsOAS = false
 
+		// Round the sub-second hard timeout durations up into the deprecated
+		// whole-second field so older Gateways still enforce a timeout.
+		newDef.FillHardTimeoutDeprecatedFields()
+
 		err, errCode := gw.writeToFile(fs, newDef, newDef.APIID)
 		if err != nil {
 			return apiError(err.Error()), errCode
@@ -1459,6 +1463,10 @@ func (gw *Gateway) handleUpdateApi(apiID string, r *http.Request, fs afero.Fs, o
 
 	} else if !oasEndpoint {
 		newDef.IsOAS = false
+
+		// Round the sub-second hard timeout durations up into the deprecated
+		// whole-second field so older Gateways still enforce a timeout.
+		newDef.FillHardTimeoutDeprecatedFields()
 
 		err, errCode := gw.writeToFile(fs, newDef, newDef.APIID)
 		if err != nil {

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
 	internalmodel "github.com/TykTechnologies/tyk/internal/model"
+	tyktime "github.com/TykTechnologies/tyk/internal/time"
 	"github.com/TykTechnologies/tyk/internal/uuid"
 	"github.com/TykTechnologies/tyk/pkg/identifier"
 	"github.com/TykTechnologies/tyk/storage"
@@ -2334,6 +2335,41 @@ func TestHandleAddApi(t *testing.T) {
 
 		assert.Equal(t, "Request malformed", errorResponse.Message)
 		assert.Equal(t, http.StatusBadRequest, statusCode)
+	})
+
+	t.Run("rounds up classic hard timeout duration into legacy field on save", func(t *testing.T) {
+		apiDef := apidef.DummyAPI()
+		apiDef.APIID = "ht-roundup"
+		v := apiDef.VersionData.Versions["Default"]
+		v.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
+			{
+				Path:            "/get",
+				Method:          http.MethodGet,
+				TimeOut:         5,
+				TimeoutDuration: tyktime.ReadableDuration(1200 * time.Millisecond),
+			},
+		}
+		apiDef.VersionData.Versions["Default"] = v
+
+		apiDefJson, err := json.Marshal(apiDef)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "http://gateway", bytes.NewBuffer(apiDefJson))
+		require.NoError(t, err)
+
+		_, statusCode := ts.Gw.handleAddApi(req, testFs, false)
+		require.Equal(t, http.StatusOK, statusCode)
+
+		defFilePath := filepath.Join(ts.Gw.GetConfig().AppPath, "ht-roundup.json")
+		stored, err := afero.ReadFile(testFs, defFilePath)
+		require.NoError(t, err)
+
+		var storedDef apidef.APIDefinition
+		require.NoError(t, json.Unmarshal(stored, &storedDef))
+
+		got := storedDef.VersionData.Versions["Default"].ExtendedPaths.HardTimeouts[0]
+		assert.Equal(t, 2, got.TimeOut, "duration 1.2s should round up to 2s in the legacy timeout field")
+		assert.Equal(t, tyktime.ReadableDuration(1200*time.Millisecond), got.TimeoutDuration)
 	})
 
 	t.Run("should return error when semantic validation fails", func(t *testing.T) {


### PR DESCRIPTION
## Description

Finishes the **Tyk Classic** side of the sub-second enforced-timeout feature (parent [TT-12339](https://tyktech.atlassian.net/browse/TT-12339); this work [TT-17515](https://tyktech.atlassian.net/browse/TT-17515)), which had only been completed for Tyk OAS.

Two changes, intentionally minimal:

1. **Rename the Classic wire field** `hard_timeouts.timeout_duration` → `hard_timeouts.duration` (JSON + BSON tags and the classic JSON schema), matching the agreed OAS name `enforceTimeout.duration`. The Go field `HardTimeoutMeta.TimeoutDuration` keeps its name. This field is pre-release/unreleased, so there is **no stored-data migration** and no compatibility concern.

2. **Round-up / back-fill:** new `APIDefinition.FillHardTimeoutDeprecatedFields()` rounds the sub-second `duration` **up** to whole seconds (`SecondsCeil`) and writes it into the deprecated `timeout` field. When `duration` is set it takes precedence and **overwrites** any supplied legacy value, mirroring the OAS `EnforceTimeout.ExtractTo` behaviour, so older Gateways that only read the legacy field still enforce a timeout. It is called on the Classic create/update REST paths (`handleAddApi`, `handleUpdateApi`) before persisting.

## Motivation and Context

A `duration` set on a Classic API was **not** rounded into the less-granular `hard_timeouts.timeout`, so an API using the new field would have **no timeout** on an older Gateway. The field name was also inconsistent with OAS. Both are fixed here.

**Scope is deliberately minimal — no new validation is added.** Negative values are still rejected by the existing rule; empty / `0` / `0ms` remain valid ("no per-endpoint timeout"). OAS already round-ups via `EnforceTimeout.ExtractTo` and validates format via its JSON schema.

## Known limitation

The legacy back-fill runs on the Gateway's REST write path. Dashboard-authored APIs are filled by the Dashboard on save (separate follow-up); other ingestion paths (Dashboard sync, RPC/MDCB, file load) carry the already-filled value from their source rather than re-deriving it.

## Dependency

Depends on #8319 (adds `duration` to the MCP/Streams OAS schema copies the original OAS rename missed). Out of scope here.

## How This Has Been Tested

- Unit tests for the round-up: overwrite semantics, ceil rounding, exact-whole-second, no-duration no-op, and multi-version/multi-entry mutation.
- Gateway handler test asserting the persisted Classic definition carries the rounded-up legacy `timeout`.
- `go build ./...`, `go test ./apidef/... ./internal/time/...`, and the relevant `gateway` tests pass; `gofmt` clean.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring or add test


[TT-12339]: https://tyktech.atlassian.net/browse/TT-12339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-17515]: https://tyktech.atlassian.net/browse/TT-17515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ