### PR TITLE
[TT-17417] docs: update swagger version to 5.14.0

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -33,7 +33,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.11.0
+  version: 5.14.0
 servers:
 - url: https://{tenant}
   variables:


### PR DESCRIPTION
## Description
Update the swagger `info.version` to `5.14.0` on the `master` branch (per the release docs runbook: version is set on all relevant branches for the release).

## Related Issue
TT-17417 (subtask of TT-17415, R3 release prep).

## Motivation and Context
The swagger version on `master` was stale. It must reflect the 5.14.0 release before the docs sync copies the spec into tyk-docs.

## How This Has Been Tested
- Verified the version string.
- Ran `redocly lint swagger.yml --config=redocly.yml` (@redocly/cli@1.33.0, matching CI).


<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17417" title="TT-17417" target="_blank">TT-17417</a>
</summary>

|         |    |
|---------|----|
| Status  | Open |
| Summary | Gateway API + config 5.14.0 |

Generated at: 2026-07-07 13:34:02

</details>

<!---TykTechnologies/jira-linter ends here-->

