### PR TITLE
[TT-17569] Bump storage to v1.3.4 (CVE fixes)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2
-	github.com/TykTechnologies/storage v1.3.1
+	github.com/TykTechnologies/storage v1.3.4
 	github.com/TykTechnologies/tyk-pump v1.14.1-rc2
 	github.com/akutz/memconn v0.1.0
 	github.com/bshuster-repo/logrus-logstash-hook v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/TykTechnologies/openid2go v0.1.2 h1:WXctksOahA/epTVVvbn9iNUuMXKRr0ksr
 github.com/TykTechnologies/openid2go v0.1.2/go.mod h1:gYfkqeWa+lY3Xz/Z2xYtIzmYXynlgKZaBIbPCqdcdMA=
 github.com/TykTechnologies/opentelemetry v0.0.22 h1:dKYUbUVe6M23grue2kxNMDK7KL5VW5AwQbaOEqZlfEM=
 github.com/TykTechnologies/opentelemetry v0.0.22/go.mod h1:O5Fh2KKeno6IEHvIhWlmpf+MHSj5sjSGCpxbo2nqSaU=
-github.com/TykTechnologies/storage v1.3.1 h1:UzfrAillaXXe5AHeIGUHVf/1niLPNJChMWrqgjCiAjY=
-github.com/TykTechnologies/storage v1.3.1/go.mod h1:fw7yR9/LgVFVAlaQFLypFnfsIP/JOkF/tAsgAwMkKj0=
+github.com/TykTechnologies/storage v1.3.4 h1:avLJFoHdHSbBfGUSme0vOIuMEzVfdgroVf21szsZcys=
+github.com/TykTechnologies/storage v1.3.4/go.mod h1:H55F7A43TeOAYkvKgAqNQPQoqHa9gzAe7mkhhRsCtLc=
 github.com/TykTechnologies/tyk-pump v1.14.1-rc2 h1:FZVTGv+m/J1gU8PRtCUhvQgpfb2/umQVorstdv+xi1I=
 github.com/TykTechnologies/tyk-pump v1.14.1-rc2/go.mod h1:av5P8OrDOrYtlXz2fqjw23lfBW/vZPleLwdc9+nmOv4=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=


### PR DESCRIPTION
## What
Bumps `github.com/TykTechnologies/storage` v1.3.1 → v1.3.3 and
`golang.org/x/crypto` v0.49.0 → v0.52.0 (indirect). The module graph now pins
`go.mongodb.org/mongo-driver` to v1.17.7 (storage's requirement).

## Why
storage v1.3.3 carries the CVE-2026-2303 fix (heap OOB read in the mongo-driver
GSSAPI/Kerberos CGo wrapper) plus the x/crypto SSH advisory fixes.