### PR TITLE
[TT-17585] MinTokenLength: apply the default floor of 3 to the create-time guard

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -600,7 +600,14 @@ func (gw *Gateway) handleAddOrUpdate(keyName string, r *http.Request, isHashed b
 		// auth attempt with the raw ID would silently 403 (AKI). Empty keyName
 		// is fine — generateToken below will produce a safe-length UUID envelope.
 		minLen := gw.GetConfig().MinTokenLength
-		if keyName != "" && minLen > 0 && len(keyName) < minLen {
+		if minLen == 0 {
+			// Mirror the auth-time floor: when min_token_length is unset,
+			// CheckSessionAndIdentityForValidKey still enforces a minimum of 3
+			// (issue #1681). Without the same fallback here a 1-2 char custom ID
+			// is accepted at create yet unreachable at auth (TT-17585).
+			minLen = 3
+		}
+		if keyName != "" && len(keyName) < minLen {
 			return apiError(fmt.Sprintf(
 				"custom key ID length %d is less than min_token_length (%d); "+
 					"the key would be unreachable at auth time. Use an ID of at least min_token_length characters, "+

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -599,14 +599,7 @@ func (gw *Gateway) handleAddOrUpdate(keyName string, r *http.Request, isHashed b
 		// shorter than that length would succeed here but every subsequent
 		// auth attempt with the raw ID would silently 403 (AKI). Empty keyName
 		// is fine — generateToken below will produce a safe-length UUID envelope.
-		minLen := gw.GetConfig().MinTokenLength
-		if minLen == 0 {
-			// Mirror the auth-time floor: when min_token_length is unset,
-			// CheckSessionAndIdentityForValidKey still enforces a minimum of 3
-			// (issue #1681). Without the same fallback here a 1-2 char custom ID
-			// is accepted at create yet unreachable at auth (TT-17585).
-			minLen = 3
-		}
+		minLen := effectiveMinTokenLength(gw.GetConfig().MinTokenLength)
 		if keyName != "" && len(keyName) < minLen {
 			return apiError(fmt.Sprintf(
 				"custom key ID length %d is less than min_token_length (%d); "+

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -1149,6 +1149,62 @@ func TestKeyHandler_RejectCustomKeyBelowMinTokenLength(t *testing.T) {
 	})
 }
 
+// TestKeyHandler_DefaultMinTokenLengthFloorOnCreate locks the create path to the
+// same effective floor the auth-time gate enforces when min_token_length is
+// unset. CheckSessionAndIdentityForValidKey falls back to a minimum of 3 (see
+// middleware.go / issue #1681), so without an explicitly configured
+// min_token_length a custom ID of length 1-2 must still be rejected at create —
+// otherwise it is accepted here yet 403s (AKI) at auth, the exact silent-accept
+// trap TT-17065 set out to close, just at the default-config boundary that the
+// original create guard left open (reported in TT-17585).
+func TestKeyHandler_DefaultMinTokenLengthFloorOnCreate(t *testing.T) {
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.MinTokenLength = 0 // unset -> effective floor of 3
+	})
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = false
+		spec.APIID = "test"
+		spec.Auth.AuthHeaderName = "authorization"
+	})
+
+	session := CreateStandardSession()
+	session.AccessRights = map[string]user.AccessDefinition{"test": {
+		APIID: "test", Versions: []string{"Default"},
+	}}
+	body := test.MarshalJSON(t)(session)
+
+	cases := []struct {
+		name     string
+		keyID    string
+		wantCode int
+	}{
+		{
+			name:     "below_default_floor_rejected",
+			keyID:    "ab", // 2 chars, strictly below the default floor of 3
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "equal_to_default_floor_accepted",
+			keyID:    "abc", // 3 chars, == default floor
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _ = ts.Run(t, test.TestCase{
+				Method:    http.MethodPost,
+				Path:      "/tyk/keys/" + tc.keyID,
+				Data:      body,
+				AdminAuth: true,
+				Code:      tc.wantCode,
+			})
+		})
+	}
+}
+
 func TestHashKeyHandler(t *testing.T) {
 	t.Skip() // DeleteAllKeys interferes with other tests.
 

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -612,15 +612,26 @@ func copyAllowedURLs(input []user.AccessSpec) []user.AccessSpec {
 	return copied
 }
 
+// defaultMinTokenLength is the floor applied to key length when min_token_length
+// is unset. It is enforced at both create time (handleAddOrUpdate) and auth time
+// so the two cannot drift (see TT-17585).
+// See https://github.com/TykTechnologies/tyk/issues/1681.
+const defaultMinTokenLength = 3
+
+// effectiveMinTokenLength returns the configured min_token_length, or the
+// default floor when it is unset (0).
+func effectiveMinTokenLength(configured int) int {
+	if configured == 0 {
+		return defaultMinTokenLength
+	}
+	return configured
+}
+
 // CheckSessionAndIdentityForValidKey will check first the Session store for a valid key, if not found, it will try
 // the Auth Handler, if not found it will fail
 func (t *BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey string, r *http.Request) (user.SessionState, bool) {
 	key := originalKey
-	minLength := t.Spec.GlobalConfig.MinTokenLength
-	if minLength == 0 {
-		// See https://github.com/TykTechnologies/tyk/issues/1681
-		minLength = 3
-	}
+	minLength := effectiveMinTokenLength(t.Spec.GlobalConfig.MinTokenLength)
 
 	if len(key) < minLength {
 		return user.SessionState{IsInactive: true}, false


### PR DESCRIPTION
## What

Follow-up to **TT-17065**. The create-time custom-key guard added there only engages when `min_token_length` is **explicitly configured** (`minLen > 0`). The auth-time gate, `CheckSessionAndIdentityForValidKey`, falls back to a minimum of **3** when `min_token_length` is unset (issue #1681). The two used different effective floors at default config, leaving a gap:

| `min_token_length` | custom ID len | create (before) | auth | net (before) |
|---|---|---|---|---|
| unset (→ 3 at auth) | 1–2 | **200** | **403 (AKI)** | silent-accept ❌ |
| unset | ≥3 | 200 | 200 | fine |
| set = N | < N | 400 | — | rejected ✓ (TT-17065) |

A 1–2 char custom key ID at default config was accepted at create but unreachable at auth — the same silent-accept trap TT-17065 set out to close, just at the default-config boundary. Reported in **TT-17585**.

## Change

`gateway/api.go` — in `handleAddOrUpdate`'s POST (create) branch, apply the same `min_token_length == 0 → 3` fallback the auth gate uses, so the create guard rejects custom IDs shorter than the **effective** floor:

```go
minLen := gw.GetConfig().MinTokenLength
if minLen == 0 {
    minLen = 3 // mirror the auth-time floor (issue #1681)
}
if keyName != "" && len(keyName) < minLen {
    return apiError(...), http.StatusBadRequest
}
```

The Dashboard `/api/keys` path inherits this automatically — it proxies to the gateway's `/tyk/keys` and bubbles up the 4xx, so **no Dashboard change is needed** (TT-17585 was originally filed as a Dashboard gap; it is not).

## Tests

- Added `TestKeyHandler_DefaultMinTokenLengthFloorOnCreate`: at default/unset `min_token_length`, custom ID len 2 → `400`, len 3 → `200`.
- Existing `TestKeyHandler_RejectCustomKeyBelowMinTokenLength` (explicit `MinTokenLength=32`) unchanged and still passes.
- Full `TestKeyHandler*` group passes. A repo-wide search confirmed no existing test creates a 1–2 char custom key ID at default config (shortest is `"user"`, 4 chars), so nothing else is affected.

## Backwards compatibility

- Pure tightening at the very bottom of the range: only `POST /tyk/keys/<id>` creates with a **1–2 char custom ID at default config** change behaviour (now `400` instead of `200`). Such keys were already unusable — they `403` at auth — so no previously-working key creation is affected.
- Explicit `min_token_length`, autogenerated creates (`POST /tyk/keys/create`), PUT/update, and all existing keys are unchanged.

## Verification on a real stack

Reproduced and validated on a matched **5.8.15-rc1** tyk-demo (gateway-ee + dashboard):
- `min_token_length=32`: gateway `POST /tyk/keys/ee` → `400`; dashboard `POST /api/keys/ee` → `403` (gateway message bubbled up).
- default config (before this PR): both surfaces → `200`, then `403` at traffic. This PR closes that window.

Refs: TT-17585, TT-17065 (#8154)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdwVB9D3hGDjeTR58pWZMn
