### PR TITLE
[PoC] TT-17423: return 401 (not 400) on missing JWT Authorization for PRM/MCP flow

### DIFF
--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -1263,7 +1263,12 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 
 		ctx.SetErrorClassification(r, tykerrors.ClassifyJWTError(tykerrors.ErrTypeAuthFieldMissing, k.Name()))
 		k.reportLoginFailure(tykId, r)
-		return k.prmError(w, r, errors.New("Authorization field missing"), http.StatusBadRequest)
+		// A missing credential is unauthorized (401), not a bad request (400).
+		// RFC 9728 / MCP clients only begin the PRM-discovery + OAuth flow on a
+		// 401 challenge, so returning 400 here (even with the WWW-Authenticate
+		// resource_metadata header) leaves spec-compliant clients (e.g. VS Code)
+		// unable to authenticate.
+		return k.prmError(w, r, errors.New("Authorization field missing"), http.StatusUnauthorized)
 	}
 
 	// enable bearer token format

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -308,7 +308,9 @@ func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 	authHeaders := map[string]string{"authorization": ""}
 	t.Run("Request with empty authorization header", func(t *testing.T) {
 		ts.Run(t, test.TestCase{
-			Headers: authHeaders, Code: 400,
+			// A missing/empty credential is 401 Unauthorized (TT-17423): RFC 9728
+			// / MCP clients only start the PRM+OAuth flow on a 401 challenge.
+			Headers: authHeaders, Code: http.StatusUnauthorized,
 		})
 	})
 }
@@ -323,7 +325,9 @@ func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
 	authHeaders := map[string]string{}
 	t.Run("Request without authorization header", func(t *testing.T) {
 		ts.Run(t, test.TestCase{
-			Headers: authHeaders, Code: http.StatusBadRequest, BodyMatch: `Authorization field missing`,
+			// A missing Authorization field is 401 Unauthorized, not 400 (TT-17423):
+			// RFC 9728 / MCP clients only begin the PRM+OAuth flow on a 401 challenge.
+			Headers: authHeaders, Code: http.StatusUnauthorized, BodyMatch: `Authorization field missing`,
 		})
 	})
 }


### PR DESCRIPTION
## What
When the `Authorization` header is missing, the JWT middleware returns **401 Unauthorized** instead of **400 Bad Request**.

## Why
RFC 9728 (Protected Resource Metadata) / MCP clients — e.g. VS Code — only begin the PRM-discovery + OAuth flow when they receive a **401** challenge. Returning 400 on a missing credential (even with the `WWW-Authenticate: ... resource_metadata=...` header) leaves spec-compliant clients unable to authenticate against a protected MCP server.

## Change
`gateway/mw_jwt.go` — in `JWTMiddleware.ProcessRequest`, the missing-Authorization-field path now calls `prmError(..., http.StatusUnauthorized)` instead of `http.StatusBadRequest`. Single-hunk, +6/-1.

## Scope / status
**Proof of concept**, draft. Gateway-side counterpart of the EDP PRM work under **TT-17423** (portal PoC + `dcr` scope-normalization PR). Not intended to merge as-is — opening for review/alignment. Needs: confirmation that 401 is correct for all missing-credential JWT cases (not just MCP/PRM), and test coverage for the status change.

## Testing
- `go build ./gateway/` passes.
- No automated test added yet (PoC).