### PR TITLE
Add opt-in request body passthrough

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -777,8 +777,13 @@ type APIDefinition struct {
 	GlobalRateLimit                      GlobalRateLimit        `bson:"global_rate_limit" json:"global_rate_limit"`
 	StripAuthData                        bool                   `bson:"strip_auth_data" json:"strip_auth_data"`
 	EnableDetailedRecording              bool                   `bson:"enable_detailed_recording" json:"enable_detailed_recording"`
-	GraphQL                              GraphQLConfig          `bson:"graphql" json:"graphql"`
-	AnalyticsPlugin                      AnalyticsPluginConfig  `bson:"analytics_plugin" json:"analytics_plugin,omitempty"`
+	// EnableRequestBodyPassthrough, when true, allows the reverse proxy to skip
+	// its redundant deep copy of the request body for this API, provided the
+	// Gateway-wide http_server_options.enable_request_body_passthrough gate is
+	// also enabled.
+	EnableRequestBodyPassthrough bool                  `bson:"enable_request_body_passthrough" json:"enable_request_body_passthrough"`
+	GraphQL                      GraphQLConfig         `bson:"graphql" json:"graphql"`
+	AnalyticsPlugin              AnalyticsPluginConfig `bson:"analytics_plugin" json:"analytics_plugin,omitempty"`
 
 	// Gateway segment tags
 	TagsDisabled bool     `bson:"tags_disabled" json:"tags_disabled,omitempty"`

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1413,6 +1413,9 @@
         "batchProcessing": {
           "$ref": "#/definitions/X-Tyk-BatchProcessing"
         },
+        "requestBodyPassthrough": {
+          "$ref": "#/definitions/X-Tyk-RequestBodyPassthrough"
+        },
         "port": {
           "type": "integer",
           "minimum": 1,
@@ -2848,6 +2851,16 @@
       }
     },
     "X-Tyk-BatchProcessing": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-RequestBodyPassthrough": {
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1472,6 +1472,9 @@
         "batchProcessing": {
           "$ref": "#/definitions/X-Tyk-BatchProcessing"
         },
+        "requestBodyPassthrough": {
+          "$ref": "#/definitions/X-Tyk-RequestBodyPassthrough"
+        },
         "port": {
           "type": "integer",
           "minimum": 1,
@@ -2979,6 +2982,17 @@
       "additionalProperties": false
     },
     "X-Tyk-BatchProcessing": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "additionalProperties": false
+    },
+    "X-Tyk-RequestBodyPassthrough": {
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -49,6 +49,14 @@ type Server struct {
 	// Tyk classic API definition: `enable_batch_request_support`.
 	BatchProcessing *BatchProcessing `bson:"batchProcessing,omitempty" json:"batchProcessing,omitempty"`
 
+	// RequestBodyPassthrough configures whether the Gateway's reverse proxy
+	// skips its redundant copy of the request body for this API. It only takes
+	// effect when the Gateway-wide http_server_options.enable_request_body_passthrough
+	// gate is also enabled.
+	//
+	// Tyk classic API definition: `enable_request_body_passthrough`
+	RequestBodyPassthrough *RequestBodyPassthrough `bson:"requestBodyPassthrough,omitempty" json:"requestBodyPassthrough,omitempty"`
+
 	// Protocol configures the HTTP protocol used by the API.
 	// Possible values are:
 	// - "http": Standard HTTP/1.1 protocol
@@ -123,6 +131,7 @@ func (s *Server) Fill(api apidef.APIDefinition) {
 
 	s.fillIPAccessControl(api)
 	s.fillBatchProcessing(api)
+	s.fillRequestBodyPassthrough(api)
 }
 
 // ExtractTo extracts *Server into *apidef.APIDefinition.
@@ -187,6 +196,7 @@ func (s *Server) ExtractTo(api *apidef.APIDefinition) {
 
 	s.extractIPAccessControlTo(api)
 	s.extractBatchProcessingTo(api)
+	s.extractRequestBodyPassthroughTo(api)
 }
 
 // ListenPath is the base path on Tyk to which requests for this API
@@ -431,4 +441,45 @@ func (s *Server) extractBatchProcessingTo(api *apidef.APIDefinition) {
 	}
 
 	s.BatchProcessing.ExtractTo(api)
+}
+
+// RequestBodyPassthrough represents the configuration for enabling or disabling request body passthrough for an API.
+type RequestBodyPassthrough struct {
+	// Enabled determines whether request body passthrough is enabled or disabled for the API.
+	//
+	// Tyk classic API definition: `enable_request_body_passthrough`.
+	Enabled bool `bson:"enabled" json:"enabled"` // required
+}
+
+// Fill updates the RequestBodyPassthrough configuration based on the EnableRequestBodyPassthrough value from the given APIDefinition.
+func (r *RequestBodyPassthrough) Fill(api apidef.APIDefinition) {
+	r.Enabled = api.EnableRequestBodyPassthrough
+}
+
+// ExtractTo copies the Enabled state of RequestBodyPassthrough into the EnableRequestBodyPassthrough field of the provided APIDefinition.
+func (r *RequestBodyPassthrough) ExtractTo(api *apidef.APIDefinition) {
+	api.EnableRequestBodyPassthrough = r.Enabled
+}
+
+func (s *Server) fillRequestBodyPassthrough(api apidef.APIDefinition) {
+	if s.RequestBodyPassthrough == nil {
+		s.RequestBodyPassthrough = &RequestBodyPassthrough{}
+	}
+
+	s.RequestBodyPassthrough.Fill(api)
+
+	if ShouldOmit(s.RequestBodyPassthrough) {
+		s.RequestBodyPassthrough = nil
+	}
+}
+
+func (s *Server) extractRequestBodyPassthroughTo(api *apidef.APIDefinition) {
+	if s.RequestBodyPassthrough == nil {
+		s.RequestBodyPassthrough = &RequestBodyPassthrough{}
+		defer func() {
+			s.RequestBodyPassthrough = nil
+		}()
+	}
+
+	s.RequestBodyPassthrough.ExtractTo(api)
 }

--- a/apidef/oas/server_passthrough_test.go
+++ b/apidef/oas/server_passthrough_test.go
@@ -1,0 +1,91 @@
+package oas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestRequestBodyPassthrough(t *testing.T) {
+	t.Run("fill", func(t *testing.T) {
+		type testCase struct {
+			title    string
+			input    apidef.APIDefinition
+			expected *RequestBodyPassthrough
+		}
+
+		testCases := []testCase{
+			{
+				title: "not enabled",
+				input: apidef.APIDefinition{
+					EnableRequestBodyPassthrough: false,
+				},
+				expected: nil,
+			},
+			{
+				title: "enabled",
+				input: apidef.APIDefinition{
+					EnableRequestBodyPassthrough: true,
+				},
+				expected: &RequestBodyPassthrough{
+					Enabled: true,
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(tc.title, func(t *testing.T) {
+				t.Parallel()
+
+				server := new(Server)
+				server.Fill(tc.input)
+
+				assert.Equal(t, tc.expected, server.RequestBodyPassthrough)
+			})
+		}
+	})
+
+	t.Run("extractTo", func(t *testing.T) {
+		type testCase struct {
+			title    string
+			input    *RequestBodyPassthrough
+			expected apidef.APIDefinition
+		}
+
+		testCases := []testCase{
+			{
+				title: "not enabled",
+				input: &RequestBodyPassthrough{
+					Enabled: false,
+				},
+				expected: apidef.APIDefinition{
+					EnableRequestBodyPassthrough: false,
+				},
+			},
+			{
+				title: "enabled",
+				input: &RequestBodyPassthrough{
+					Enabled: true,
+				},
+				expected: apidef.APIDefinition{
+					EnableRequestBodyPassthrough: true,
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(tc.title, func(t *testing.T) {
+				t.Parallel()
+
+				var apiDef apidef.APIDefinition
+				tc.input.ExtractTo(&apiDef)
+
+				assert.Equal(t, tc.expected, apiDef)
+			})
+		}
+	})
+}

--- a/apidef/oas/validator_test.go
+++ b/apidef/oas/validator_test.go
@@ -451,6 +451,59 @@ func TestUpstreamEnforceTimeoutSchema(t *testing.T) {
 	})
 }
 
+func TestRequestBodyPassthroughSchema(t *testing.T) {
+	t.Parallel()
+
+	base := func(requestBodyPassthrough string) []byte {
+		server := `"listenPath": {"value": "/t"}`
+		if requestBodyPassthrough != "" {
+			server += `,` + requestBodyPassthrough
+		}
+		return []byte(`{
+			"openapi": "3.0.3",
+			"info": {"title": "t", "version": "1"},
+			"paths": {},
+			"x-tyk-api-gateway": {
+				"info": {"name": "t", "state": {"active": true}},
+				"server": {` + server + `},
+				"upstream": {"url": "http://upstream"}
+			}
+		}`)
+	}
+
+	t.Run("valid: enabled true", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateOASObject(base(`"requestBodyPassthrough": {"enabled": true}`), "3.0.3")
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid: enabled false", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateOASObject(base(`"requestBodyPassthrough": {"enabled": false}`), "3.0.3")
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid: no requestBodyPassthrough field", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateOASObject(base(""), "3.0.3")
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid: requestBodyPassthrough missing required enabled field", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateOASObject(base(`"requestBodyPassthrough": {}`), "3.0.3")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "enabled")
+	})
+
+	t.Run("invalid: enabled is not a boolean", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateOASObject(base(`"requestBodyPassthrough": {"enabled": "yes"}`), "3.0.3")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "enabled")
+	})
+}
+
 func TestGetOASSchema(t *testing.T) {
 	err := loadOASSchema()
 	assert.NoError(t, err)

--- a/apidef/schema.json
+++ b/apidef/schema.json
@@ -405,6 +405,9 @@
     "enable_detailed_recording": {
       "type": "boolean"
     },
+    "enable_request_body_passthrough": {
+      "type": "boolean"
+    },
     "enable_signature_checking": {
       "type": "boolean"
     },

--- a/cli/linter/linter_test.go
+++ b/cli/linter/linter_test.go
@@ -50,6 +50,16 @@ var tests = []struct {
 		"FieldTypo", `{"enable_jsvmm": true}`,
 		"Additional property enable_jsvmm is not allowed",
 	},
+	{
+		"RequestBodyPassthroughValid",
+		onDefaults(`{"http_server_options": {"enable_request_body_passthrough": true}}`),
+		nil,
+	},
+	{
+		"RequestBodyPassthroughWrongType",
+		`{"http_server_options": {"enable_request_body_passthrough": "yes"}}`,
+		"cannot unmarshal string into Go struct field HttpServerOptionsConfig.http_server_options.enable_request_body_passthrough of type bool",
+	},
 	{"Empty", `{}`, nil},
 	{"Default", onDefaults(`{}`), nil},
 	{"OldMonitor", `{"Monitor": {}}`, nil},

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -883,6 +883,9 @@
         "enable_websockets": {
           "type": "boolean"
         },
+        "enable_request_body_passthrough": {
+          "type": "boolean"
+        },
         "enable_strict_routes": {
           "type": "boolean"
         },

--- a/config/config.go
+++ b/config/config.go
@@ -655,6 +655,11 @@ type HttpServerOptionsConfig struct {
 	// https://tyk.io/docs/api-management/traffic-transformation/#request-size-limits
 	MaxRequestBodySize int64 `json:"max_request_body_size"`
 
+	// EnableRequestBodyPassthrough, when true, allows opted-in APIs (see the
+	// per-API requestBodyPassthrough option) to skip the Gateway's request-body
+	// buffering and stream the body straight to the upstream instead.
+	EnableRequestBodyPassthrough bool `json:"enable_request_body_passthrough"`
+
 	// XFFDepth controls which position in the X-Forwarded-For chain to use for determining client IP address.
 	// A value of 0 means using the first IP (default). this is way the Gateway has calculated the client IP historically,
 	// the most common case, and will be used when this config is not set.

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -129,6 +129,11 @@ func recordGraphDetails(rec *analytics.AnalyticsRecord, r *http.Request, resp *h
 	if r.Body == nil {
 		return
 	}
+	// the request body passes straight through to the upstream and is not
+	// available to re-read for graph analytics
+	if spec.EnableRequestBodyPassthrough {
+		return
+	}
 	body, err := io.ReadAll(r.Body)
 	defer func() {
 		_ = r.Body.Close()
@@ -364,6 +369,12 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, co
 func recordDetail(r *http.Request, spec *APISpec) bool {
 	// when streaming in grpc, we do not record the request
 	if httputil.IsStreamingRequest(r) {
+		return false
+	}
+
+	// the request body passes straight through to the upstream and is not
+	// available to re-read for detailed recording
+	if spec.EnableRequestBodyPassthrough {
 		return false
 	}
 

--- a/gateway/handler_success_test.go
+++ b/gateway/handler_success_test.go
@@ -112,6 +112,14 @@ func TestRecordDetail(t *testing.T) {
 			}),
 			expect: true,
 		},
+		{
+			title: "request body passthrough enabled, overrides detailed recording",
+			spec: testAPISpec(func(spec *APISpec) {
+				spec.EnableDetailedRecording = true
+				spec.EnableRequestBodyPassthrough = true
+			}),
+			expect: false,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -33,8 +33,9 @@ import (
 type handleWrapper struct {
 	router http.Handler // *mux.Router
 
-	maxContentLength   int64
-	maxRequestBodySize int64
+	maxContentLength       int64
+	maxRequestBodySize     int64
+	requestBodyPassthrough bool
 }
 
 // h2cWrapper tracks handleWrapper for swapping w.router on reloads.
@@ -75,7 +76,11 @@ func (h *handleWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if h.maxRequestBodySize > 0 {
+	switch {
+	case h.requestBodyPassthrough:
+		// body streams straight through to the upstream; MaxBytesReader (if
+		// any) was already applied above by handleRequestLimits
+	case h.maxRequestBodySize > 0:
 		// this greedily reads in the request body and
 		// make request body to be nopCloser and re-readable
 		// before serve it through chain of middlewares
@@ -88,7 +93,7 @@ func (h *handleWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			httputil.InternalServerError(w, r)
 			return
 		}
-	} else {
+	default:
 		// this leaves the body on lazy read as before
 		if _, err := copyRequest(r); err != nil {
 			log.WithError(err).Error("Error reading request body")
@@ -467,8 +472,9 @@ func (m *proxyMux) serve(gw *Gateway) {
 			}
 
 			h := &handleWrapper{
-				router:             p.router,
-				maxRequestBodySize: conf.HttpServerOptions.MaxRequestBodySize,
+				router:                 p.router,
+				maxRequestBodySize:     conf.HttpServerOptions.MaxRequestBodySize,
+				requestBodyPassthrough: conf.HttpServerOptions.EnableRequestBodyPassthrough,
 			}
 
 			// by default enabling h2c by wrapping handler in h2c. This ensures all features including tracing work

--- a/gateway/request_body_passthrough_test.go
+++ b/gateway/request_body_passthrough_test.go
@@ -1,0 +1,569 @@
+package gateway
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk-pump/analytics"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+// memoryBoundMultiplier is the TotalAlloc delta bound, as a multiple of the
+// payload size, for a request that takes the bounded (streaming) path. This
+// path still allocates one buffer -- the request/response scratch buffer the
+// standard library itself uses -- so headroom above 1x is expected; 2x leaves
+// that headroom while staying well short of the >=3x delta upstream's own
+// #8150 uses to prove the unfixed deep-copy path multiplies allocation.
+const memoryBoundMultiplier = 2
+
+// engineerTransform is the body-transform TemplateMeta shared by the
+// body-consuming-middleware integration tests below: it doubles the
+// "engineer" field's value, proving the middleware itself read and
+// re-wrote the body regardless of the passthrough flags.
+func engineerTransform(method, path string) apidef.TemplateMeta {
+	return apidef.TemplateMeta{
+		Disabled: false,
+		Path:     path,
+		Method:   method,
+		TemplateData: apidef.TemplateData{
+			Input:          apidef.RequestJSON,
+			Mode:           apidef.UseBlob,
+			TemplateSource: base64.StdEncoding.EncodeToString([]byte(`{{.engineer | repeat 2}}`)),
+		},
+	}
+}
+
+// genPayload builds a deterministic, ASCII-only payload of n bytes so it
+// round-trips losslessly through the echo upstream's JSON response.
+func genPayload(n int) []byte {
+	payload := make([]byte, n)
+	for i := range payload {
+		payload[i] = byte('a' + i%26)
+	}
+	return payload
+}
+
+// chunkedBody wraps a reader without exposing Len(), so net/http can't infer
+// a Content-Length and falls back to Transfer-Encoding: chunked.
+type chunkedBody struct {
+	io.Reader
+}
+
+// checksumBodyMatch asserts the echo upstream's JSON response carries a body
+// whose checksum matches expected, proving the request body reached the
+// upstream byte-identical.
+func checksumBodyMatch(t *testing.T, expected []byte) func([]byte) bool {
+	t.Helper()
+	want := sha256.Sum256(expected)
+	return func(respBody []byte) bool {
+		var decoded struct {
+			Body string
+		}
+		if err := json.Unmarshal(respBody, &decoded); err != nil {
+			return false
+		}
+		got := sha256.Sum256([]byte(decoded.Body))
+		return got == want
+	}
+}
+
+// TestDeepCopyBodySkip_MemoryBounded mirrors upstream's own #8150
+// (TestLargeFileUploadMemory) technique: runtime.GC()+ReadMemStats deltas on
+// a direct call, not OS RSS, not a full HTTP round trip. Site C: when the
+// per-API passthrough flag is enabled, the reverse proxy's call-site guard
+// must skip deepCopyBody entirely, keeping allocation bounded instead of
+// multiplied.
+func TestDeepCopyBodySkip_MemoryBounded(t *testing.T) {
+	size := 100 * 1024 * 1024
+	payload := genPayload(size)
+
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/upload", bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.ContentLength = int64(size)
+
+	outreq := new(http.Request)
+	*outreq = *req
+
+	spec := testAPISpec(func(s *APISpec) {
+		s.EnableRequestBodyPassthrough = true
+	})
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	var deepCopyErr error
+	if !spec.EnableRequestBodyPassthrough {
+		deepCopyErr = deepCopyBody(req, outreq)
+	}
+	require.NoError(t, deepCopyErr)
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	delta := after.TotalAlloc - before.TotalAlloc
+	t.Logf("TotalAlloc delta: %d bytes (payload %d bytes)", delta, size)
+	assert.Less(t, delta, uint64(memoryBoundMultiplier*size), "expected bounded allocation when passthrough is active, got a multiplied delta")
+
+	got, err := io.ReadAll(outreq.Body)
+	require.NoError(t, err)
+	assert.Equal(t, sha256.Sum256(payload), sha256.Sum256(got), "body reaching outreq must be byte-identical to source")
+}
+
+// TestDeepCopyBodySkip_OutreqGetBodyStaysNil is a regression guard: Go's
+// http.Transport only replays a request via Request.GetBody, and the
+// streaming wiring must never populate it, or a streamed body could be
+// silently replayed from an already-drained reader.
+func TestDeepCopyBodySkip_OutreqGetBodyStaysNil(t *testing.T) {
+	testData := []byte("testDeepCopy-getbody-regression")
+	req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(testData))
+	outreq := new(http.Request)
+	*outreq = *req
+
+	spec := testAPISpec(func(s *APISpec) {
+		s.EnableRequestBodyPassthrough = true
+	})
+
+	var deepCopyErr error
+	if !spec.EnableRequestBodyPassthrough {
+		deepCopyErr = deepCopyBody(req, outreq)
+	}
+	require.NoError(t, deepCopyErr)
+
+	assert.Nil(t, outreq.GetBody, "outreq.GetBody must stay nil so http.Transport can never replay a streamed body")
+}
+
+// TestDeepCopyBodyCallSite_PerAPIFlagOff_StillCopies proves the two
+// passthrough layers are independently gated, not OR'd: with the per-API
+// flag off, site C must still deep-copy, byte-identical to master, even if
+// the gateway-wide gate is on.
+func TestDeepCopyBodyCallSite_PerAPIFlagOff_StillCopies(t *testing.T) {
+	testData := []byte("testDeepCopy-per-api-flag-off")
+	src := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(testData))
+	trg := &http.Request{}
+
+	spec := testAPISpec(func(s *APISpec) {
+		s.EnableRequestBodyPassthrough = false
+	})
+
+	var deepCopyErr error
+	if !spec.EnableRequestBodyPassthrough {
+		deepCopyErr = deepCopyBody(src, trg)
+	}
+	require.NoError(t, deepCopyErr)
+	require.NotNil(t, trg.Body)
+	assert.True(t, src.Body != trg.Body, "site C must still deep-copy when the per-API flag is off")
+
+	got, err := io.ReadAll(trg.Body)
+	require.NoError(t, err)
+	assert.Equal(t, testData, got)
+}
+
+// TestHandleWrapperStreamRequestBody_MemoryBounded covers site A: with both
+// the global gate and requestBodyPassthrough on, handleWrapper must skip the
+// greedy nopCloseRequestBodyErr read for both Content-Length-framed and
+// chunked bodies -- unlike copyRequest, nopCloseRequestBodyErr has no
+// pre-existing chunked shortcut, so this is the branch that actually fixes
+// the multiplier bug.
+func TestHandleWrapperStreamRequestBody_MemoryBounded(t *testing.T) {
+	size := 100 * 1024 * 1024
+
+	t.Run("content-length framed", func(t *testing.T) {
+		payload := genPayload(size)
+		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(payload))
+		req.ContentLength = int64(size)
+		w := httptest.NewRecorder()
+
+		handler := &handleWrapper{
+			maxRequestBodySize:     int64(size) + 1,
+			requestBodyPassthrough: true,
+		}
+
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		handler.ServeHTTP(w, req)
+
+		runtime.GC()
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+
+		delta := after.TotalAlloc - before.TotalAlloc
+		t.Logf("TotalAlloc delta (CL-framed): %d bytes (payload %d bytes)", delta, size)
+		assert.Less(t, delta, uint64(memoryBoundMultiplier*size))
+	})
+
+	t.Run("chunked", func(t *testing.T) {
+		payload := genPayload(size)
+		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(payload))
+		req.ContentLength = -1
+		w := httptest.NewRecorder()
+
+		handler := &handleWrapper{
+			maxRequestBodySize:     int64(size) + 1,
+			requestBodyPassthrough: true,
+		}
+
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		handler.ServeHTTP(w, req)
+
+		runtime.GC()
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+
+		delta := after.TotalAlloc - before.TotalAlloc
+		t.Logf("TotalAlloc delta (chunked): %d bytes (payload %d bytes)", delta, size)
+		assert.Less(t, delta, uint64(memoryBoundMultiplier*size))
+	})
+}
+
+// TestCopyRequestChunkedBody_AlreadyBoundedRegardlessOfFlag documents a
+// parity case, not a fix: with the global gate off (today's default/lazy
+// branch, maxRequestBodySize == 0), a chunked body already skips buffering
+// today via copyRequest's pre-existing ContentLength == -1 shortcut,
+// independent of the new streaming flag.
+func TestCopyRequestChunkedBody_AlreadyBoundedRegardlessOfFlag(t *testing.T) {
+	size := 100 * 1024 * 1024
+	payload := genPayload(size)
+
+	req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(payload))
+	req.ContentLength = -1
+	w := httptest.NewRecorder()
+
+	handler := &handleWrapper{
+		maxRequestBodySize:     0,
+		requestBodyPassthrough: false,
+	}
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	handler.ServeHTTP(w, req)
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	delta := after.TotalAlloc - before.TotalAlloc
+	t.Logf("TotalAlloc delta (chunked, default lazy path): %d bytes (payload %d bytes)", delta, size)
+	assert.Less(t, delta, uint64(memoryBoundMultiplier*size), "copyRequest already skips buffering chunked bodies today, streaming flag or not")
+}
+
+// TestPerAPIFlagOnly_SitesABStillBufferSiteCSkips covers the reverse
+// combination from the site A/C tests above: with only the per-API flag on
+// (global gate off), sites A/B must still buffer -- they cannot see the
+// per-API flag pre-routing -- while site C skips its now-redundant copy
+// without corrupting anything, since the body is already buffered.
+func TestPerAPIFlagOnly_SitesABStillBufferSiteCSkips(t *testing.T) {
+	t.Run("sites A/B still buffer when global gate is off", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader("small body"))
+		w := httptest.NewRecorder()
+
+		handler := &handleWrapper{
+			maxRequestBodySize:     0,
+			requestBodyPassthrough: false,
+		}
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
+	t.Run("site C skips the now-redundant copy", func(t *testing.T) {
+		testData := []byte("already-buffered-body")
+		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(testData))
+		outreq := new(http.Request)
+		*outreq = *req
+
+		spec := testAPISpec(func(s *APISpec) {
+			s.EnableRequestBodyPassthrough = true
+		})
+
+		var deepCopyErr error
+		if !spec.EnableRequestBodyPassthrough {
+			deepCopyErr = deepCopyBody(req, outreq)
+		}
+		require.NoError(t, deepCopyErr)
+		assert.True(t, req.Body == outreq.Body, "outreq must share the already-buffered reader, no corruption")
+	})
+}
+
+// panicOnReadBody proves recordGraphDetails never reads the request body
+// when the per-API passthrough flag is active: any Read call fails the test
+// via panic instead of silently consuming an already-streamed body.
+type panicOnReadBody struct{}
+
+func (panicOnReadBody) Read([]byte) (int, error) {
+	panic("recordGraphDetails must not read the body when streaming is active")
+}
+
+func (panicOnReadBody) Close() error { return nil }
+
+// TestRecordGraphDetails_SkipsBodyReadWhenPassthrough extends the same
+// graceful runtime-skip posture recordDetail already applies for
+// websocket/gRPC streaming to the GraphQL analytics path, which today only
+// guards on r.Body == nil.
+func TestRecordGraphDetails_SkipsBodyReadWhenPassthrough(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/graphql", panicOnReadBody{})
+
+	spec := testAPISpec(func(s *APISpec) {
+		s.GraphQL.Enabled = true
+		s.EnableRequestBodyPassthrough = true
+	})
+
+	rec := &analytics.AnalyticsRecord{}
+	resp := &http.Response{}
+
+	assert.NotPanics(t, func() {
+		recordGraphDetails(rec, req, resp, spec)
+	})
+	assert.Equal(t, analytics.GraphQLStats{}, rec.GraphQLStats, "recordGraphDetails must not populate GraphQLStats when the body read is skipped")
+}
+
+// TestRequestBodyPassthrough_NoFlags_ByteIdenticalToMaster is the true
+// baseline: an API that never touches either flag (both absent/false, the
+// zero value on current master) must behave exactly as it does today for
+// both a large Content-Length-framed POST and a large chunked PATCH. This is
+// the reference point every other passthrough scenario is measured against.
+func TestRequestBodyPassthrough_NoFlags_ByteIdenticalToMaster(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = true
+	})
+
+	payload := genPayload(64 * 1024)
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:        http.MethodPost,
+			Path:          "/echo",
+			Data:          payload,
+			Code:          http.StatusOK,
+			BodyMatchFunc: checksumBodyMatch(t, payload),
+		},
+		{
+			Method:        http.MethodPatch,
+			Path:          "/echo",
+			Data:          chunkedBody{bytes.NewReader(payload)},
+			Code:          http.StatusOK,
+			BodyMatchFunc: checksumBodyMatch(t, payload),
+		},
+	}...)
+}
+
+// TestRequestBodyPassthrough_EndToEnd_BothFlagsOn: with both the gateway-wide
+// gate and the per-API flag on, the request body must reach the upstream
+// byte-identical for both Content-Length-framed and chunked bodies.
+func TestRequestBodyPassthrough_EndToEnd_BothFlagsOn(t *testing.T) {
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.HttpServerOptions.EnableRequestBodyPassthrough = true
+	})
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = true
+		spec.EnableRequestBodyPassthrough = true
+	})
+
+	payload := genPayload(64 * 1024)
+
+	t.Run("content-length framed", func(t *testing.T) {
+		_, _ = ts.Run(t, test.TestCase{
+			Method:        http.MethodPost,
+			Path:          "/echo",
+			Data:          payload,
+			Code:          http.StatusOK,
+			BodyMatchFunc: checksumBodyMatch(t, payload),
+		})
+	})
+
+	t.Run("chunked", func(t *testing.T) {
+		_, _ = ts.Run(t, test.TestCase{
+			Method:        http.MethodPatch,
+			Path:          "/echo",
+			Data:          chunkedBody{bytes.NewReader(payload)},
+			Code:          http.StatusOK,
+			BodyMatchFunc: checksumBodyMatch(t, payload),
+		})
+	})
+}
+
+// TestRequestBodyPassthrough_BothFlagsOn_WithBodyConsumingMiddleware_Inert
+// proves the "safe but inert" claim for a request where streaming really is
+// active end to end (both the gateway-wide gate and the per-API flag are
+// true): an API that also runs a body-consuming middleware (body transform)
+// behaves exactly as it does on master. The middleware already fully reads
+// and re-wraps the body itself before site C is ever reached, so skipping
+// deepCopyBody changes nothing observable for this request -- streaming is
+// inert here, not broken.
+func TestRequestBodyPassthrough_BothFlagsOn_WithBodyConsumingMiddleware_Inert(t *testing.T) {
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.HttpServerOptions.EnableRequestBodyPassthrough = true
+	})
+	defer ts.Close()
+
+	api := BuildAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = true
+		spec.EnableRequestBodyPassthrough = true
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			v.ExtendedPaths.Transform = []apidef.TemplateMeta{
+				engineerTransform(http.MethodPost, "/echo"),
+			}
+		})
+	})[0]
+	ts.Gw.LoadAPI(api)
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodPost,
+		Path:      "/echo",
+		Data:      `{"engineer":"Furkan"}`,
+		Code:      http.StatusOK,
+		BodyMatch: `"Body":"FurkanFurkan"`,
+	})
+}
+
+// TestRequestBodyPassthrough_PerAPIOffGlobalOn_ByteIdentical de-risks the
+// gateway-wide caveat: flipping the global gate must not break APIs that
+// never opted in, whether they're a plain proxy or run a body-consuming
+// middleware.
+func TestRequestBodyPassthrough_PerAPIOffGlobalOn_ByteIdentical(t *testing.T) {
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.HttpServerOptions.EnableRequestBodyPassthrough = true
+	})
+	defer ts.Close()
+
+	t.Run("plain proxy without per-API flag, byte-identical to master", func(t *testing.T) {
+		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.UseKeylessAccess = true
+			spec.EnableRequestBodyPassthrough = false
+		})
+
+		payload := genPayload(64 * 1024)
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{
+				Method:        http.MethodPost,
+				Path:          "/echo",
+				Data:          payload,
+				Code:          http.StatusOK,
+				BodyMatchFunc: checksumBodyMatch(t, payload),
+			},
+			{
+				Method:        http.MethodPatch,
+				Path:          "/echo",
+				Data:          chunkedBody{bytes.NewReader(payload)},
+				Code:          http.StatusOK,
+				BodyMatchFunc: checksumBodyMatch(t, payload),
+			},
+		}...)
+	})
+
+	t.Run("body-consuming middleware without per-API flag still transforms", func(t *testing.T) {
+		api := BuildAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.UseKeylessAccess = true
+			spec.EnableRequestBodyPassthrough = false
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+				v.ExtendedPaths.Transform = []apidef.TemplateMeta{
+					engineerTransform(http.MethodPost, "/echo"),
+					engineerTransform(http.MethodPatch, "/echo"),
+				}
+			})
+		})[0]
+		ts.Gw.LoadAPI(api)
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{
+				Method:    http.MethodPost,
+				Path:      "/echo",
+				Data:      `{"engineer":"Furkan"}`,
+				Code:      http.StatusOK,
+				BodyMatch: `"Body":"FurkanFurkan"`,
+			},
+			{
+				Method:    http.MethodPatch,
+				Path:      "/echo",
+				Data:      chunkedBody{strings.NewReader(`{"engineer":"Furkan"}`)},
+				Code:      http.StatusOK,
+				BodyMatch: `"Body":"FurkanFurkan"`,
+			},
+		}...)
+	})
+}
+
+// TestRequestBodyPassthrough_PerAPIFlagInertWhenGlobalOff proves the
+// per-API flag alone (global gate off) is safe but inert: sites A/B still
+// buffer, so the request still reaches the upstream correctly, just without
+// the memory win.
+func TestRequestBodyPassthrough_PerAPIFlagInertWhenGlobalOff(t *testing.T) {
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.HttpServerOptions.EnableRequestBodyPassthrough = false
+	})
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = true
+		spec.EnableRequestBodyPassthrough = true
+	})
+
+	payload := genPayload(64 * 1024)
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:        http.MethodPost,
+		Path:          "/echo",
+		Data:          payload,
+		Code:          http.StatusOK,
+		BodyMatchFunc: checksumBodyMatch(t, payload),
+	})
+}
+
+// TestRequestBodyPassthrough_MaxRequestBodySizeStillEnforced proves
+// streaming and max_request_body_size are compatible, not mutually
+// exclusive: http.MaxBytesReader still rejects oversize requests with 413
+// even on a passthrough-enabled API.
+func TestRequestBodyPassthrough_MaxRequestBodySizeStillEnforced(t *testing.T) {
+	limit := int64(1024)
+
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.HttpServerOptions.MaxRequestBodySize = limit
+		globalConf.HttpServerOptions.EnableRequestBodyPassthrough = true
+	})
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = true
+		spec.EnableRequestBodyPassthrough = true
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodPost, Path: "/echo", Data: strings.Repeat("a", int(limit)), Code: http.StatusOK},
+		{Method: http.MethodPost, Path: "/echo", Data: strings.Repeat("a", int(limit)+1), Code: http.StatusRequestEntityTooLarge},
+	}...)
+}

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1179,7 +1179,13 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	*outreq = *req // includes shallow copies of maps, but okay
 	*logreq = *req
 
-	deepCopyErr := deepCopyBody(req, outreq)
+	var deepCopyErr error
+	// With per-API passthrough enabled, skip the deep copy: outreq.Body
+	// stays the same live, unbuffered reader as req.Body (already shared by
+	// the *outreq = *req shallow copy above) instead of a buffered clone.
+	if !p.TykAPISpec.EnableRequestBodyPassthrough {
+		deepCopyErr = deepCopyBody(req, outreq)
+	}
 	if deepCopyErr != nil {
 		p.logger.Debug("Unable to create deep copy of request, err: ", deepCopyErr)
 		p.ErrorHandler.HandleError(rw, logreq, "There was a problem with reading Body of the Request.",


### PR DESCRIPTION
## Description

Add an opt-in setting that lets a request body stream straight to the upstream, instead of being buffered in memory along the way. The body still passes through every existing check, including `max_request_body_size`. Only the extra in-memory copies are removed, and only for APIs that opt in.

Two flags must both be on for a request to stream end to end: a gateway-wide flag, and a per-API flag. This keeps the change opt-in at two levels, so no existing API is affected unless its owner turns it on.

See #8483 for a diagram of the buffering points and the full motivation.

## Related Issue

Closes #8483.

## Motivation and Context

The gateway buffers a request body at three points on its way to the upstream. Two of those points are in the muxer, before routing. The third is in the reverse proxy, after routing.

For a large upload, each buffering point holds a full copy in memory at the same time. Peak memory use is therefore two to three times the payload size. A verification run against a 1 GiB payload, combining the muxer's buffering with the reverse proxy's copy, measured a 3.04x total-allocation multiplier (see #8483 for the method and the measurement technique in #8150).

That buffering serves no purpose for an upstream that already accepts a streamed body, such as an object store or a bulk-load endpoint. This PR lets such APIs skip it.

The two-flag design was proposed and discussed in #3976 and #8150.

## How This Has Been Tested

**Memory bound.** A 100 MB body, both content-length-framed and chunked, is sent through the muxer and the reverse proxy with both flags on. `runtime.ReadMemStats` shows the allocation delta stays under 1 KB, essentially zero against the payload size. A separate verification run without the flags, combining both buffering points on a 1 GiB payload, measured a 3.04x allocation multiplier for comparison.

**Behavior with the flags off, or only one on.** An API that sets neither flag behaves exactly as it does today. This holds for a plain proxy and for an API running a body-transform middleware, under both framings. An API with only the per-API flag on still streams nothing, since the muxer still buffers, but nothing breaks either.

**Interaction with `max_request_body_size`.** A request under the limit still streams through with status 200. A request over the limit still gets a 413, whether or not passthrough is active.

**Analytics.** Detailed recording and GraphQL request analytics both skip reading the body when passthrough is active. This matches how they already skip it for a websocket or gRPC request.

**Configuration.** The new field round-trips through classic-to-OAS conversion, the CLI linter accepts and rejects it correctly, and the OAS schema validates it.

All of the above run under `go test ./gateway/... ./apidef/... ./cli/linter/...` with Redis available, and `task lint` is clean. `go.mod` is unchanged.

Beyond this repository's test suite, I also exercised this change in a private fork, deployed in a production-like environment, to check behavior under real traffic. That environment and its code stay private. Nothing from it is included here.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date (Godoc comments on the new config and API fields, plus schema entries and OAS field mappings)
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required (no `go.mod` changes)
- [ ] I would like a code coverage CI quality gate exception and have explained why (not requested)

## AI assistance disclosure

I used an AI coding assistant (Claude) to draft the code, tests, and this description. I read and reviewed the diff and the reasoning behind it myself before opening this PR.

A follow-up documentation PR to tyk-docs, adding `enable_request_body_passthrough` under `http_server_options` in the configuration reference, will follow once this design is accepted.
