### PR TITLE
Add non-cloning ctx.GetOASDefinitionRaw accessor

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -179,6 +179,22 @@ func GetOASDefinition(r *http.Request) *oas.OAS {
 	return nil
 }
 
+// GetOASDefinitionRaw returns the OAS API definition stored in the request
+// context without cloning it. The returned *oas.OAS is the API's live spec
+// object, shared by every concurrent request routed to that API until the
+// next reload; mutating it races with other goroutines and corrupts the
+// live definition for all traffic. Call GetOASDefinition instead for a
+// mutable, request-private copy.
+func GetOASDefinitionRaw(r *http.Request) *oas.OAS {
+	if v := r.Context().Value(OASDefinition); v != nil {
+		if val, ok := v.(*oas.OAS); ok {
+			return val
+		}
+	}
+
+	return nil
+}
+
 // SetErrorClassification sets the error classification for the request context.
 // This is used to store structured error information for access logs.
 func SetErrorClassification(r *http.Request, ec *errors.ErrorClassification) {

--- a/ctx/ctx_test.go
+++ b/ctx/ctx_test.go
@@ -1,12 +1,15 @@
 package ctx_test
 
 import (
+	"encoding/json"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
@@ -49,6 +52,65 @@ func TestGetOASDefinition(t *testing.T) {
 	assert.Equal(t, oasDef, cloned)
 }
 
+// Test for GetOASDefinitionRaw
+func TestGetOASDefinitionRaw(t *testing.T) {
+	t.Run("nil when nothing is stored", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "http://example.com", nil)
+		assert.Nil(t, ctx.GetOASDefinitionRaw(req))
+	})
+
+	t.Run("returns the exact pointer stored by SetOASDefinition", func(t *testing.T) {
+		oasDef := &oas.OAS{}
+		oasDef.Info = &openapi3.Info{
+			Title:   uuid.New(),
+			Version: "1",
+		}
+
+		req := httptest.NewRequest("GET", "http://example.com", nil)
+		ctx.SetOASDefinition(req, oasDef)
+
+		raw := ctx.GetOASDefinitionRaw(req)
+
+		assert.Same(t, oasDef, raw)
+	})
+
+	t.Run("repeated calls allocate ~nothing", func(t *testing.T) {
+		oasDef := &oas.OAS{}
+		oasDef.Info = &openapi3.Info{
+			Title:   uuid.New(),
+			Version: "1",
+		}
+
+		req := httptest.NewRequest("GET", "http://example.com", nil)
+		ctx.SetOASDefinition(req, oasDef)
+
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = ctx.GetOASDefinitionRaw(req)
+		})
+
+		assert.Zero(t, allocs, "GetOASDefinitionRaw must not allocate: it's a context value lookup plus a type assertion, no reflect.Clone")
+	})
+
+	t.Run("mutating the raw pointer does not affect a clone obtained from GetOASDefinition", func(t *testing.T) {
+		oasDef := &oas.OAS{}
+		oasDef.Info = &openapi3.Info{
+			Title:   uuid.New(),
+			Version: "1",
+		}
+
+		req := httptest.NewRequest("GET", "http://example.com", nil)
+		ctx.SetOASDefinition(req, oasDef)
+
+		raw := ctx.GetOASDefinitionRaw(req)
+		cloned := ctx.GetOASDefinition(req)
+
+		raw.Info.Title = "mutated"
+
+		assert.Equal(t, "mutated", raw.Info.Title)
+		assert.NotEqual(t, "mutated", cloned.Info.Title)
+	})
+}
+
 // Benchmark for GetDefinition
 func BenchmarkGetDefinition(b *testing.B) {
 	apiDef := &apidef.APIDefinition{
@@ -68,11 +130,7 @@ func BenchmarkGetDefinition(b *testing.B) {
 
 // Benchmark for GetOASDefinition
 func BenchmarkGetOASDefinition(b *testing.B) {
-	oasDef := &oas.OAS{}
-	oasDef.Info = &openapi3.Info{
-		Title:   uuid.New(),
-		Version: "1",
-	}
+	oasDef := loadPetstoreOAS(b)
 
 	req := httptest.NewRequest("GET", "http://example.com", nil)
 
@@ -80,9 +138,40 @@ func BenchmarkGetOASDefinition(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cloned := ctx.GetOASDefinition(req)
-		assert.Equal(b, oasDef, cloned)
+		oasDefinitionSink = ctx.GetOASDefinition(req)
 	}
+}
+
+// Benchmark for GetOASDefinitionRaw
+func BenchmarkGetOASDefinitionRaw(b *testing.B) {
+	oasDef := loadPetstoreOAS(b)
+
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	ctx.SetOASDefinition(req, oasDef)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		oasDefinitionSink = ctx.GetOASDefinitionRaw(req)
+	}
+}
+
+// oasDefinitionSink prevents the compiler from eliding the benchmarked calls.
+var oasDefinitionSink *oas.OAS
+
+// loadPetstoreOAS loads a realistically-sized OAS fixture (petstore, several
+// paths and operations) so the GetOASDefinition/GetOASDefinitionRaw benchmarks
+// measure the clone cost against a representative payload, not a near-empty one.
+func loadPetstoreOAS(tb testing.TB) *oas.OAS {
+	tb.Helper()
+
+	contents, err := os.ReadFile("../apidef/oas/testdata/petstore-no-responses.json")
+	require.NoError(tb, err)
+
+	var petstore oas.OAS
+	require.NoError(tb, json.Unmarshal(contents, &petstore))
+
+	return &petstore
 }
 
 // TestContextKeyUniqueness verifies all context keys have unique values


### PR DESCRIPTION
## Description

Add `ctx.GetOASDefinitionRaw()`, a companion to `ctx.GetOASDefinition()`. It returns the OAS definition stored in the request context as a direct pointer, with no clone. `GetOASDefinition()` is unchanged and still returns a private, mutable copy.

Use `GetOASDefinitionRaw()` only to read the definition. The returned value is the live spec object, shared by every concurrent request for that API. A caller that mutates it corrupts the definition for other requests. Keep using `GetOASDefinition()` when the caller needs to change the result.

See #8484 for a diagram of the two access paths and the full motivation.

## Related Issue

Closes #8484.

## Motivation and Context

`GetOASDefinition()` deep-clones the OAS definition through `reflect.Clone` on every call, even when the caller only reads it. An auth plugin that reads the definition once per request pays that cost per request. At around 100 requests per second, the clone takes about 80% of that plugin's CPU time.

A benchmark against a realistic definition (`go test -bench=. -benchmem ./ctx/...`) shows the difference. Timing varies by machine. The allocation counts do not:

| Function | Time per call | Allocations | Memory |
|---|---|---|---|
| `GetOASDefinition` | 215 µs | 857 | 75.5 KB |
| `GetOASDefinitionRaw` | 5 ns | 0 | 0 B |

## How This Has Been Tested

- Pointer identity: `GetOASDefinitionRaw` returns the exact pointer stored by `SetOASDefinition`.
- Nil case: an empty context returns nil, matching `GetOASDefinition`.
- Isolation regression: mutating the value returned by `GetOASDefinitionRaw` does not change a copy obtained earlier from `GetOASDefinition`.
- Allocation gate: `testing.AllocsPerRun` asserts the new function allocates nothing.
- `go test ./ctx/...` passes, `task lint` is clean, and `go.mod` is unchanged.
- The benchmark table above was re-run and confirmed on the submitter's machine before this PR was opened, not only estimated.

Beyond this repository's test suite, I also exercised this change in a private fork, deployed in a production-like environment, to check behavior under real traffic. That environment and its code stay private. Nothing from it is included here.

The classic-definition equivalent, `ctx.GetDefinition()`, has the same clone cost. That is a separate, un-started piece of work. This PR only covers the OAS auth path profiled in #8484.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date (Godoc comment on `GetOASDefinitionRaw`, with a mutation warning)
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required (no `go.mod` changes)
- [ ] I would like a code coverage CI quality gate exception and have explained why (not requested)

## AI assistance disclosure

I used an AI coding assistant (Claude) to draft the code, tests, and this description. I read and reviewed the diff and the reasoning behind it myself before opening this PR.
