### PR TITLE
[TT-17515] Rename Tyk Classic hard_timeouts duration wire field

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -231,7 +231,7 @@ type HardTimeoutMeta struct {
 	Method   string `bson:"method" json:"method"`
 	// Deprecated: Use TimeoutDuration instead.
 	TimeOut         int                      `bson:"timeout" json:"timeout"`
-	TimeoutDuration tyktime.ReadableDuration `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty"`
+	TimeoutDuration tyktime.ReadableDuration `bson:"duration,omitempty" json:"duration,omitempty"`
 }
 
 type TrackEndpointMeta struct {

--- a/apidef/api_definitions_test.go
+++ b/apidef/api_definitions_test.go
@@ -54,6 +54,42 @@ func TestAPIDefinition_JsonRpcVersion(t *testing.T) {
 	})
 }
 
+// TestHardTimeoutMeta_DurationWireTag locks in the TT-17515 rename of the
+// granular enforced-timeout field from `timeout_duration` to `duration`.
+// The Go field name (TimeoutDuration) is unchanged; only the JSON/BSON tags moved.
+func TestHardTimeoutMeta_DurationWireTag(t *testing.T) {
+	t.Run("marshals to duration, not timeout_duration", func(t *testing.T) {
+		meta := HardTimeoutMeta{
+			Path:            "/get",
+			Method:          http.MethodGet,
+			TimeOut:         2,
+			TimeoutDuration: tyktime.ReadableDuration(1500 * time.Millisecond),
+		}
+
+		data, err := json.Marshal(meta)
+		assert.NoError(t, err)
+
+		assert.Contains(t, string(data), `"duration"`)
+		assert.NotContains(t, string(data), "timeout_duration")
+	})
+
+	t.Run("unmarshals the duration key", func(t *testing.T) {
+		var meta HardTimeoutMeta
+		err := json.Unmarshal([]byte(`{"path":"/get","method":"GET","timeout":2,"duration":"500ms"}`), &meta)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, meta.TimeOut)
+		assert.Equal(t, tyktime.ReadableDuration(500*time.Millisecond), meta.TimeoutDuration)
+	})
+
+	t.Run("empty duration omitted", func(t *testing.T) {
+		data, err := json.Marshal(HardTimeoutMeta{Path: "/get", Method: http.MethodGet, TimeOut: 3})
+		assert.NoError(t, err)
+
+		assert.NotContains(t, string(data), "duration")
+	})
+}
+
 func TestAPIDefinition_ApplicationProtocol(t *testing.T) {
 	t.Run("application protocol field marshaling", func(t *testing.T) {
 		api := APIDefinition{

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1323,7 +1323,7 @@ type EnforceTimeout struct {
 
 	// Duration is the configured timeout duration. Supports sub-second values (e.g. "500ms", "5s").
 	//
-	// Tyk classic API definition: `version_data.versions.extended_paths.hard_timeouts[].timeout_duration`.
+	// Tyk classic API definition: `version_data.versions.extended_paths.hard_timeouts[].duration`.
 	Duration tyktime.ReadableDuration `bson:"duration,omitempty" json:"duration,omitempty"`
 }
 

--- a/apidef/schema.json
+++ b/apidef/schema.json
@@ -642,7 +642,7 @@
                           "timeout": {
                             "type": "integer"
                           },
-                          "timeout_duration": {
+                          "duration": {
                             "type": "string",
                             "pattern": "^(\\d+(?:\\.\\d+)?m)?(\\d+(?:\\.\\d+)?s)?(\\d+(?:\\.\\d+)?ms)?$"
                           }


### PR DESCRIPTION
## Summary

Renames the granular enforced-timeout field on the **Tyk Classic** API definition from `timeout_duration` to `duration`, so it matches the Tyk OAS field name (`enforceTimeout.duration`). Closes the Classic half of the `duration` rename agreed during TT-12339 (OAS was done in #8278).

Ticket: **TT-17515** (parent TT-12339).

## What changed

Minimal **wire-tag rename only** — the Go field name `HardTimeoutMeta.TimeoutDuration` is unchanged, so the enforcement path (`gateway/reverse_proxy.go`) and the negative-value validator (`apidef/validator.go`) are untouched.

- `apidef/api_definitions.go` — `HardTimeoutMeta.TimeoutDuration` json/bson tag `timeout_duration` → `duration`
- `apidef/schema.json` — `hard_timeouts[]` item property renamed (format pattern preserved)
- `apidef/oas/middleware.go` — doc-comment reference updated
- `apidef/api_definitions_test.go` — new `TestHardTimeoutMeta_DurationWireTag` (marshal/unmarshal/omitempty)

## Out of scope (by product decision)

- **No round-up for Classic.** Setting only `duration` is *not* folded into the legacy whole-second `timeout` field. This was a deliberate omission (agreed with product) — a Classic API created with only `duration` has no enforced timeout on an older Gateway unless `timeout` is also set. This is an accepted, documented limitation; users wanting sub-second precision are steered to Tyk OAS.
- **No new backend validation.** Negatives still rejected (existing behaviour); empty/`0`/`0ms` remain valid (no timeout).

## Compatibility

- **Backwards compatible:** the legacy whole-second `timeout` field is untouched; existing APIs keep working on upgrade and downgrade.
- **No JSON alias for the old key.** The pre-release `timeout_duration` name was **never released**, so there is nothing to migrate — any definition still carrying that key would deserialize the granular value as zero. This rename is safe on that premise.

## Testing

- `go test ./apidef/ -run 'TestSchema$|HardTimeoutMeta_DurationWireTag' -count=1` ✅ (incl. struct-vs-embedded-schema validation)
- `go test ./gateway/ -run TestTimeoutPrioritization -count=1` ✅ (sub-second + legacy enforcement)

## Downstream

Dashboard support is in tyk-analytics-ui (Classic designer note) + a `tyk` dependency bump in tyk-analytics that lands after this merges.
