### PR TITLE
[TT-16039] Add configurable client authentication method for upstream OAuth

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -137,6 +137,13 @@ const (
 	// OAuthAuthorizationTypePassword is the authorization type for password flow.
 	OAuthAuthorizationTypePassword = "password"
 
+	// OAuth2ClientAuthBasic and OAuth2ClientAuthPost are the client authentication
+	// methods defined by RFC 6749 Section 2.3.1 (the `token_endpoint_auth_method`
+	// values IdPs publish). Shared by upstream OAuth (ClientAuthData.Method) and
+	// the OAS OAuth2 token-exchange feature (oas.OAuth2ClientAuth.Method).
+	OAuth2ClientAuthBasic = "client_secret_basic"
+	OAuth2ClientAuthPost  = "client_secret_post"
+
 	// JSON-RPC protocol versions
 	JsonRPC20 = "2.0"
 
@@ -925,6 +932,16 @@ type ClientAuthData struct {
 	ClientID string `bson:"client_id" json:"client_id"`
 	// ClientSecret is the application's secret.
 	ClientSecret string `bson:"client_secret,omitempty" json:"client_secret,omitempty"` // client secret is optional for password flow
+	// Method controls how the client credentials are sent to the upstream token
+	// endpoint (RFC 6749 Section 2.3.1). Valid values are `client_secret_basic`
+	// (credentials in the Authorization header only, no fallback) and
+	// `client_secret_post` (credentials in the request body only, no fallback).
+	// When empty, Tyk keeps the historical auto-detect behaviour: it tries the
+	// header first and falls back to the body on failure. Unlike the OAuth2
+	// token-exchange clientAuth.method, empty deliberately does NOT default to
+	// client_secret_basic — existing APIs pointed at body-only IdPs rely on the
+	// fallback.
+	Method string `bson:"method,omitempty" json:"method,omitempty"`
 }
 
 // ClientCredentials holds the client credentials for upstream OAuth2 authentication.

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -376,8 +376,8 @@ const (
 
 	// OAuth2ClientAuth.Method values, aliased from package apidef so the classic
 	// and OAS formats share one set of constants (apidef cannot import apidef/oas).
-	OAuth2ClientAuthBasic = apidef.OAuth2ClientAuthBasic
-	OAuth2ClientAuthPost  = apidef.OAuth2ClientAuthPost
+	OAuth2ClientAuthBasic         = apidef.OAuth2ClientAuthBasic
+	OAuth2ClientAuthPost          = apidef.OAuth2ClientAuthPost
 	OAuth2ClientAuthPrivateKeyJWT = "private_key_jwt"
 
 	// client_assertion_type value for the private_key_jwt method (RFC 7523 §2.2).

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	tyktime "github.com/TykTechnologies/tyk/internal/time"
 )
 
@@ -373,9 +374,10 @@ const (
 	// exact-match semantics.
 	OAuth2IssuerRegexPrefix = "regex:"
 
-	// OAuth2ClientAuth.Method values.
-	OAuth2ClientAuthBasic         = "client_secret_basic"
-	OAuth2ClientAuthPost          = "client_secret_post"
+	// OAuth2ClientAuth.Method values, aliased from package apidef so the classic
+	// and OAS formats share one set of constants (apidef cannot import apidef/oas).
+	OAuth2ClientAuthBasic = apidef.OAuth2ClientAuthBasic
+	OAuth2ClientAuthPost  = apidef.OAuth2ClientAuthPost
 	OAuth2ClientAuthPrivateKeyJWT = "private_key_jwt"
 
 	// client_assertion_type value for the private_key_jwt method (RFC 7523 §2.2).

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -2736,6 +2736,13 @@
             "clientSecret": {
               "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
+            "method": {
+              "type": "string",
+              "enum": [
+                "client_secret_basic",
+                "client_secret_post"
+              ]
+            },
             "tokenUrl": {
               "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
@@ -2769,6 +2776,13 @@
             },
             "clientSecret": {
               "$ref": "#/definitions/X-Tyk-NonEmptyString"
+            },
+            "method": {
+              "type": "string",
+              "enum": [
+                "client_secret_basic",
+                "client_secret_post"
+              ]
             },
             "tokenUrl": {
               "$ref": "#/definitions/X-Tyk-NonEmptyString"

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2865,6 +2865,13 @@
             "clientSecret": {
               "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
+            "method": {
+              "type": "string",
+              "enum": [
+                "client_secret_basic",
+                "client_secret_post"
+              ]
+            },
             "tokenUrl": {
               "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
@@ -2898,6 +2905,13 @@
             },
             "clientSecret": {
               "$ref": "#/definitions/X-Tyk-NonEmptyString"
+            },
+            "method": {
+              "type": "string",
+              "enum": [
+                "client_secret_basic",
+                "client_secret_post"
+              ]
             },
             "tokenUrl": {
               "$ref": "#/definitions/X-Tyk-NonEmptyString"

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -1064,7 +1064,7 @@ func (u *UpstreamAuth) requestSigningExtractTo(api *apidef.APIDefinition) {
 	if u.RequestSigning == nil {
 		u.RequestSigning = &UpstreamRequestSigning{}
 		defer func() {
-			u.BasicAuth = nil
+			u.RequestSigning = nil
 		}()
 	}
 	u.RequestSigning.ExtractTo(api)
@@ -1149,6 +1149,19 @@ type ClientAuthData struct {
 	ClientID string `bson:"clientId" json:"clientId"`
 	// ClientSecret is the application's secret.
 	ClientSecret string `bson:"clientSecret,omitempty" json:"clientSecret,omitempty"` // client secret is optional for password flow
+	// Method controls how Tyk sends the client credentials to the upstream token
+	// endpoint. Valid values are `client_secret_basic` (RFC 6749 Section 2.3.1 —
+	// credentials in the Authorization header only, no fallback) and
+	// `client_secret_post` (credentials in the request body only, no fallback).
+	// Leave empty for the default auto-detect behaviour: Tyk tries the header
+	// first and falls back to the body on failure. Note this deliberately
+	// differs from the token-exchange `clientAuth.method`, where empty defaults
+	// to client_secret_basic — here empty must preserve the fallback so
+	// existing APIs keep working.
+	//
+	// Tyk classic API definition: `upstream_auth.oauth.client_credentials.method`
+	// and `upstream_auth.oauth.password.method`.
+	Method string `bson:"method,omitempty" json:"method,omitempty"`
 }
 
 // ClientCredentials holds the configuration for OAuth2 Client Credentials flow.
@@ -1168,6 +1181,7 @@ type ClientCredentials struct {
 func (c *ClientCredentials) Fill(api apidef.ClientCredentials) {
 	c.ClientID = api.ClientID
 	c.ClientSecret = api.ClientSecret
+	c.Method = api.Method
 	c.TokenURL = api.TokenURL
 	c.Scopes = api.Scopes
 	c.ExtraMetadata = api.ExtraMetadata
@@ -1184,6 +1198,7 @@ func (c *ClientCredentials) Fill(api apidef.ClientCredentials) {
 func (p *PasswordAuthentication) Fill(api apidef.PasswordAuthentication) {
 	p.ClientID = api.ClientID
 	p.ClientSecret = api.ClientSecret
+	p.Method = api.Method
 	p.Username = api.Username
 	p.Password = api.Password
 	p.TokenURL = api.TokenURL
@@ -1222,6 +1237,7 @@ func (u *UpstreamOAuth) Fill(api apidef.UpstreamOAuth) {
 func (c *ClientCredentials) ExtractTo(api *apidef.ClientCredentials) {
 	api.ClientID = c.ClientID
 	api.ClientSecret = c.ClientSecret
+	api.Method = c.Method
 	api.TokenURL = c.TokenURL
 	api.Scopes = c.Scopes
 	api.ExtraMetadata = c.ExtraMetadata
@@ -1238,6 +1254,7 @@ func (c *ClientCredentials) ExtractTo(api *apidef.ClientCredentials) {
 func (p *PasswordAuthentication) ExtractTo(api *apidef.PasswordAuthentication) {
 	api.ClientID = p.ClientID
 	api.ClientSecret = p.ClientSecret
+	api.Method = p.Method
 	api.Username = p.Username
 	api.Password = p.Password
 	api.TokenURL = p.TokenURL

--- a/apidef/oas/upstream_test.go
+++ b/apidef/oas/upstream_test.go
@@ -205,6 +205,47 @@ func TestUpstream(t *testing.T) {
 		})
 	})
 
+	t.Run("upstream oauth client auth method", func(t *testing.T) {
+		upstream := Upstream{
+			Authentication: &UpstreamAuth{
+				Enabled: true,
+				OAuth: &UpstreamOAuth{
+					Enabled:               true,
+					AllowedAuthorizeTypes: []string{apidef.OAuthAuthorizationTypeClientCredentials},
+					ClientCredentials: &ClientCredentials{
+						ClientAuthData: ClientAuthData{
+							ClientID:     "client-id",
+							ClientSecret: "client-secret",
+							Method:       apidef.OAuth2ClientAuthPost,
+						},
+						TokenURL: "https://idp.example.com/token",
+					},
+					PasswordAuthentication: &PasswordAuthentication{
+						ClientAuthData: ClientAuthData{
+							ClientID: "client-id",
+							Method:   apidef.OAuth2ClientAuthBasic,
+						},
+						Username: "user",
+						Password: "pass",
+						TokenURL: "https://idp.example.com/token",
+					},
+				},
+			},
+		}
+
+		var api apidef.APIDefinition
+		api.SetDisabledFlags()
+		upstream.ExtractTo(&api)
+
+		assert.Equal(t, apidef.OAuth2ClientAuthPost, api.UpstreamAuth.OAuth.ClientCredentials.Method)
+		assert.Equal(t, apidef.OAuth2ClientAuthBasic, api.UpstreamAuth.OAuth.PasswordAuthentication.Method)
+
+		var result Upstream
+		result.Fill(api)
+
+		assert.Equal(t, upstream, result)
+	})
+
 	t.Run("rate limit", func(t *testing.T) {
 		t.Run("valid duration", func(t *testing.T) {
 			rateLimitUpstream := Upstream{

--- a/apidef/validator.go
+++ b/apidef/validator.go
@@ -226,6 +226,8 @@ var (
 	ErrUpstreamOAuthAuthorizationTypeRequired = errors.New("upstream OAuth authorization type is required")
 	// ErrInvalidUpstreamOAuthAuthorizationType is the error to return when configured OAuth authorization type is invalid.
 	ErrInvalidUpstreamOAuthAuthorizationType = errors.New("invalid OAuth authorization type")
+	// ErrInvalidUpstreamOAuthClientAuthMethod is the error to return when the configured upstream OAuth client authentication method is invalid.
+	ErrInvalidUpstreamOAuthClientAuthMethod = errors.New("invalid upstream OAuth client authentication method, valid values are: client_secret_basic, client_secret_post")
 	// ErrAllLoadBalancingTargetsZeroWeight is the error to return when all load balancing targets have weight 0.
 	ErrAllLoadBalancingTargetsZeroWeight = errors.New("all load balancing targets have weight 0, at least one target must have weight > 0")
 )
@@ -266,6 +268,14 @@ func (r *RuleUpstreamAuth) Validate(apiDef *APIDefinition, validationResult *Val
 	if authType := upstreamAuth.OAuth.AllowedAuthorizeTypes[0]; authType != OAuthAuthorizationTypeClientCredentials && authType != OAuthAuthorizationTypePassword {
 		validationResult.IsValid = false
 		validationResult.AppendError(ErrInvalidUpstreamOAuthAuthorizationType)
+	}
+
+	for _, method := range []string{upstreamOAuth.ClientCredentials.Method, upstreamOAuth.PasswordAuthentication.Method} {
+		if method != "" && method != OAuth2ClientAuthBasic && method != OAuth2ClientAuthPost {
+			validationResult.IsValid = false
+			validationResult.AppendError(ErrInvalidUpstreamOAuthClientAuthMethod)
+			break
+		}
 	}
 }
 

--- a/apidef/validator_test.go
+++ b/apidef/validator_test.go
@@ -565,6 +565,60 @@ func TestRuleUpstreamAuth_Validate(t *testing.T) {
 				Errors:  []error{ErrInvalidUpstreamOAuthAuthorizationType},
 			},
 		},
+		{
+			name: "invalid client authentication method",
+			upstreamAuth: UpstreamAuth{
+				Enabled: true,
+				OAuth: UpstreamOAuth{
+					Enabled:               true,
+					AllowedAuthorizeTypes: []string{OAuthAuthorizationTypeClientCredentials},
+					ClientCredentials: ClientCredentials{
+						ClientAuthData: ClientAuthData{Method: "client_secret_jwt"},
+					},
+				},
+			},
+			result: ValidationResult{
+				IsValid: false,
+				Errors:  []error{ErrInvalidUpstreamOAuthClientAuthMethod},
+			},
+		},
+		{
+			name: "invalid client authentication method on password grant",
+			upstreamAuth: UpstreamAuth{
+				Enabled: true,
+				OAuth: UpstreamOAuth{
+					Enabled:               true,
+					AllowedAuthorizeTypes: []string{OAuthAuthorizationTypePassword},
+					PasswordAuthentication: PasswordAuthentication{
+						ClientAuthData: ClientAuthData{Method: "bogus"},
+					},
+				},
+			},
+			result: ValidationResult{
+				IsValid: false,
+				Errors:  []error{ErrInvalidUpstreamOAuthClientAuthMethod},
+			},
+		},
+		{
+			name: "valid client authentication methods",
+			upstreamAuth: UpstreamAuth{
+				Enabled: true,
+				OAuth: UpstreamOAuth{
+					Enabled:               true,
+					AllowedAuthorizeTypes: []string{OAuthAuthorizationTypeClientCredentials},
+					ClientCredentials: ClientCredentials{
+						ClientAuthData: ClientAuthData{Method: OAuth2ClientAuthPost},
+					},
+					PasswordAuthentication: PasswordAuthentication{
+						ClientAuthData: ClientAuthData{Method: OAuth2ClientAuthBasic},
+					},
+				},
+			},
+			result: ValidationResult{
+				IsValid: true,
+				Errors:  nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/ee/middleware/upstreamoauth/provider.go
+++ b/ee/middleware/upstreamoauth/provider.go
@@ -88,12 +88,34 @@ func (p *ClientCredentialsOAuthProvider) headerEnabled(OAuthSpec *Middleware) bo
 	return OAuthSpec.Spec.UpstreamAuth.OAuth.ClientCredentials.Header.Enabled
 }
 
+// authStyle maps a ClientAuthData.Method value to the oauth2 library's
+// AuthStyle. Empty keeps the library's auto-detect: header first, body
+// fallback. Unrecognised values are rejected by API-load validation, but can
+// still arrive here (e.g. definitions loaded from disk); they fall back to
+// auto-detect with a warning so the misconfiguration is observable.
+func authStyle(OAuthSpec *Middleware, method string) oauth2.AuthStyle {
+	switch method {
+	case apidef.OAuth2ClientAuthBasic:
+		return oauth2.AuthStyleInHeader
+	case apidef.OAuth2ClientAuthPost:
+		return oauth2.AuthStyleInParams
+	case "":
+		return oauth2.AuthStyleAutoDetect
+	default:
+		if OAuthSpec.Base != nil {
+			OAuthSpec.Logger().WithField("method", method).Warning("Unsupported upstream OAuth client authentication method, falling back to auto-detect")
+		}
+		return oauth2.AuthStyleAutoDetect
+	}
+}
+
 func newOAuth2ClientCredentialsConfig(OAuthSpec *Middleware) oauth2clientcredentials.Config {
 	return oauth2clientcredentials.Config{
 		ClientID:     OAuthSpec.Spec.UpstreamAuth.OAuth.ClientCredentials.ClientID,
 		ClientSecret: OAuthSpec.Spec.UpstreamAuth.OAuth.ClientCredentials.ClientSecret,
 		TokenURL:     OAuthSpec.Spec.UpstreamAuth.OAuth.ClientCredentials.TokenURL,
 		Scopes:       OAuthSpec.Spec.UpstreamAuth.OAuth.ClientCredentials.Scopes,
+		AuthStyle:    authStyle(OAuthSpec, OAuthSpec.Spec.UpstreamAuth.OAuth.ClientCredentials.Method),
 	}
 }
 
@@ -102,7 +124,8 @@ func newOAuth2PasswordConfig(OAuthSpec *Middleware) oauth2.Config {
 		ClientID:     OAuthSpec.Spec.UpstreamAuth.OAuth.PasswordAuthentication.ClientID,
 		ClientSecret: OAuthSpec.Spec.UpstreamAuth.OAuth.PasswordAuthentication.ClientSecret,
 		Endpoint: oauth2.Endpoint{
-			TokenURL: OAuthSpec.Spec.UpstreamAuth.OAuth.PasswordAuthentication.TokenURL,
+			TokenURL:  OAuthSpec.Spec.UpstreamAuth.OAuth.PasswordAuthentication.TokenURL,
+			AuthStyle: authStyle(OAuthSpec, OAuthSpec.Spec.UpstreamAuth.OAuth.PasswordAuthentication.Method),
 		},
 		Scopes: OAuthSpec.Spec.UpstreamAuth.OAuth.PasswordAuthentication.Scopes,
 	}

--- a/ee/middleware/upstreamoauth/provider_test.go
+++ b/ee/middleware/upstreamoauth/provider_test.go
@@ -2,9 +2,11 @@ package upstreamoauth_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -232,6 +234,284 @@ func TestProvider_PasswordAuthorizeType(t *testing.T) {
 			},
 		},
 	}...)
+}
+
+// bodyOnlyTokenServer imitates an IdP that rejects header (Basic) client
+// authentication and only accepts client credentials in the request body.
+// Every token request increments *requestCount; expectedForm keys are asserted
+// against the successful (body-credentials) request.
+func bodyOnlyTokenServer(t *testing.T, requestCount *int, expectedForm url.Values) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		*requestCount++
+
+		if r.Header.Get("Authorization") != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		parsed, err := url.ParseQuery(string(body))
+		assert.NoError(t, err)
+		for key, want := range expectedForm {
+			assert.Equal(t, want, parsed[key], "form key %q", key)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"body-only-token","token_type":"bearer","expires_in":3600}`))
+	}))
+}
+
+// headerOnlyTokenServer imitates an IdP that only accepts client credentials
+// via HTTP Basic authentication and rejects credentials in the request body.
+func headerOnlyTokenServer(t *testing.T, requestCount *int, wantBasicAuth string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		*requestCount++
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		parsed, err := url.ParseQuery(string(body))
+		assert.NoError(t, err)
+
+		if r.Header.Get("Authorization") != wantBasicAuth || parsed.Get("client_secret") != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"header-only-token","token_type":"bearer","expires_in":3600}`))
+	}))
+}
+
+// buildUpstreamOAuthAPI loads a keyless API proxying with the given upstream
+// OAuth configuration on the given listen path.
+func buildUpstreamOAuthAPI(tst *gateway.Test, listenPath string, oauth apidef.UpstreamOAuth) {
+	tst.Gw.BuildAndLoadAPI(
+		func(spec *APISpec) {
+			spec.Proxy.ListenPath = listenPath
+			spec.UseKeylessAccess = true
+			spec.UpstreamAuth = apidef.UpstreamAuth{
+				Enabled: true,
+				OAuth:   oauth,
+			}
+			spec.Proxy.StripListenPath = true
+		},
+	)
+}
+
+func TestProvider_ClientCredentials_MethodPost(t *testing.T) {
+	tst := StartTest(nil)
+	t.Cleanup(tst.Close)
+
+	var requestCount int
+	ts := bodyOnlyTokenServer(t, &requestCount, url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {"CC_POST_CLIENT"},
+		"client_secret": {"CC_POST_SECRET"},
+	})
+	t.Cleanup(ts.Close)
+
+	buildUpstreamOAuthAPI(tst, "/upstream-oauth-cc-post/", apidef.UpstreamOAuth{
+		Enabled:               true,
+		AllowedAuthorizeTypes: []string{apidef.OAuthAuthorizationTypeClientCredentials},
+		ClientCredentials: apidef.ClientCredentials{
+			ClientAuthData: apidef.ClientAuthData{
+				ClientID:     "CC_POST_CLIENT",
+				ClientSecret: "CC_POST_SECRET",
+				Method:       apidef.OAuth2ClientAuthPost,
+			},
+			TokenURL: ts.URL + "/token",
+			Header:   apidef.AuthSource{Enabled: true, Name: "Authorization"},
+		},
+	})
+
+	_, _ = tst.Run(t, test.TestCase{
+		Path: "/upstream-oauth-cc-post/",
+		Code: http.StatusOK,
+		BodyMatchFunc: func(body []byte) bool {
+			resp := struct {
+				Headers map[string]string `json:"headers"`
+			}{}
+			assert.NoError(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, "Bearer body-only-token", resp.Headers[header.Authorization])
+			return true
+		},
+	})
+
+	assert.Equal(t, 1, requestCount, "expected a single token request with body credentials, no Basic Auth probe")
+}
+
+func TestProvider_Password_MethodPost(t *testing.T) {
+	tst := StartTest(nil)
+	t.Cleanup(tst.Close)
+
+	// The password-grant token cache key is derived from client ID, secret and
+	// scopes only (not the token URL), so use per-run credentials to avoid
+	// serving a token cached in Redis by a previous run.
+	clientID := fmt.Sprintf("PW_POST_CLIENT_%d", time.Now().UnixNano())
+
+	var requestCount int
+	ts := bodyOnlyTokenServer(t, &requestCount, url.Values{
+		"grant_type":    {"password"},
+		"client_id":     {clientID},
+		"client_secret": {"PW_POST_SECRET"},
+		"username":      {"user1"},
+		"password":      {"password1"},
+	})
+	t.Cleanup(ts.Close)
+
+	buildUpstreamOAuthAPI(tst, "/upstream-oauth-pw-post/", apidef.UpstreamOAuth{
+		Enabled:               true,
+		AllowedAuthorizeTypes: []string{apidef.OAuthAuthorizationTypePassword},
+		PasswordAuthentication: apidef.PasswordAuthentication{
+			ClientAuthData: apidef.ClientAuthData{
+				ClientID:     clientID,
+				ClientSecret: "PW_POST_SECRET",
+				Method:       apidef.OAuth2ClientAuthPost,
+			},
+			Username: "user1",
+			Password: "password1",
+			TokenURL: ts.URL + "/token",
+			Header:   apidef.AuthSource{Enabled: true, Name: "Authorization"},
+		},
+	})
+
+	_, _ = tst.Run(t, test.TestCase{
+		Path: "/upstream-oauth-pw-post/",
+		Code: http.StatusOK,
+		BodyMatchFunc: func(body []byte) bool {
+			resp := struct {
+				Headers map[string]string `json:"headers"`
+			}{}
+			assert.NoError(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, "Bearer body-only-token", resp.Headers[header.Authorization])
+			return true
+		},
+	})
+
+	assert.Equal(t, 1, requestCount, "expected a single token request with body credentials, no Basic Auth probe")
+}
+
+func TestProvider_ClientCredentials_MethodBasic(t *testing.T) {
+	tst := StartTest(nil)
+	t.Cleanup(tst.Close)
+
+	var requestCount int
+	ts := headerOnlyTokenServer(t, &requestCount, "Basic Q0xJRU5UX0lEOkNMSUVOVF9TRUNSRVQ=")
+	t.Cleanup(ts.Close)
+
+	buildUpstreamOAuthAPI(tst, "/upstream-oauth-cc-basic/", apidef.UpstreamOAuth{
+		Enabled:               true,
+		AllowedAuthorizeTypes: []string{apidef.OAuthAuthorizationTypeClientCredentials},
+		ClientCredentials: apidef.ClientCredentials{
+			ClientAuthData: apidef.ClientAuthData{
+				ClientID:     "CLIENT_ID",
+				ClientSecret: "CLIENT_SECRET",
+				Method:       apidef.OAuth2ClientAuthBasic,
+			},
+			TokenURL: ts.URL + "/token",
+			Header:   apidef.AuthSource{Enabled: true, Name: "Authorization"},
+		},
+	})
+
+	_, _ = tst.Run(t, test.TestCase{
+		Path: "/upstream-oauth-cc-basic/",
+		Code: http.StatusOK,
+		BodyMatchFunc: func(body []byte) bool {
+			resp := struct {
+				Headers map[string]string `json:"headers"`
+			}{}
+			assert.NoError(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, "Bearer header-only-token", resp.Headers[header.Authorization])
+			return true
+		},
+	})
+
+	assert.Equal(t, 1, requestCount, "expected a single token request with header credentials")
+}
+
+// TestProvider_ClientCredentials_MethodEmpty_AutoDetectFallback pins the
+// backwards-compatible default: with method unset, Tyk keeps the RFC
+// auto-detect behaviour — the first attempt uses Basic Auth (rejected by a
+// body-only IdP), the second retries with body credentials and succeeds.
+func TestProvider_ClientCredentials_MethodEmpty_AutoDetectFallback(t *testing.T) {
+	tst := StartTest(nil)
+	t.Cleanup(tst.Close)
+
+	var requestCount int
+	ts := bodyOnlyTokenServer(t, &requestCount, url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {"CC_AUTO_CLIENT"},
+		"client_secret": {"CC_AUTO_SECRET"},
+	})
+	t.Cleanup(ts.Close)
+
+	buildUpstreamOAuthAPI(tst, "/upstream-oauth-cc-auto/", apidef.UpstreamOAuth{
+		Enabled:               true,
+		AllowedAuthorizeTypes: []string{apidef.OAuthAuthorizationTypeClientCredentials},
+		ClientCredentials: apidef.ClientCredentials{
+			ClientAuthData: apidef.ClientAuthData{
+				ClientID:     "CC_AUTO_CLIENT",
+				ClientSecret: "CC_AUTO_SECRET",
+			},
+			TokenURL: ts.URL + "/token",
+			Header:   apidef.AuthSource{Enabled: true, Name: "Authorization"},
+		},
+	})
+
+	_, _ = tst.Run(t, test.TestCase{
+		Path: "/upstream-oauth-cc-auto/",
+		Code: http.StatusOK,
+		BodyMatchFunc: func(body []byte) bool {
+			resp := struct {
+				Headers map[string]string `json:"headers"`
+			}{}
+			assert.NoError(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, "Bearer body-only-token", resp.Headers[header.Authorization])
+			return true
+		},
+	})
+
+	assert.Equal(t, 2, requestCount, "expected the auto-detect probe: failed Basic Auth attempt followed by a body-credentials retry")
+}
+
+// TestProvider_ClientCredentials_MethodPost_NoFallbackOnMismatch verifies an
+// explicit method is honoured: body-only credentials against a header-only
+// IdP fail without a silent fallback to Basic Auth.
+func TestProvider_ClientCredentials_MethodPost_NoFallbackOnMismatch(t *testing.T) {
+	tst := StartTest(nil)
+	t.Cleanup(tst.Close)
+
+	var requestCount int
+	ts := headerOnlyTokenServer(t, &requestCount, "Basic Q0xJRU5UX0lEOkNMSUVOVF9TRUNSRVQ=")
+	t.Cleanup(ts.Close)
+
+	buildUpstreamOAuthAPI(tst, "/upstream-oauth-cc-mismatch/", apidef.UpstreamOAuth{
+		Enabled:               true,
+		AllowedAuthorizeTypes: []string{apidef.OAuthAuthorizationTypeClientCredentials},
+		ClientCredentials: apidef.ClientCredentials{
+			ClientAuthData: apidef.ClientAuthData{
+				ClientID:     "CLIENT_ID",
+				ClientSecret: "CLIENT_SECRET",
+				Method:       apidef.OAuth2ClientAuthPost,
+			},
+			TokenURL: ts.URL + "/token",
+			Header:   apidef.AuthSource{Enabled: true, Name: "Authorization"},
+		},
+	})
+
+	_, _ = tst.Run(t, test.TestCase{
+		Path: "/upstream-oauth-cc-mismatch/",
+		Code: http.StatusInternalServerError,
+	})
+
+	assert.Equal(t, 1, requestCount, "expected a single rejected token request and no fallback to header credentials")
 }
 
 func TestSetExtraMetadata(t *testing.T) {

--- a/ee/middleware/upstreamoauth/provider_test.go
+++ b/ee/middleware/upstreamoauth/provider_test.go
@@ -248,7 +248,8 @@ func bodyOnlyTokenServer(t *testing.T, requestCount *int, expectedForm url.Value
 
 		if r.Header.Get("Authorization") != "" {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+			_, err := w.Write([]byte(`{"error":"invalid_client"}`))
+			assert.NoError(t, err)
 			return
 		}
 
@@ -261,7 +262,8 @@ func bodyOnlyTokenServer(t *testing.T, requestCount *int, expectedForm url.Value
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"body-only-token","token_type":"bearer","expires_in":3600}`))
+		_, err = w.Write([]byte(`{"access_token":"body-only-token","token_type":"bearer","expires_in":3600}`))
+		assert.NoError(t, err)
 	}))
 }
 
@@ -280,12 +282,14 @@ func headerOnlyTokenServer(t *testing.T, requestCount *int, wantBasicAuth string
 
 		if r.Header.Get("Authorization") != wantBasicAuth || parsed.Get("client_secret") != "" {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+			_, err := w.Write([]byte(`{"error":"invalid_client"}`))
+			assert.NoError(t, err)
 			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"header-only-token","token_type":"bearer","expires_in":3600}`))
+		_, err = w.Write([]byte(`{"access_token":"header-only-token","token_type":"bearer","expires_in":3600}`))
+		assert.NoError(t, err)
 	}))
 }
 


### PR DESCRIPTION
## Description

Upstream OAuth currently relies on the oauth2 library's auto-detect for client authentication at the IdP token endpoint: it always tries HTTP Basic Auth first and falls back to sending the credentials in the request body. Against body-only IdPs this produces a guaranteed failing 400 before every successful token fetch — noisy logs, false alerts, and an extra round-trip (and because the OAuth config is rebuilt per fetch, the probe never "sticks").

This PR adds an optional `method` field on the shared `ClientAuthData` (so it applies to both the Client Credentials and Password/ROPC grants, in both the classic and OAS formats):

| Value | Behaviour |
|---|---|
| empty / unset | **Unchanged default** — auto-detect (header first, body fallback) |
| `client_secret_basic` | Credentials in the Authorization header only, single request, no fallback |
| `client_secret_post` | Credentials in the request body only, single request, no fallback |

The values and constants are reused from the OAuth2 Token Exchange feature (`OAuth2ClientAuthBasic`/`OAuth2ClientAuthPost`, relocated from `apidef/oas` to `apidef` so both formats can share them; `apidef/oas` keeps aliases so existing consumers are untouched).

**Deliberate divergence from Token Exchange:** empty does NOT default to `client_secret_basic`. Existing upstream OAuth users pointed at body-only IdPs depend on the fallback, so empty must preserve auto-detect. This is called out in the field docs.

### Changes

- `apidef`: `Method` on `ClientAuthData` (classic `method`), constants relocation, new `RuleUpstreamAuth` validation (`ErrInvalidUpstreamOAuthClientAuthMethod`).
- `apidef/oas`: `method` on OAS `ClientAuthData` with Fill/ExtractTo wiring for both grant blocks; schema enum for `upstream.authentication.oauth.{clientCredentials,password}.method` (strict schema regenerated via `build.sh`).
- `ee/middleware/upstreamoauth`: `authStyle()` maps the field to `oauth2.AuthStyle` (`AuthStyleInHeader` / `AuthStyleInParams` / `AuthStyleAutoDetect`); unrecognised values (possible for file-loaded definitions that bypass validation) log a warning and fall back to auto-detect.
- **Drive-by fix (call-out):** `UpstreamAuth.requestSigningExtractTo` reset `u.BasicAuth` instead of `u.RequestSigning` in its cleanup defer, so `ExtractTo` permanently mutated the OAS struct. Covered by the new round-trip test.

### Tests

- Validator table tests (invalid values on both grants, valid values pass).
- OAS round-trip test for `method` on both grant blocks.
- Integration tests (`-tags ee`, real gateway + httptest IdPs with request counting):
  - `client_secret_post` vs body-only IdP → exactly 1 token request, no Basic probe (both grants);
  - `client_secret_basic` vs header-only IdP → exactly 1 header request;
  - empty method vs body-only IdP → pins today's probe (400 then 200) for back-compat;
  - `client_secret_post` vs header-only IdP → single rejected request, no silent fallback, error surfaced.
- Also manually verified end-to-end against a local Dashboard + mock IdP (single body-creds request with the field set; legacy 400→200 probe with it unset).

### Follow-ups (separate PRs)

- Dashboard: designer dropdown for both grants (webclient PR) + `go.mod` tyk pin bump after this merges.
- tyk-docs update.
- MDCB needs no change (field travels inside the standard API definition).





<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16039" title="TT-16039" target="_blank">TT-16039</a>
</summary>

|         |    |
|---------|----|
| Status  | Merge |
| Summary | Upstream OAuth: avoid duplicate token requests and log noise |

Generated at: 2026-08-04 11:05:01

</details>

<!---TykTechnologies/jira-linter ends here-->





