### PR TITLE
fix: set DateCreated on OAuth token sessions

### DIFF
--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -996,6 +996,10 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 	// Override timeouts so that we can be in sync with Osin
 	newSession.Expires = time.Now().Unix() + int64(accessData.ExpiresIn)
 
+	// Record the creation time, matching the normal key creation flow;
+	// otherwise date_created serialises as Go's zero time (0001-01-01T00:00:00Z).
+	newSession.DateCreated = time.Now()
+
 	c, ok := accessData.Client.(*OAuthClient)
 	if ok && c.MetaData != nil {
 		if newSession.MetaData == nil {


### PR DESCRIPTION
Fixes #7917

## Problem

When issuing an OAuth 2.0 access token (`POST /tyk/oauth/authorize-client`), the resulting key/session has `date_created` set to Go's zero time (`0001-01-01T00:00:00Z`) instead of the real creation time.

In `RedisOsinStorageInterface.SaveAccess` (`gateway/oauth_manager.go`), `newSession` is built via `user.NewSessionState()` (or `generateSessionFromPolicy`) and several fields are overridden (`OauthClientID`, `Expires`, `MetaData`), but `DateCreated` is never assigned — so it keeps the zero value. The normal key-creation flow in `gateway/api.go` sets `newSession.DateCreated = time.Now()`; the OAuth path doesn't.

## Fix

Set `newSession.DateCreated = time.Now()` in `SaveAccess`, alongside the other session-field overrides, matching the normal key-creation flow.

`time` is already imported (used on the adjacent `Expires` line). One-line, type-safe change verifiable by inspection.

Note: this fixes newly issued tokens. Existing tokens already stored with the zero value stay as-is, since `PUT /tyk/keys/{keyId}` intentionally preserves the original `DateCreated` — happy to discuss whether that path should also be adjusted, but the root cause is the missing assignment here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)