### PR TITLE
[TT-17416] docs: update swagger version to 5.8.15

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -30,7 +30,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.8.9
+  version: 5.8.15
 servers:
 - url: https://{tenant}
   variables:


### PR DESCRIPTION
### **User description**
## Description
Update the swagger `info.version` to `5.8.15` for tyk on the `release-5.8.15` branch.

## Related Issue
TT-17416 (subtask of TT-17415, R3 release prep). Clone of the R2 work in #8171 (TT-16944).

## Motivation and Context
The swagger version on `release-5.8.15` was stale (5.8.9). It must reflect the 5.8.15 release before the docs sync copies the spec into tyk-docs.

## How This Has Been Tested
- Verified the version string in `swagger.yml`.
- Ran `redocly lint swagger.yml --config=redocly.yml` (@redocly/cli@1.33.0, matching CI). Validates cleanly; same 31 problems ignored as on the base branch, no new issues.


___

### **PR Type**
Documentation


___

### **Description**
- Update Swagger `info.version` to `5.8.15`

- Align API spec with release branch


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Swagger version 5.8.9"]
  new["Swagger version 5.8.15"]
  old -- "updated to" --> new
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>swagger.yml</strong><dd><code>Bump Swagger spec version for release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger.yml

<ul><li>Update <code>info.version</code> from <code>5.8.9</code> to <code>5.8.15</code><br> <li> Keep the Swagger spec aligned with the <code>release-5.8.15</code> branch</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/8458/files#diff-8f3c4cb253eee09ae2401daa7279a8bbfbfd4168bb579c3ac0ee5c672d63bb2c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

