### PR TITLE
[TT-17416] docs: update swagger version to 5.8.15

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -30,7 +30,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.8.9
+  version: 5.8.15
 servers:
 - url: https://{tenant}
   variables:


### PR DESCRIPTION
### **User description**
## Description
Update the swagger `info.version` to `5.8.15` on the `release-5.8` branch (per the release docs runbook: version is set on all relevant branches for the release).

## Related Issue
TT-17416 (subtask of TT-17415, R3 release prep).

## Motivation and Context
The swagger version on `release-5.8` was stale. It must reflect the 5.8.15 release before the docs sync copies the spec into tyk-docs.

## How This Has Been Tested
- Verified the version string.
- Ran `redocly lint swagger.yml --config=redocly.yml` (@redocly/cli@1.33.0, matching CI).


___

### **PR Type**
Documentation


___

### **Description**
- Update Swagger spec to `5.8.15`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  a["swagger.yml API metadata"]
  b["Version 5.8.15"]
  a -- "updates `info.version` to" --> b
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>swagger.yml</strong><dd><code>Bump Swagger API version metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger.yml

<ul><li>Update <code>info.version</code> from <code>5.8.9</code> to <code>5.8.15</code><br> <li> Keep OpenAPI metadata aligned with the release branch</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/8461/files#diff-8f3c4cb253eee09ae2401daa7279a8bbfbfd4168bb579c3ac0ee5c672d63bb2c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

