### PR TITLE
[TT-17417] docs: update swagger version to 5.14.0

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -33,7 +33,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.11.0
+  version: 5.14.0
 servers:
 - url: https://{tenant}
   variables:


### PR DESCRIPTION
## Description
Update the swagger `info.version` to `5.14.0` for tyk on the `release-5.14.0` branch.

## Related Issue
TT-17417 (subtask of TT-17415, R3 release prep). Clone of the R2 work in #8170 (TT-16944).

## Motivation and Context
The swagger version on `release-5.14.0` was stale (5.11.0). It must reflect the 5.14.0 release before the docs sync copies the spec into tyk-docs.

## How This Has Been Tested
- Verified the version string in `swagger.yml`.
- Ran `redocly lint swagger.yml --config=redocly.yml` (@redocly/cli@1.33.0, matching CI). Validates cleanly.
