### PR TITLE
fix: add Date header during request signing with a non-empty header_list

### DIFF
--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -56,7 +56,20 @@ func generateHeaderList(r *http.Request, headerList []string) []string {
 		result = make([]string, 0, len(headerList))
 
 		for _, v := range headerList {
-			if r.Header.Get(v) != "" {
+			switch {
+			case strings.EqualFold(v, "(request-target)"):
+				// Pseudo-header derived from method + path, not a real request
+				// header, so include it regardless of what r.Header contains.
+				result = append(result, v)
+			case strings.EqualFold(v, "date"):
+				// The Date header is required by the Signing HTTP Messages draft;
+				// add it if the client did not send one, then include it.
+				if r.Header.Get("date") == "" {
+					refDate := "Mon, 02 Jan 2006 15:04:05 MST"
+					r.Header.Set("date", time.Now().Format(refDate))
+				}
+				result = append(result, v)
+			case r.Header.Get(v) != "":
 				result = append(result, v)
 			}
 		}

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -694,3 +694,37 @@ func TestRequestSigning_isRequestSigningConfigValid(t *testing.T) {
 		assert.Equal(t, tc.expected, rs.isRequestSigningConfigValid())
 	}
 }
+
+func TestGenerateHeaderList(t *testing.T) {
+	contains := func(list []string, v string) bool {
+		for _, s := range list {
+			if s == v {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("adds Date header when listed but absent from the request", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("x-example", "value")
+
+		result := generateHeaderList(r, []string{"(request-target)", "x-example", "date"})
+
+		assert.True(t, contains(result, "date"), "date should be part of the signed header list")
+		assert.NotEmpty(t, r.Header.Get("date"), "a Date header should have been added to the request")
+		assert.True(t, contains(result, "(request-target)"), "(request-target) should always be included")
+		assert.True(t, contains(result, "x-example"))
+	})
+
+	t.Run("does not override an existing Date header", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		existing := "Mon, 02 Jan 2006 15:04:05 MST"
+		r.Header.Set("date", existing)
+
+		result := generateHeaderList(r, []string{"date"})
+
+		assert.Equal(t, existing, r.Header.Get("date"))
+		assert.True(t, contains(result, "date"))
+	})
+}


### PR DESCRIPTION
Fixes #7926

## Problem

With upstream HMAC request signing, the docs state a `Date` header is added for RFC compliance. In practice this only happens when `header_list` is **empty**. With a non-empty `header_list` — even one that explicitly includes `date` — no Date header is added and the signature isn't computed over one.

In `generateHeaderList` (`gateway/mw_request_signing.go`), the non-empty branch only appends a configured header if it's already on the request:

```go
for _, v := range headerList {
    if r.Header.Get(v) != "" {   // absent "date" (and "(request-target)") get dropped
        result = append(result, v)
    }
}
if len(result) == 0 {           // fallback only when NOTHING matched
    ...
}
```

So a listed `date` is dropped whenever the client didn't send one, and the Date-adding fallback only runs when the whole list resolved to empty. The `(request-target)` pseudo-header (which isn't a real request header) is dropped the same way.

## Fix

For a non-empty `header_list`:
- always include `(request-target)` (pseudo-header derived from method + path);
- when `date` is listed, add a Date header if the request lacks one, then include it (mirrors the empty-list branch);
- other headers keep the existing present-only behaviour.

Matching is case-insensitive (`strings.EqualFold`). Adds a `TestGenerateHeaderList` unit test covering both the add-when-absent and don't-override-existing cases.

I couldn't run `go test` locally (Go isn't available in my environment), but the change is small and the added test targets `generateHeaderList` directly with `httptest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)