### PR TITLE
[TT-17786] Backport multi-bundle plugin composition (gRPC + Go) to release-5.13

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -742,6 +742,9 @@ type APIDefinition struct {
 	DisableRateLimit                     bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`
 	DisableQuota                         bool                   `bson:"disable_quota" json:"disable_quota"`
 	CustomMiddleware                     MiddlewareSection      `bson:"custom_middleware" json:"custom_middleware"`
+	// CustomMiddlewareBundle names the plugin bundle to load, resolved against the gateway's bundle_base_url.
+	// It accepts either a single bundle filename or a comma-separated list of filenames; when more than one
+	// name is supplied each bundle is fetched into its own subdirectory and their manifests are merged.
 	CustomMiddlewareBundle               string                 `bson:"custom_middleware_bundle" json:"custom_middleware_bundle"`
 	CustomMiddlewareBundleDisabled       bool                   `bson:"custom_middleware_bundle_disabled" json:"custom_middleware_bundle_disabled"`
 	CacheOptions                         CacheOptions           `bson:"cache_options" json:"cache_options"`

--- a/gateway/coprocess_bundle.go
+++ b/gateway/coprocess_bundle.go
@@ -298,8 +298,16 @@ func (z *ZipBundleSaver) extractFile(f *zip.File, bundlePath string) error {
 	return nil
 }
 
-// FetchBundle will fetch a given bundle, using the right BundleGetter. The first argument is the bundle name, the base bundle URL will be used as prefix.
+// FetchBundle fetches the API spec's CustomMiddlewareBundle. Preserved for
+// backward compatibility; multi-bundle callers should use FetchBundleByName.
 func (gw *Gateway) FetchBundle(bundleFs afero.Fs, spec *APISpec) (Bundle, error) {
+	return gw.FetchBundleByName(bundleFs, spec, spec.CustomMiddlewareBundle)
+}
+
+// FetchBundleByName fetches a bundle by name (resolved against the gateway's
+// BundleBaseURL). The returned Bundle.Name is set to bundleName so subsequent
+// save/verify steps stay scoped to this specific bundle.
+func (gw *Gateway) FetchBundleByName(bundleFs afero.Fs, spec *APISpec, bundleName string) (Bundle, error) {
 	bundle := Bundle{Gw: gw}
 	var err error
 
@@ -316,7 +324,7 @@ func (gw *Gateway) FetchBundle(bundleFs afero.Fs, spec *APISpec) (Bundle, error)
 		return bundle, err
 	}
 
-	u.Path = path.Join(u.Path, spec.CustomMiddlewareBundle)
+	u.Path = path.Join(u.Path, bundleName)
 
 	bundleURL := u.String()
 
@@ -348,7 +356,7 @@ func (gw *Gateway) FetchBundle(bundleFs afero.Fs, spec *APISpec) (Bundle, error)
 
 	bundleData, err := pullBundle(getter, bundleBackoffMultiplier)
 
-	bundle.Name = spec.CustomMiddlewareBundle
+	bundle.Name = bundleName
 	bundle.Data = bundleData
 	bundle.Spec = spec
 	return bundle, err
@@ -441,6 +449,22 @@ func (gw *Gateway) getHashedBundleName(bundleName string) (string, error) {
 	return fmt.Sprintf("%x", bundleNameHash.Sum(nil)), nil
 }
 
+// parseBundleNames splits spec.CustomMiddlewareBundle on commas, trims
+// whitespace, and drops empty entries. A bare filename (no comma) yields a
+// one-element slice equal to the input; an empty input yields nil.
+func parseBundleNames(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // loadBundle configures the gateway to load a custom middleware bundle based on the provided API specification.
 // It verifies the existence, integrity, and configuration of the bundle, applying it to the spec if validation succeeds.
 // Returns an error if the bundle cannot be loaded, validated, or is disabled in the spec.
@@ -448,30 +472,82 @@ func (gw *Gateway) loadBundle(spec *APISpec) error {
 	return gw.loadBundleWithFs(spec, afero.NewOsFs())
 }
 
-// loadBundleWithFs loads and validates a middleware bundle for the given API specification using the provided filesystem.
-// It operates only if required settings like CustomMiddlewareBundle and BundleBaseURL are configured in the API spec.
-// The method handles bundle fetching, saving, and manifest validation.
-// Returns an error if the bundle cannot be fetched, saved, or its manifest cannot be verified successfully.
+// loadBundleWithFs loads and validates one or more middleware bundles for the
+// given API specification using the provided filesystem.
+//
+// spec.CustomMiddlewareBundle accepts either a single bundle filename or a
+// comma-separated list of filenames, each resolved against the gateway's
+// bundle_base_url. Selection rule (backward compatible):
+//   - A single bare filename (no comma) takes the legacy single-bundle path
+//     unchanged — same on-disk layout, same AddToSpec replacement semantics.
+//     Existing deployments continue to behave identically.
+//   - Two or more comma-separated names take the multi-bundle merge path:
+//     each entry is fetched, unpacked into its own subdirectory under the
+//     API's bundle root, and its manifest merged into spec.CustomMiddleware.
+//
+// Returns an error if any bundle cannot be fetched, saved, or verified.
 func (gw *Gateway) loadBundleWithFs(spec *APISpec, bundleFs afero.Fs) error {
 	if gw.GetConfig().ManagementNode {
 		return nil
 	}
-
-	// Skip if no custom middleware bundle name is set.
-	if spec.CustomMiddlewareBundleDisabled || spec.CustomMiddlewareBundle == "" {
+	if spec.CustomMiddlewareBundleDisabled {
 		return nil
 	}
 
-	// Skip if no bundle base URL is set.
+	bundleNames := parseBundleNames(spec.CustomMiddlewareBundle)
+	if len(bundleNames) == 0 {
+		return nil
+	}
+	// Single bare filename → preserve the legacy path exactly so existing
+	// deployments keep their on-disk layout and hashing.
+	if len(bundleNames) == 1 && bundleNames[0] == spec.CustomMiddlewareBundle {
+		return gw.loadSingleBundle(spec, bundleFs)
+	}
+
 	if gw.GetConfig().BundleBaseURL == "" {
 		return bundleError(spec, nil, "No bundle base URL set, skipping bundle")
 	}
 
-	// get bundle destination on disk
+	rootPath := gw.getBundleDestPath(spec)
+	if err := bundleFs.MkdirAll(rootPath, 0700); err != nil {
+		return bundleError(spec, err, "Couldn't create bundle root directory")
+	}
+
+	// Reset the spec's middleware section before merging — multi-bundle mode
+	// is the source of truth for hooks, not whatever was previously attached.
+	spec.CustomMiddleware = apidef.MiddlewareSection{}
+
+	for _, name := range bundleNames {
+		if name == "" {
+			continue
+		}
+		if err := gw.loadOneBundleForMerge(spec, bundleFs, rootPath, name); err != nil {
+			return err
+		}
+	}
+
+	// Initialise non-goja drivers once after all bundles are merged. The legacy
+	// single-bundle path does this inside Bundle.AddToSpec; for multi-bundle we
+	// do it explicitly with the merged Driver.
+	if dispatcher := loadedDrivers[spec.CustomMiddleware.Driver]; dispatcher != nil {
+		dispatcher.HandleMiddlewareCache(&apidef.BundleManifest{
+			CustomMiddleware: spec.CustomMiddleware,
+		}, rootPath)
+	}
+
+	return nil
+}
+
+// loadSingleBundle is the original single-bundle path, factored out so the
+// new multi-bundle entry point can fall back to it without behavioural
+// drift. Existing single-bundle deployments take this path unchanged.
+func (gw *Gateway) loadSingleBundle(spec *APISpec, bundleFs afero.Fs) error {
+	if gw.GetConfig().BundleBaseURL == "" {
+		return bundleError(spec, nil, "No bundle base URL set, skipping bundle")
+	}
+
 	destPath := gw.getBundleDestPath(spec)
 
-	// Skip if the bundle destination path already exists.
-	// The bundle exists, load and return:
 	if _, err := bundleFs.Stat(destPath); err == nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -522,7 +598,6 @@ func (gw *Gateway) loadBundleWithFs(spec *APISpec, bundleFs afero.Fs) error {
 		"prefix": "main",
 	}).Debug("----> Saving Bundle: ", spec.CustomMiddlewareBundle)
 
-	// Set the destination path:
 	bundle.Path = destPath
 
 	if err := loadBundleManifest(bundleFs, &bundle, spec, false, false); err != nil {
@@ -541,6 +616,179 @@ func (gw *Gateway) loadBundleWithFs(spec *APISpec, bundleFs afero.Fs) error {
 	bundle.AddToSpec()
 
 	return nil
+}
+
+// loadOneBundleForMerge fetches/loads a single bundle into a per-bundle
+// subdirectory under rootPath, then merges its manifest into spec.CustomMiddleware
+// with file paths rewritten so api_loader's prefix-join still resolves
+// correctly.
+func (gw *Gateway) loadOneBundleForMerge(spec *APISpec, bundleFs afero.Fs, rootPath, bundleName string) error {
+	subdir := bundleSubdirName(bundleName)
+	destPath := filepath.Join(rootPath, subdir)
+
+	bundle := Bundle{
+		Name: bundleName,
+		Path: destPath,
+		Spec: spec,
+		Gw:   gw,
+	}
+
+	if _, err := bundleFs.Stat(destPath); err == nil {
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Info("Loading existing bundle: ", bundleName)
+
+		if err := loadBundleManifestNamed(bundleFs, &bundle, bundleName, true, gw.GetConfig().SkipVerifyExistingPluginBundle); err != nil {
+			return bundleError(spec, err, fmt.Sprintf("Couldn't load bundle %q", bundleName))
+		}
+	} else {
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Info("----> Fetching Bundle: ", bundleName)
+
+		fetched, err := gw.FetchBundleByName(bundleFs, spec, bundleName)
+		if err != nil {
+			return bundleError(spec, err, fmt.Sprintf("Couldn't fetch bundle %q", bundleName))
+		}
+
+		if err := bundleFs.MkdirAll(destPath, 0700); err != nil {
+			return bundleError(spec, err, fmt.Sprintf("Couldn't create bundle directory for %q", bundleName))
+		}
+
+		fetched.Path = destPath
+		if err := saveBundle(bundleFs, &fetched, destPath, spec); err != nil {
+			return bundleError(spec, err, fmt.Sprintf("Couldn't save bundle %q", bundleName))
+		}
+
+		bundle = fetched
+		bundle.Path = destPath
+
+		if err := loadBundleManifestNamed(bundleFs, &bundle, bundleName, false, false); err != nil {
+			if removeErr := bundleFs.RemoveAll(bundle.Path); removeErr != nil {
+				bundleError(spec, removeErr, "Couldn't remove bundle")
+			}
+			return bundleError(spec, err, fmt.Sprintf("Couldn't load bundle %q", bundleName))
+		}
+	}
+
+	if err := mergeBundleManifest(spec, &bundle.Manifest, subdir, bundleName); err != nil {
+		return bundleError(spec, err, fmt.Sprintf("Couldn't merge bundle %q", bundleName))
+	}
+
+	log.WithFields(logrus.Fields{
+		"prefix": "main",
+	}).Info("----> Merged bundle into spec: ", bundleName)
+
+	return nil
+}
+
+// loadBundleManifestNamed mirrors loadBundleManifest but uses the supplied
+// bundleName for log messages so multi-bundle merges have meaningful logs.
+// The verification logic is identical.
+func loadBundleManifestNamed(bundleFs afero.Fs, bundle *Bundle, bundleName string, partial bool, skipVerification bool) error {
+	log.WithFields(logrus.Fields{
+		"prefix": "main",
+	}).Info("----> Loading bundle: ", bundleName)
+
+	manifestPath := filepath.Join(bundle.Path, "manifest.json")
+	f, err := bundleFs.Open(manifestPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := json.NewDecoder(f).Decode(&bundle.Manifest); err != nil {
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Info("----> Couldn't unmarshal the manifest file for bundle: ", bundleName)
+		return err
+	}
+
+	if partial {
+		err = bundle.PartialVerify(bundleFs, skipVerification)
+	} else {
+		err = bundle.DeepVerify(bundleFs)
+	}
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Info("----> Bundle verification failed: ", bundleName)
+		return err
+	}
+
+	return nil
+}
+
+// mergeBundleManifest merges a bundle's manifest into the spec's
+// CustomMiddleware section. Each entry's Path is prepended with the bundle's
+// subdir so the api_loader's prefix-join (prefix = api bundle root) resolves
+// to the correct file under the per-bundle subdirectory.
+//
+// Hook arity rules:
+//   - pre/post/post_key_auth/response: append in declaration order
+//   - auth_check: at most one bundle may set this; merging a second is an error
+//   - driver: must be uniform; mismatch is an error
+func mergeBundleManifest(spec *APISpec, manifest *apidef.BundleManifest, subdir, bundleName string) error {
+	src := manifest.CustomMiddleware
+
+	// Driver consistency
+	if src.Driver != "" {
+		if spec.CustomMiddleware.Driver == "" {
+			spec.CustomMiddleware.Driver = src.Driver
+		} else if spec.CustomMiddleware.Driver != src.Driver {
+			return fmt.Errorf("bundle %q declares driver %q but earlier bundles set %q", bundleName, src.Driver, spec.CustomMiddleware.Driver)
+		}
+	}
+
+	rewritePath := func(md apidef.MiddlewareDefinition) apidef.MiddlewareDefinition {
+		if md.Path != "" {
+			md.Path = filepath.Join(subdir, md.Path)
+		}
+		return md
+	}
+
+	// auth_check is single-valued across the whole API
+	if src.AuthCheck.Name != "" {
+		if spec.CustomMiddleware.AuthCheck.Name != "" {
+			return fmt.Errorf("bundle %q declares an auth_check hook but another bundle has already set one (%q)", bundleName, spec.CustomMiddleware.AuthCheck.Name)
+		}
+		spec.CustomMiddleware.AuthCheck = rewritePath(src.AuthCheck)
+	}
+
+	for _, md := range src.Pre {
+		spec.CustomMiddleware.Pre = append(spec.CustomMiddleware.Pre, rewritePath(md))
+	}
+	for _, md := range src.Post {
+		spec.CustomMiddleware.Post = append(spec.CustomMiddleware.Post, rewritePath(md))
+	}
+	for _, md := range src.PostKeyAuth {
+		spec.CustomMiddleware.PostKeyAuth = append(spec.CustomMiddleware.PostKeyAuth, rewritePath(md))
+	}
+	for _, md := range src.Response {
+		spec.CustomMiddleware.Response = append(spec.CustomMiddleware.Response, rewritePath(md))
+	}
+
+	// IdExtractor: take the first bundle that sets one
+	if !spec.CustomMiddleware.IdExtractor.Disabled && spec.CustomMiddleware.IdExtractor.ExtractWith == "" && src.IdExtractor.ExtractWith != "" {
+		spec.CustomMiddleware.IdExtractor = src.IdExtractor
+	}
+
+	return nil
+}
+
+// bundleSubdirName derives a filesystem-friendly subdirectory name from a
+// bundle filename. The output is stable across runs and gateways so that an
+// already-unpacked bundle can be reused without redownload.
+func bundleSubdirName(bundleName string) string {
+	clean := strings.TrimSuffix(bundleName, filepath.Ext(bundleName))
+	clean = strings.ReplaceAll(clean, "/", "__")
+	clean = strings.ReplaceAll(clean, "\\", "__")
+	if clean == "" {
+		// Fallback: hash the original name so we always produce *something*.
+		sum := sha256.Sum256([]byte(bundleName))
+		return fmt.Sprintf("bundle_%x", sum[:6])
+	}
+	return clean
 }
 
 // bundleError is a log helper.

--- a/gateway/multi_bundle_backport_test.go
+++ b/gateway/multi_bundle_backport_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 // TestParseBundleNames covers the comma-splitting/trimming contract that the
@@ -317,4 +319,447 @@ func TestMultiBundleMerge_GRPC(t *testing.T) {
 // Redis.
 func TestMultiBundleMerge_GoPlugin(t *testing.T) {
 	testMultiBundleMerge(t, "goplugin")
+}
+
+// stagePreUnpackedBundle writes a manifest.json into the per-bundle subdir on
+// the supplied FS so loadOneBundleForMerge takes the "existing bundle on disk"
+// branch (Stat succeeds → loadBundleManifestNamed with partial=true) instead of
+// fetching over HTTP. The checksum/signature are dummies because callers set
+// SkipVerifyExistingPluginBundle=true, so PartialVerify short-circuits.
+func stagePreUnpackedBundle(t *testing.T, fs afero.Fs, rootPath, bundleName, manifestJSON string) {
+	t.Helper()
+	subdir := bundleSubdirName(bundleName)
+	dir := filepath.Join(rootPath, subdir)
+	require.NoError(t, fs.MkdirAll(dir, 0755))
+	f, err := fs.Create(filepath.Join(dir, "manifest.json"))
+	require.NoError(t, err)
+	_, err = f.WriteString(manifestJSON)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+}
+
+// TestLoadBundleWithFs_OnDiskReuseMergesBothBundles is master's dropped
+// TestLoadBundleWithFs_CommaSeparatedMergesBothBundles (driver swapped
+// javascript→grpc). Both bundles are pre-staged on the in-memory FS, so
+// loadOneBundleForMerge takes the existing-bundle branch (Stat ok →
+// loadBundleManifestNamed partial=true, lines 636-643 + 707-709) and NO HTTP
+// fetch happens. SkipVerifyExistingPluginBundle=true skips signature checks.
+// Requires a running Redis.
+func TestLoadBundleWithFs_OnDiskReuseMergesBothBundles(t *testing.T) {
+	ts := StartTest(func(c *config.Config) {
+		c.BundleBaseURL = "http://bundles.local/"
+		c.SkipVerifyExistingPluginBundle = true
+	})
+	defer ts.Close()
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-ondisk",
+			CustomMiddlewareBundle: "bundle-a.zip,bundle-b.zip",
+		},
+	}
+
+	rootPath := ts.Gw.getBundleDestPath(spec)
+	subdirA := bundleSubdirName("bundle-a.zip")
+	subdirB := bundleSubdirName("bundle-b.zip")
+
+	memFs := afero.NewMemMapFs()
+	stagePreUnpackedBundle(t, memFs, rootPath, "bundle-a.zip", `{
+		"file_list": ["plugin.so"],
+		"custom_middleware": {
+			"driver": "grpc",
+			"pre":  [{"name": "preA",  "path": "plugin.so"}],
+			"post": [{"name": "postA", "path": "plugin.so"}]
+		},
+		"checksum": "deadbeef",
+		"signature": ""
+	}`)
+	stagePreUnpackedBundle(t, memFs, rootPath, "bundle-b.zip", `{
+		"file_list": ["plugin.so"],
+		"custom_middleware": {
+			"driver": "grpc",
+			"pre":      [{"name": "preB",      "path": "plugin.so"}],
+			"response": [{"name": "responseB", "path": "plugin.so"}]
+		},
+		"checksum": "deadbeef",
+		"signature": ""
+	}`)
+
+	require.NoError(t, ts.Gw.loadBundleWithFs(spec, memFs))
+
+	require.Len(t, spec.CustomMiddleware.Pre, 2)
+	assert.Equal(t, "preA", spec.CustomMiddleware.Pre[0].Name)
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Pre[0].Path, subdirA))
+	assert.Equal(t, "preB", spec.CustomMiddleware.Pre[1].Name)
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Pre[1].Path, subdirB))
+
+	require.Len(t, spec.CustomMiddleware.Post, 1)
+	assert.Equal(t, "postA", spec.CustomMiddleware.Post[0].Name)
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Post[0].Path, subdirA))
+
+	require.Len(t, spec.CustomMiddleware.Response, 1)
+	assert.Equal(t, "responseB", spec.CustomMiddleware.Response[0].Name)
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Response[0].Path, subdirB))
+
+	assert.Equal(t, apidef.GrpcDriver, spec.CustomMiddleware.Driver)
+}
+
+// TestLoadBundleWithFs_ResetsStaleCustomMiddleware pins the line-518 behaviour:
+// multi-bundle mode is the source of truth for hooks, so any middleware already
+// attached to the spec is discarded before merging. We pre-populate a stale Pre
+// hook, run a 2-bundle on-disk merge, and assert the stale entry is gone and
+// only the merged hooks remain. Requires a running Redis.
+func TestLoadBundleWithFs_ResetsStaleCustomMiddleware(t *testing.T) {
+	ts := StartTest(func(c *config.Config) {
+		c.BundleBaseURL = "http://bundles.local/"
+		c.SkipVerifyExistingPluginBundle = true
+	})
+	defer ts.Close()
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-reset",
+			CustomMiddlewareBundle: "bundle-a.zip,bundle-b.zip",
+		},
+	}
+	// Stale middleware that must be wiped by the reset at line 518.
+	spec.CustomMiddleware = apidef.MiddlewareSection{
+		Pre: []apidef.MiddlewareDefinition{{Name: "stale", Path: "old.so"}},
+	}
+
+	rootPath := ts.Gw.getBundleDestPath(spec)
+	memFs := afero.NewMemMapFs()
+	stagePreUnpackedBundle(t, memFs, rootPath, "bundle-a.zip", `{
+		"file_list": [],
+		"custom_middleware": {"driver": "grpc", "pre": [{"name": "preA", "path": "plugin.so"}]},
+		"checksum": "deadbeef", "signature": ""
+	}`)
+	stagePreUnpackedBundle(t, memFs, rootPath, "bundle-b.zip", `{
+		"file_list": [],
+		"custom_middleware": {"driver": "grpc", "pre": [{"name": "preB", "path": "plugin.so"}]},
+		"checksum": "deadbeef", "signature": ""
+	}`)
+
+	require.NoError(t, ts.Gw.loadBundleWithFs(spec, memFs))
+
+	for _, md := range spec.CustomMiddleware.Pre {
+		assert.NotEqual(t, "stale", md.Name, "stale middleware must be reset before merge")
+	}
+	require.Len(t, spec.CustomMiddleware.Pre, 2)
+	assert.Equal(t, "preA", spec.CustomMiddleware.Pre[0].Name)
+	assert.Equal(t, "preB", spec.CustomMiddleware.Pre[1].Name)
+}
+
+// TestLoadBundleWithFs_EmptyBaseURLMultiBundle covers the multi-bundle guard at
+// lines 507-509: with two comma-separated names but an empty bundle_base_url,
+// loadBundleWithFs must fail closed with "No bundle base URL set". Requires a
+// running Redis.
+func TestLoadBundleWithFs_EmptyBaseURLMultiBundle(t *testing.T) {
+	ts := StartTest(func(c *config.Config) {
+		c.BundleBaseURL = ""
+	})
+	defer ts.Close()
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-nobaseurl",
+			CustomMiddlewareBundle: "a.zip,b.zip",
+		},
+	}
+
+	err := ts.Gw.loadBundleWithFs(spec, afero.NewMemMapFs())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "No bundle base URL set")
+}
+
+// TestLoadBundleWithFs_PartialFailureFailsClosed covers the fail-closed loop
+// exit at lines 524-526 and the fetch-error branch in loadOneBundleForMerge
+// (650-651): the first bundle is valid and fetchable over HTTP, the second
+// names a bundle that isn't registered (404 on every retry). The overall load
+// must error and the error must name the failing bundle. Requires a running
+// Redis.
+func TestLoadBundleWithFs_PartialFailureFailsClosed(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	// Shrink retries so the 404 fails fast instead of backing off.
+	orig := bundleMaxBackoffRetries
+	bundleMaxBackoffRetries = 0
+	defer func() { bundleMaxBackoffRetries = orig }()
+
+	bundleA := ts.RegisterBundle("partial_ok_a", mergeBundleManifestJSON("grpc",
+		`"pre": [{"name": "PreHookA", "path": "plugin.so"}]`))
+	missingB := "does-not-exist-" + "b.zip"
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-partial",
+			CustomMiddlewareBundle: bundleA + "," + missingB,
+		},
+	}
+
+	err := ts.Gw.loadBundle(spec)
+	require.Error(t, err, "a failing second bundle must fail the whole load")
+	assert.Contains(t, err.Error(), missingB, "error should name the failing bundle")
+}
+
+// TestLoadBundleWithFs_FetchedBadManifestFailsAndCleansUp covers the fetch →
+// save → manifest-load failure path in loadOneBundleForMerge (666-670, incl.
+// RemoveAll cleanup) and loadBundleManifestNamed's open/decode error branches
+// (695-705). Bundle A is valid; bundle B fetches and unzips fine but its
+// manifest.json is invalid JSON, so DeepVerify never runs and the load fails
+// closed. A second sub-case omits manifest.json entirely (open error).
+// Requires a running Redis.
+func TestLoadBundleWithFs_FetchedBadManifestFailsAndCleansUp(t *testing.T) {
+	t.Run("invalid manifest json", func(t *testing.T) {
+		ts := StartTest(nil)
+		defer ts.Close()
+
+		bundleA := ts.RegisterBundle("badmanifest_ok_a", mergeBundleManifestJSON("grpc",
+			`"pre": [{"name": "PreHookA", "path": "plugin.so"}]`))
+		badB := ts.RegisterBundle("badmanifest_bad_b", map[string]string{
+			"manifest.json": `{ this is not valid json `,
+		})
+
+		spec := &APISpec{
+			APIDefinition: &apidef.APIDefinition{
+				APIID:                  "multi-bundle-badjson",
+				CustomMiddlewareBundle: bundleA + "," + badB,
+			},
+		}
+
+		err := ts.Gw.loadBundle(spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), badB)
+	})
+
+	t.Run("missing manifest file", func(t *testing.T) {
+		ts := StartTest(nil)
+		defer ts.Close()
+
+		bundleA := ts.RegisterBundle("nomanifest_ok_a", mergeBundleManifestJSON("grpc",
+			`"pre": [{"name": "PreHookA", "path": "plugin.so"}]`))
+		// A zip that unpacks a file but has no manifest.json → Open fails.
+		noManifestB := ts.RegisterBundle("nomanifest_bad_b", map[string]string{
+			"plugin.so": "not-a-manifest",
+		})
+
+		spec := &APISpec{
+			APIDefinition: &apidef.APIDefinition{
+				APIID:                  "multi-bundle-nomanifest",
+				CustomMiddlewareBundle: bundleA + "," + noManifestB,
+			},
+		}
+
+		err := ts.Gw.loadBundle(spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), noManifestB)
+	})
+}
+
+// TestFetchBundleByName_BadScheme covers FetchBundleByName's error branches:
+// the default "Unknown URL scheme" case (line 350-351) via an ftp base URL, and
+// the url.Parse error (line 323-324) via a malformed base URL. Both are reached
+// through the multi-bundle path (two names) so the single-bundle fast path is
+// bypassed. Requires a running Redis.
+func TestFetchBundleByName_BadScheme(t *testing.T) {
+	t.Run("unknown scheme", func(t *testing.T) {
+		ts := StartTest(func(c *config.Config) {
+			c.BundleBaseURL = "ftp://bundles.local/"
+		})
+		defer ts.Close()
+
+		spec := &APISpec{APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-ftp",
+			CustomMiddlewareBundle: "a.zip,b.zip",
+		}}
+		err := ts.Gw.loadBundleWithFs(spec, afero.NewMemMapFs())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Unknown URL scheme")
+	})
+
+	t.Run("malformed base url", func(t *testing.T) {
+		ts := StartTest(func(c *config.Config) {
+			c.BundleBaseURL = "://missing-scheme"
+		})
+		defer ts.Close()
+
+		spec := &APISpec{APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-badurl",
+			CustomMiddlewareBundle: "a.zip,b.zip",
+		}}
+		err := ts.Gw.loadBundleWithFs(spec, afero.NewMemMapFs())
+		require.Error(t, err)
+	})
+
+	t.Run("downloader disabled", func(t *testing.T) {
+		// Covers FetchBundleByName's early guard (314-320): with the bundle
+		// downloader turned off, a fetch-requiring multi-bundle load fails
+		// closed with "Bundle downloader is disabled".
+		ts := StartTest(func(c *config.Config) {
+			c.BundleBaseURL = "http://bundles.local/"
+			c.EnableBundleDownloader = false
+		})
+		defer ts.Close()
+
+		spec := &APISpec{APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-nodownloader",
+			CustomMiddlewareBundle: "a.zip,b.zip",
+		}}
+		err := ts.Gw.loadBundleWithFs(spec, afero.NewMemMapFs())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Bundle downloader is disabled")
+	})
+}
+
+// TestMergeBundleManifestIdExtractorFirstWins pins the first-wins IdExtractor
+// merge rule at lines 772-774. Sub-case 1: bundle A sets an extractor and bundle
+// B sets a different one → A's is kept. Sub-case 2: bundle A sets none and
+// bundle B sets one → B's is adopted.
+func TestMergeBundleManifestIdExtractorFirstWins(t *testing.T) {
+	t.Run("first bundle wins over later", func(t *testing.T) {
+		spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+
+		a := &apidef.BundleManifest{CustomMiddleware: apidef.MiddlewareSection{
+			Driver:      apidef.GrpcDriver,
+			IdExtractor: apidef.MiddlewareIdExtractor{ExtractWith: apidef.ValueExtractor},
+		}}
+		b := &apidef.BundleManifest{CustomMiddleware: apidef.MiddlewareSection{
+			Driver:      apidef.GrpcDriver,
+			IdExtractor: apidef.MiddlewareIdExtractor{ExtractWith: apidef.RegexExtractor},
+		}}
+
+		require.NoError(t, mergeBundleManifest(spec, a, "bundle-a", "bundle-a.zip"))
+		require.NoError(t, mergeBundleManifest(spec, b, "bundle-b", "bundle-b.zip"))
+
+		assert.Equal(t, apidef.ValueExtractor, spec.CustomMiddleware.IdExtractor.ExtractWith,
+			"first bundle's IdExtractor must win")
+	})
+
+	t.Run("later bundle fills when first has none", func(t *testing.T) {
+		spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+
+		a := &apidef.BundleManifest{CustomMiddleware: apidef.MiddlewareSection{
+			Driver: apidef.GrpcDriver,
+		}}
+		b := &apidef.BundleManifest{CustomMiddleware: apidef.MiddlewareSection{
+			Driver:      apidef.GrpcDriver,
+			IdExtractor: apidef.MiddlewareIdExtractor{ExtractWith: apidef.RegexExtractor},
+		}}
+
+		require.NoError(t, mergeBundleManifest(spec, a, "bundle-a", "bundle-a.zip"))
+		require.NoError(t, mergeBundleManifest(spec, b, "bundle-b", "bundle-b.zip"))
+
+		assert.Equal(t, apidef.RegexExtractor, spec.CustomMiddleware.IdExtractor.ExtractWith,
+			"second bundle's IdExtractor must be adopted when the first sets none")
+	})
+}
+
+// TestLoadOneBundleForMerge_OnDiskVerificationFails covers the existing-bundle
+// verification-failure path: loadOneBundleForMerge Stats a staged bundle
+// (636-643) then loadBundleManifestNamed runs PartialVerify with
+// skipVerification=false. The staged manifest declares a signature but a bogus
+// checksum, so verification fails (loadBundleManifestNamed 712-717) and
+// loadOneBundleForMerge returns a wrapped error naming the bundle (641-643).
+// Requires a running Redis.
+func TestLoadOneBundleForMerge_OnDiskVerificationFails(t *testing.T) {
+	ts := StartTest(func(c *config.Config) {
+		c.BundleBaseURL = "http://bundles.local/"
+		c.SkipVerifyExistingPluginBundle = false
+	})
+	defer ts.Close()
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-verifyfail",
+			CustomMiddlewareBundle: "bad-a.zip,bad-b.zip",
+		},
+	}
+	rootPath := ts.Gw.getBundleDestPath(spec)
+	memFs := afero.NewMemMapFs()
+	// signature set + wrong checksum → PartialVerify runs and fails.
+	stagePreUnpackedBundle(t, memFs, rootPath, "bad-a.zip", `{
+		"file_list": [],
+		"custom_middleware": {"driver": "grpc", "pre": [{"name": "preA", "path": "plugin.so"}]},
+		"checksum": "not-the-real-checksum",
+		"signature": "AAAA"
+	}`)
+
+	err := ts.Gw.loadBundleWithFs(spec, memFs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad-a.zip")
+}
+
+// TestLoadOneBundleForMerge_DriverMismatchOnDisk covers loadOneBundleForMerge's
+// merge-error branch (674-676): two on-disk bundles declare different drivers,
+// so the second mergeBundleManifest fails driver uniformity and the error is
+// wrapped with the offending bundle name. Requires a running Redis.
+func TestLoadOneBundleForMerge_DriverMismatchOnDisk(t *testing.T) {
+	ts := StartTest(func(c *config.Config) {
+		c.BundleBaseURL = "http://bundles.local/"
+		c.SkipVerifyExistingPluginBundle = true
+	})
+	defer ts.Close()
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-drivermismatch",
+			CustomMiddlewareBundle: "grpc-a.zip,go-b.zip",
+		},
+	}
+	rootPath := ts.Gw.getBundleDestPath(spec)
+	memFs := afero.NewMemMapFs()
+	stagePreUnpackedBundle(t, memFs, rootPath, "grpc-a.zip", `{
+		"file_list": [],
+		"custom_middleware": {"driver": "grpc", "pre": [{"name": "preA", "path": "plugin.so"}]},
+		"checksum": "deadbeef", "signature": ""
+	}`)
+	stagePreUnpackedBundle(t, memFs, rootPath, "go-b.zip", `{
+		"file_list": [],
+		"custom_middleware": {"driver": "goplugin", "pre": [{"name": "preB", "path": "plugin.so"}]},
+		"checksum": "deadbeef", "signature": ""
+	}`)
+
+	err := ts.Gw.loadBundleWithFs(spec, memFs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "go-b.zip")
+	assert.Contains(t, err.Error(), "driver")
+}
+
+// TestLoadSingleBundle_OnDiskReuse exercises loadSingleBundle's existing-bundle
+// branch (Stat ok → loadBundleManifest partial=true → AddToSpec) which the
+// single bare-filename fast path takes. Pre-stage the hashed bundle dir on the
+// FS with SkipVerifyExistingPluginBundle so no HTTP fetch happens. Requires a
+// running Redis.
+func TestLoadSingleBundle_OnDiskReuse(t *testing.T) {
+	ts := StartTest(func(c *config.Config) {
+		c.BundleBaseURL = "http://bundles.local/"
+		c.SkipVerifyExistingPluginBundle = true
+	})
+	defer ts.Close()
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID:                  "single-bundle-ondisk",
+			CustomMiddlewareBundle: "single.zip",
+		},
+	}
+
+	destPath := ts.Gw.getBundleDestPath(spec)
+	memFs := afero.NewMemMapFs()
+	require.NoError(t, memFs.MkdirAll(destPath, 0755))
+	f, err := memFs.Create(filepath.Join(destPath, "manifest.json"))
+	require.NoError(t, err)
+	_, err = f.WriteString(`{
+		"file_list": [],
+		"custom_middleware": {"driver": "grpc", "pre": [{"name": "preSingle", "path": "plugin.so"}]},
+		"checksum": "deadbeef", "signature": ""
+	}`)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, ts.Gw.loadBundleWithFs(spec, memFs))
+	require.Len(t, spec.CustomMiddleware.Pre, 1)
+	assert.Equal(t, "preSingle", spec.CustomMiddleware.Pre[0].Name)
+	assert.Equal(t, apidef.GrpcDriver, spec.CustomMiddleware.Driver)
 }

--- a/gateway/multi_bundle_backport_test.go
+++ b/gateway/multi_bundle_backport_test.go
@@ -1,0 +1,320 @@
+package gateway
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+// TestParseBundleNames covers the comma-splitting/trimming contract that the
+// multi-bundle dispatcher relies on: a bare filename yields a single element
+// equal to the input, whitespace is trimmed, empty entries are dropped, and an
+// empty/comma-only input yields nothing.
+func TestParseBundleNames(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "bundle.zip", []string{"bundle.zip"}},
+		{"single with surrounding space", "  bundle.zip  ", []string{"bundle.zip"}},
+		{"two", "a.zip,b.zip", []string{"a.zip", "b.zip"}},
+		{"two with spaces", " a.zip , b.zip ", []string{"a.zip", "b.zip"}},
+		{"trailing comma", "a.zip,", []string{"a.zip"}},
+		{"empty middle entry", "a.zip,,b.zip", []string{"a.zip", "b.zip"}},
+		{"only commas and spaces", ", , ", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseBundleNames(tc.in))
+		})
+	}
+
+	// The single-bundle fast path in loadBundleWithFs keys off the parsed
+	// result being exactly one element equal to the untrimmed input. Lock in
+	// that a bare name (no comma, no padding) satisfies it.
+	got := parseBundleNames("bundle.zip")
+	require.Len(t, got, 1)
+	assert.Equal(t, "bundle.zip", got[0])
+}
+
+// TestMergeBundleManifestAppendsHooks verifies the multi-bundle merge
+// concatenates every array hook (pre/post/post_key_auth/response) in
+// declaration order across bundles and within each bundle, and that each
+// entry's Path is prefixed with the bundle's subdir so api_loader's
+// prefix-join resolves to the correct file. Driver-agnostic (uses grpc).
+func TestMergeBundleManifestAppendsHooks(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+
+	a := &apidef.BundleManifest{
+		CustomMiddleware: apidef.MiddlewareSection{
+			Driver: apidef.GrpcDriver,
+			Pre: []apidef.MiddlewareDefinition{
+				{Name: "preA1", Path: "plugin.so"},
+				{Name: "preA2", Path: "plugin.so"},
+			},
+			Post: []apidef.MiddlewareDefinition{
+				{Name: "postA1", Path: "plugin.so"},
+			},
+			PostKeyAuth: []apidef.MiddlewareDefinition{
+				{Name: "pkaA1", Path: "plugin.so"},
+			},
+		},
+	}
+	b := &apidef.BundleManifest{
+		CustomMiddleware: apidef.MiddlewareSection{
+			Driver: apidef.GrpcDriver,
+			Pre: []apidef.MiddlewareDefinition{
+				{Name: "preB1", Path: "plugin.so"},
+			},
+			PostKeyAuth: []apidef.MiddlewareDefinition{
+				{Name: "pkaB1", Path: "plugin.so"},
+				{Name: "pkaB2", Path: "plugin.so"},
+			},
+			Response: []apidef.MiddlewareDefinition{
+				{Name: "respB1", Path: "plugin.so"},
+			},
+		},
+	}
+
+	require.NoError(t, mergeBundleManifest(spec, a, "bundle-a", "bundle-a.zip"))
+	require.NoError(t, mergeBundleManifest(spec, b, "bundle-b", "bundle-b.zip"))
+
+	// pre: A's two then B's one, all path-prefixed by their bundle subdir.
+	require.Len(t, spec.CustomMiddleware.Pre, 3)
+	assert.Equal(t, []string{"preA1", "preA2", "preB1"}, []string{
+		spec.CustomMiddleware.Pre[0].Name,
+		spec.CustomMiddleware.Pre[1].Name,
+		spec.CustomMiddleware.Pre[2].Name,
+	})
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Pre[0].Path, "bundle-a"))
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Pre[1].Path, "bundle-a"))
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Pre[2].Path, "bundle-b"))
+
+	// post_key_auth: A's one then B's two.
+	require.Len(t, spec.CustomMiddleware.PostKeyAuth, 3)
+	assert.Equal(t, []string{"pkaA1", "pkaB1", "pkaB2"}, []string{
+		spec.CustomMiddleware.PostKeyAuth[0].Name,
+		spec.CustomMiddleware.PostKeyAuth[1].Name,
+		spec.CustomMiddleware.PostKeyAuth[2].Name,
+	})
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.PostKeyAuth[0].Path, "bundle-a"))
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.PostKeyAuth[2].Path, "bundle-b"))
+
+	// post: only from A.
+	require.Len(t, spec.CustomMiddleware.Post, 1)
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Post[0].Path, "bundle-a"))
+
+	// response: only from B.
+	require.Len(t, spec.CustomMiddleware.Response, 1)
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Response[0].Path, "bundle-b"))
+
+	// driver propagated and consistent across both bundles.
+	assert.Equal(t, apidef.GrpcDriver, spec.CustomMiddleware.Driver)
+}
+
+// TestMergeBundleManifestEmptyPathNotPrefixed verifies a middleware entry with
+// no Path (nothing to mount on disk) is not given a spurious subdir prefix.
+func TestMergeBundleManifestEmptyPathNotPrefixed(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+
+	manifest := &apidef.BundleManifest{
+		CustomMiddleware: apidef.MiddlewareSection{
+			Driver: apidef.GrpcDriver,
+			Pre: []apidef.MiddlewareDefinition{
+				{Name: "noPath"},                    // empty Path stays empty
+				{Name: "withPath", Path: "hook.so"}, // gets prefixed
+			},
+		},
+	}
+
+	require.NoError(t, mergeBundleManifest(spec, manifest, "bundle-a", "bundle-a.zip"))
+	require.Len(t, spec.CustomMiddleware.Pre, 2)
+	assert.Empty(t, spec.CustomMiddleware.Pre[0].Path, "empty Path must not get a subdir prefix")
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Pre[1].Path, "bundle-a"))
+}
+
+// TestMergeBundleManifestRejectsDuplicateAuthCheck enforces that only one
+// bundle may declare an auth_check hook per API.
+func TestMergeBundleManifestRejectsDuplicateAuthCheck(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+
+	a := &apidef.BundleManifest{
+		CustomMiddleware: apidef.MiddlewareSection{
+			Driver:    apidef.GrpcDriver,
+			AuthCheck: apidef.MiddlewareDefinition{Name: "authA", Path: "plugin.so"},
+		},
+	}
+	b := &apidef.BundleManifest{
+		CustomMiddleware: apidef.MiddlewareSection{
+			Driver:    apidef.GrpcDriver,
+			AuthCheck: apidef.MiddlewareDefinition{Name: "authB", Path: "plugin.so"},
+		},
+	}
+
+	require.NoError(t, mergeBundleManifest(spec, a, "bundle-a", "bundle-a.zip"))
+	err := mergeBundleManifest(spec, b, "bundle-b", "bundle-b.zip")
+	require.Error(t, err, "second auth_check must be rejected")
+	assert.Contains(t, err.Error(), "auth_check")
+
+	// The first bundle's auth_check must remain intact after rejection.
+	assert.Equal(t, "authA", spec.CustomMiddleware.AuthCheck.Name)
+}
+
+// TestMergeBundleManifestRejectsDriverMismatch enforces driver uniformity
+// across composed bundles.
+func TestMergeBundleManifestRejectsDriverMismatch(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+
+	a := &apidef.BundleManifest{
+		CustomMiddleware: apidef.MiddlewareSection{Driver: apidef.GrpcDriver},
+	}
+	b := &apidef.BundleManifest{
+		CustomMiddleware: apidef.MiddlewareSection{Driver: apidef.GoPluginDriver},
+	}
+
+	require.NoError(t, mergeBundleManifest(spec, a, "bundle-a", "bundle-a.zip"))
+	err := mergeBundleManifest(spec, b, "bundle-b", "bundle-b.zip")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "driver")
+}
+
+// TestBundleSubdirNameStripsExtAndCollapsesSlashes verifies the per-bundle
+// directory name derivation is filesystem-safe and stable.
+func TestBundleSubdirNameStripsExtAndCollapsesSlashes(t *testing.T) {
+	assert.Equal(t, "correlation-id-1.4.0", bundleSubdirName("correlation-id-1.4.0.zip"))
+	assert.Equal(t, "platform__correlation-id-1.4.0", bundleSubdirName("platform/correlation-id-1.4.0.zip"))
+	assert.Equal(t, "a__b", bundleSubdirName("a\\b.zip"))
+	assert.NotEmpty(t, bundleSubdirName("")) // fallback hash path
+}
+
+// TestLoadBundleWithFs_EarlyReturns covers the short-circuit branches at the
+// top of loadBundleWithFs: management node, bundle explicitly disabled, empty
+// CustomMiddlewareBundle, and a comma/space-only value that parses to nothing.
+// All must return nil without touching the filesystem.
+//
+// Uses StartTest, so requires a running Redis.
+func TestLoadBundleWithFs_EarlyReturns(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	t.Run("management node skips bundle loading", func(t *testing.T) {
+		conf := ts.Gw.GetConfig()
+		conf.ManagementNode = true
+		ts.Gw.SetConfig(conf)
+		defer func() {
+			conf.ManagementNode = false
+			ts.Gw.SetConfig(conf)
+		}()
+
+		spec := &APISpec{APIDefinition: &apidef.APIDefinition{CustomMiddlewareBundle: "anything.zip"}}
+		assert.NoError(t, ts.Gw.loadBundleWithFs(spec, afero.NewMemMapFs()))
+	})
+
+	t.Run("disabled flag skips bundle loading", func(t *testing.T) {
+		spec := &APISpec{APIDefinition: &apidef.APIDefinition{
+			CustomMiddlewareBundle:         "anything.zip",
+			CustomMiddlewareBundleDisabled: true,
+		}}
+		assert.NoError(t, ts.Gw.loadBundleWithFs(spec, afero.NewMemMapFs()))
+	})
+
+	t.Run("empty bundle field is a no-op", func(t *testing.T) {
+		spec := &APISpec{APIDefinition: &apidef.APIDefinition{CustomMiddlewareBundle: ""}}
+		assert.NoError(t, ts.Gw.loadBundleWithFs(spec, afero.NewMemMapFs()))
+	})
+
+	t.Run("bundle field with only commas parses to nothing", func(t *testing.T) {
+		spec := &APISpec{APIDefinition: &apidef.APIDefinition{CustomMiddlewareBundle: ", , "}}
+		assert.NoError(t, ts.Gw.loadBundleWithFs(spec, afero.NewMemMapFs()))
+	})
+}
+
+// mergeBundleManifestJSON builds a minimal, checksum-valid bundle manifest.
+// file_list is empty, so the md5 checksum over the (zero) referenced files is
+// the well-known md5 of the empty input; DeepVerify therefore passes without
+// any signature configured.
+func mergeBundleManifestJSON(driver, middlewareBody string) map[string]string {
+	return map[string]string{
+		"manifest.json": `{
+			"file_list": [],
+			"custom_middleware": {
+				"driver": "` + driver + `",
+				` + middlewareBody + `
+			},
+			"checksum": "d41d8cd98f00b204e9800998ecf8427e"
+		}`,
+	}
+}
+
+// testMultiBundleMerge is the shared body for the driver-parameterised
+// integration test. It registers two bundles over the test HTTP bundle server,
+// loads them via a comma-separated CustomMiddlewareBundle, and asserts both
+// bundles' hooks land in the merged spec in order with subdir-prefixed paths.
+//
+// This exercises the real fetch → unzip → verify → merge pipeline end to end
+// (no external gRPC/goplugin server is needed, because the merge operates on
+// manifests). Requires a running Redis via StartTest.
+func testMultiBundleMerge(t *testing.T, driver string) {
+	t.Helper()
+
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	bundleA := ts.RegisterBundle("multi_merge_a", mergeBundleManifestJSON(driver,
+		`"pre": [{"name": "PreHookA", "path": "plugin.so"}]`))
+	bundleB := ts.RegisterBundle("multi_merge_b", mergeBundleManifestJSON(driver,
+		`"post": [{"name": "PostHookB", "path": "plugin.so"}],
+		 "auth_check": {"name": "AuthHookB", "path": "plugin.so"}`))
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID:                  "multi-bundle-" + driver,
+			CustomMiddlewareBundle: bundleA + "," + bundleB,
+		},
+	}
+
+	require.NoError(t, ts.Gw.loadBundle(spec))
+
+	// Driver propagated uniformly.
+	assert.Equal(t, apidef.MiddlewareDriver(driver), spec.CustomMiddleware.Driver)
+
+	// Bundle A's pre hook and bundle B's post/auth hooks all present.
+	require.Len(t, spec.CustomMiddleware.Pre, 1)
+	assert.Equal(t, "PreHookA", spec.CustomMiddleware.Pre[0].Name)
+	require.Len(t, spec.CustomMiddleware.Post, 1)
+	assert.Equal(t, "PostHookB", spec.CustomMiddleware.Post[0].Name)
+	assert.Equal(t, "AuthHookB", spec.CustomMiddleware.AuthCheck.Name)
+
+	// Each entry's Path is prefixed with its own bundle's subdir, so the two
+	// bundles' files resolve independently on disk.
+	preSubdir := bundleSubdirName(bundleA)
+	postSubdir := bundleSubdirName(bundleB)
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Pre[0].Path, preSubdir),
+		"pre hook path %q must be prefixed with %q", spec.CustomMiddleware.Pre[0].Path, preSubdir)
+	assert.True(t, strings.HasPrefix(spec.CustomMiddleware.Post[0].Path, postSubdir),
+		"post hook path %q must be prefixed with %q", spec.CustomMiddleware.Post[0].Path, postSubdir)
+	assert.NotEqual(t, preSubdir, postSubdir, "bundles must unpack into distinct subdirs")
+}
+
+// TestMultiBundleMerge_GRPC loads two grpc-driver bundles and asserts their
+// hooks merge in order. Requires a running Redis.
+func TestMultiBundleMerge_GRPC(t *testing.T) {
+	testMultiBundleMerge(t, "grpc")
+}
+
+// TestMultiBundleMerge_GoPlugin loads two goplugin-driver bundles and asserts
+// their hooks merge in order. The goplugin driver is not a registered
+// dispatcher, so the post-merge HandleMiddlewareCache finalizer is a harmless
+// no-op — the manifest-level merge is identical to grpc. Requires a running
+// Redis.
+func TestMultiBundleMerge_GoPlugin(t *testing.T) {
+	testMultiBundleMerge(t, "goplugin")
+}


### PR DESCRIPTION
## Summary

Backports multi-bundle plugin composition to the 5.13 LTS line, scoped to the **gRPC** and **native Go (goplugin)** drivers. A `custom_middleware_bundle` value may now be a comma-separated list of bundle filenames; each bundle is fetched into its own subdirectory and their middleware manifests are merged in declaration order.

The merge machinery is engine-agnostic (it operates on `spec.CustomMiddleware` hook slices and the filesystem). gRPC dispatches each merged hook to the remote server by hook name and native Go resolves each symbol from its own `.so`, so neither needs shared-runtime isolation. The goja/JavaScript handler-isolation work from [TT-16948](https://tyktech.atlassian.net/browse/TT-16948) is **not** included, and the Python and Lua drivers are out of scope (they are broken on the merge path on `master`).

Ticket: https://tyktech.atlassian.net/browse/TT-17786

## What's ported (from `master`, into `gateway/coprocess_bundle.go`)

- `parseBundleNames` - split on commas, trim, drop empties
- `FetchBundle` / `FetchBundleByName` split
- `loadBundleWithFs` dispatcher: 1 name -> legacy `loadSingleBundle` (5.13 body unchanged); >= 2 names -> merge path
- `loadOneBundleForMerge`, `loadBundleManifestNamed`
- `mergeBundleManifest` - concat Pre/Post/PostKeyAuth/Response, single AuthCheck, uniform Driver, first-wins IdExtractor, subdir-prefixed paths
- `bundleSubdirName`
- doc comment on `CustomMiddlewareBundle` in `apidef/api_definitions.go` (no new schema field)

## Backward compatibility

- Single-bundle behavior is byte-identical (legacy code path, gated behind >= 2 comma-separated names).
- The MD5-hashed on-disk cache layout for existing single bundles is unchanged - no re-download or migration on upgrade.
- No goja, JavaScript, Python, or Lua multi-bundle paths introduced.

## Test plan

`go test ./gateway/ -run 'Bundle|MultiBundle|Merge' -count=1`

- `TestParseBundleNames` - trimming, empty/comma/whitespace handling (incl. the untrimmed-single-name edge case)
- `TestMergeBundleManifestAppendsHooks` - cross-bundle + within-bundle ordering, subdir path prefixing
- `TestMergeBundleManifestRejectsDuplicateAuthCheck`, `...RejectsDriverMismatch`, `...EmptyPathNotPrefixed`
- `TestBundleSubdirNameStripsExtAndCollapsesSlashes`
- `TestMultiBundleMerge_GRPC`, `TestMultiBundleMerge_GoPlugin` - real fetch -> unzip -> DeepVerify -> merge against two registered bundles, asserting both bundles' hooks land with subdir-prefixed paths
- Existing single-bundle regression (`TestBundleLoader`, `TestLoadBundleWithFs_*`) passes unchanged

All pass locally against Redis. Note: the integration tests verify spec-composition of the merged manifest; request-time dispatch through a live gRPC server / real `.so` is unchanged by this backport and not exercised end-to-end here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TT-16948]: https://tyktech.atlassian.net/browse/TT-16948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17786" title="TT-17786" target="_blank">TT-17786</a>
</summary>

|         |    |
|---------|----|
| Status  | In design review |
| Summary | Backport multi-bundle plugin composition (gRPC + Go drivers) to release-5.13 |

Generated at: 2026-07-21 15:19:46

</details>

<!---TykTechnologies/jira-linter ends here-->

