### PR TITLE
[TT-17578] Bump graphql-go-tools to fix Federation subscription-then-query null regression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/TykTechnologies/goautosocket v0.0.0-20190430121222-97bfa5e7e481
 	github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6
 	github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260623130956-98d2c88fce43
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260624141309-dae0d8d8d038
 	github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/TykTechnologies/goautosocket v0.0.0-20190430121222-97bfa5e7e481
 	github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6
 	github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260610093432-c7048b604e16
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260623130956-98d2c88fce43
 	github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6 h1:wwt23wdyi
 github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6/go.mod h1:v6v7Mlj08+EmEcXOfpuTxGt2qYU9yhqqtv4QF9Wf50E=
 github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e h1:wbd35YYCywZbgc4Fk/G2pQHnvwYzjedrw8pNzUsVowg=
 github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e/go.mod h1:WtiSLIlItUVsHyHQB1NG+de/L4/PTtmZWc9CnzTRBLs=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260610093432-c7048b604e16 h1:gqmN+bl7hZoRrrckPicIu+m+Y6k3o8oPYpA9jWy1YiM=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260610093432-c7048b604e16/go.mod h1:bvVafmGebtdjIFG2bXkLd+O1jOjjU/3To+mQHcLr4KI=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260623130956-98d2c88fce43 h1:svepDDOAyOuzKKsgL5I/J+/tm2jmELXgNOnSnHsy6uc=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260623130956-98d2c88fce43/go.mod h1:bvVafmGebtdjIFG2bXkLd+O1jOjjU/3To+mQHcLr4KI=
 github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d h1:bK9T78hExbTuDK4UaBuGi9aL28hK68Uw3OyNZswdPcA=
 github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d/go.mod h1:XM1owY0ZCJ1Rai64Q1UKXZYNDkWikZDojgefZw8raPk=
 github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36 h1:7nNsyocI/RKBqo73RR9G/SiFMZ8w2sN+HMsQXYp9wPI=

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6 h1:wwt23wdyi
 github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6/go.mod h1:v6v7Mlj08+EmEcXOfpuTxGt2qYU9yhqqtv4QF9Wf50E=
 github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e h1:wbd35YYCywZbgc4Fk/G2pQHnvwYzjedrw8pNzUsVowg=
 github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e/go.mod h1:WtiSLIlItUVsHyHQB1NG+de/L4/PTtmZWc9CnzTRBLs=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260623130956-98d2c88fce43 h1:svepDDOAyOuzKKsgL5I/J+/tm2jmELXgNOnSnHsy6uc=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260623130956-98d2c88fce43/go.mod h1:bvVafmGebtdjIFG2bXkLd+O1jOjjU/3To+mQHcLr4KI=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260624141309-dae0d8d8d038 h1:akyeFvwB5ZnVq9jbGPx1pP33ETxp0ziDlt5r40HRCDY=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260624141309-dae0d8d8d038/go.mod h1:bvVafmGebtdjIFG2bXkLd+O1jOjjU/3To+mQHcLr4KI=
 github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d h1:bK9T78hExbTuDK4UaBuGi9aL28hK68Uw3OyNZswdPcA=
 github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d/go.mod h1:XM1owY0ZCJ1Rai64Q1UKXZYNDkWikZDojgefZw8raPk=
 github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36 h1:7nNsyocI/RKBqo73RR9G/SiFMZ8w2sN+HMsQXYp9wPI=


### PR DESCRIPTION
## Description

Bumps `github.com/TykTechnologies/graphql-go-tools` to pick up **TykTechnologies/graphql-go-tools#447**.

### The bug

On a GraphQL Federation supergraph API, running a subscription (websocket) first and then a query over the same connection makes the query return `null` instead of data. Gateway logs show `websocket upgrade for GraphQL engine failed: 'upgrade' token not found in 'Connection' header` against the subgraphs. Regression introduced in 5.8.15 / 5.13.1 / 5.14.0 (clean on 5.8.14 and 5.13.0).

### Root cause

The gateway tags an inbound websocket subscription request with a context value `GraphQLIsWebSocketUpgrade=true`. The library change in #446 ([TT-17442]) wrapped the subscription executor's context in a `mergedContext` that resolved values from that original request context, so the flag leaked into every subgraph fetch. The subgraphs then tried to perform a websocket handshake on plain HTTP fetches, which failed → `null`.

### The fix (library #447)

The executor now builds its execution context without inheriting the original request's context values, while still forwarding the per-request header modifier — preserving TT-17442's per-user connection/credential isolation. See #447 for details and tests.

## Scope

- Bumps the **v1** module only (`v1.6.2-0.20260610093432-c7048b604e16` → `v1.6.2-0.20260623130956-98d2c88fce43`).
- The gateway's `graphql-go-tools/v2` pin predates TT-17442, so the v3/v2 engine path is **not** affected and is intentionally left unchanged.

## Verification

- `go mod verify` passes; `internal/graphengine` and `apidef/adapter/...` build against the new pin.

> Draft — depends on graphql-go-tools#447, which is not merged yet. The version pin points at the #447 branch commit and must be re-pinned to the squash-merge commit once #447 lands.

[TT-17442]: https://tyktech.atlassian.net/browse/TT-17442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ