### PR TITLE
fix: log intentional Go-plugin reject responses at warn instead of error

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -319,6 +319,20 @@ func (m *GoPluginMiddleware) handlePluginResponse(
 	return ErrResponseSucceed, middleware.StatusRespond
 }
 
+// levelForPluginStatus maps the status code sent by a Go-plugin to the level
+// used for the "Failed to process request" log line. Codes conventionally used
+// for intentional throttling and backpressure are logged at Warn so that
+// plugin rejects do not flood severity-based alerting; everything else,
+// including auth failures, stays at Error.
+func levelForPluginStatus(code int) logrus.Level {
+	switch code {
+	case http.StatusRequestTimeout, http.StatusTeapot, http.StatusTooManyRequests, http.StatusServiceUnavailable:
+		return logrus.WarnLevel
+	default:
+		return logrus.ErrorLevel
+	}
+}
+
 func (m *GoPluginMiddleware) handleErrorResponse(
 	r *http.Request,
 	rw *customResponseWriter,
@@ -339,7 +353,7 @@ func (m *GoPluginMiddleware) handleErrorResponse(
 
 	// base middleware will report this error to analytics if needed
 	err := fmt.Errorf("plugin function sent error response code: %d", rw.statusCodeSent)
-	logger.WithError(err).Error("Failed to process request with Go-plugin middleware func")
+	logger.WithError(err).Log(levelForPluginStatus(rw.statusCodeSent), "Failed to process request with Go-plugin middleware func")
 
 	if rw.responseSent {
 		err = fmt.Errorf("%w: %w", ErrResponseErrorSent, err)

--- a/gateway/mw_go_plugin_test.go
+++ b/gateway/mw_go_plugin_test.go
@@ -1,8 +1,12 @@
 package gateway
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -52,4 +56,53 @@ func TestGoPluginMiddleware_EnabledForSpec(t *testing.T) {
 			assert.False(t, gpm.EnabledForSpec())
 		})
 	})
+}
+
+func TestGoPluginMiddleware_handleErrorResponseLogLevel(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	entry := logrus.NewEntry(logger)
+
+	m := &GoPluginMiddleware{BaseMiddleware: &BaseMiddleware{}}
+
+	tests := []struct {
+		name          string
+		statusCode    int
+		expectedLevel logrus.Level
+	}{
+		{"request timeout logs at warn", http.StatusRequestTimeout, logrus.WarnLevel},
+		{"teapot logs at warn", http.StatusTeapot, logrus.WarnLevel},
+		{"rate limit logs at warn", http.StatusTooManyRequests, logrus.WarnLevel},
+		{"service unavailable logs at warn", http.StatusServiceUnavailable, logrus.WarnLevel},
+		{"bad request logs at error", http.StatusBadRequest, logrus.ErrorLevel},
+		{"unauthorized logs at error", http.StatusUnauthorized, logrus.ErrorLevel},
+		{"internal server error logs at error", http.StatusInternalServerError, logrus.ErrorLevel},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hook.Reset()
+
+			r := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rw := &customResponseWriter{
+				ResponseWriter: httptest.NewRecorder(),
+				responseSent:   true,
+				statusCodeSent: tc.statusCode,
+			}
+
+			err, code := m.handleErrorResponse(r, rw, entry)
+
+			assert.ErrorIs(t, err, ErrResponseErrorSent)
+			assert.Equal(t, tc.statusCode, code)
+
+			if assert.Len(t, hook.Entries, 1) {
+				assert.Equal(t, tc.expectedLevel, hook.LastEntry().Level)
+				assert.Equal(t, "Failed to process request with Go-plugin middleware func", hook.LastEntry().Message)
+			}
+		})
+	}
+
+	// 403 is not in the table because handleErrorResponse fires
+	// EventAuthFailure for it, which needs the full test framework; assert
+	// its mapping directly on the pure function instead.
+	assert.Equal(t, logrus.ErrorLevel, levelForPluginStatus(http.StatusForbidden))
 }


### PR DESCRIPTION
## Description

Go-plugin middleware logs every 4xx/5xx plugin response at `level=error`, with no distinction between an unexpected failure and an intentional reject such as 429 from rate limiting or 503 from circuit breaking. This adds `levelForPluginStatus` in `gateway/mw_go_plugin.go` and uses it for the "Failed to process request with Go-plugin middleware func" line in `handleErrorResponse`:

- 408, 418, 429 and 503 log at `warn`
- every other 4xx/5xx, including 401 and 403 auth failures, stays at `error`

This is Option 1 from the issue, which the Visor triage bot endorsed and invited a PR for. It follows the per-error log-level convention already in this file: `ErrResponseErrorSent` carries `errpack.WithLogLevel` and `gateway/middleware.go` honors it via `errpack.LogLevel`, but the spamming line fires before that wrap and hardcoded `.Error()`. `gateway/mw_jwt.go` uses the same switch-then-`Log` shape (#8401).

No config or API definition schema changes. Deployments alerting on `level=error` counts from this line will see 408, 418, 429 and 503 move to `warn`, which is the point of the fix.

## Related Issue

Fixes #8245

## Motivation and Context

At 1k QPS with 10 percent rejects that is 100 lines/sec of `level=error` for traffic that is normal by design, which floods severity-based alerting. The JS and gRPC coprocess paths avoid this via `ReturnOverrides`; the Go-plugin path has no equivalent, and the only control today is the global `log_level`, which also silences unrelated real errors.

## How This Has Been Tested

`TestGoPluginMiddleware_handleErrorResponseLogLevel` calls `handleErrorResponse` for 408, 418, 429 and 503 expecting `warn`, and 400, 401 and 500 expecting `error`, then checks the returned error still wraps `ErrResponseErrorSent` with the status code unchanged. 403 is asserted on `levelForPluginStatus` directly because that branch fires a gateway event.

Locally on Go 1.25: `gofmt` clean on both files, `go build ./gateway/`, `go vet ./gateway/` and the new test all pass.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why

No documentation or go.mod changes in this PR.
