### PR TITLE
ci: bind PR branch refs to env when building the SonarCloud arguments

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -228,6 +228,9 @@ jobs:
 
       - name: Set SonarCloud parameters
         id: sonar_params
+        env:
+          PR_HEAD_REF: ${{ github.head_ref }}
+          PR_BASE_REF: ${{ github.base_ref }}
         run: |
           # Common parameters for both PR and push
           SONAR_ARGS="-Dsonar.organization=tyktechnologies \
@@ -244,8 +247,8 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             SONAR_ARGS="$SONAR_ARGS \
             -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
-            -Dsonar.pullrequest.branch=${{ github.head_ref }} \
-            -Dsonar.pullrequest.base=${{ github.base_ref }}"
+            -Dsonar.pullrequest.branch=$PR_HEAD_REF \
+            -Dsonar.pullrequest.base=$PR_BASE_REF"
             echo "Running SonarCloud in pull request mode"
           else
             echo "Running SonarCloud in full analysis mode"


### PR DESCRIPTION
Hi, and thanks for Tyk.

In `.github/workflows/ci-tests.yml`, the "Set SonarCloud parameters" step builds the scanner argument string with the PR branch names interpolated in:

```yaml
SONAR_ARGS="$SONAR_ARGS \
-Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
-Dsonar.pullrequest.branch=${{ github.head_ref }} \
-Dsonar.pullrequest.base=${{ github.base_ref }}"
```

Actions expands `${{ ... }}` into the script text before bash runs, so the branch names become part of the script rather than values. Git allows `$`, `(`, `)` and backticks in branch names, and `$(...)` executes inside double quotes — so a PR from a fork on a branch named `x$(id)` would run that while this string is being assembled.

The string then goes to `$GITHUB_OUTPUT` and is consumed by the `Scan` step as `args:`, which is where the SonarCloud credentials are in play.

The change binds the two refs to environment variables:

```yaml
env:
  PR_HEAD_REF: ${{ github.head_ref }}
  PR_BASE_REF: ${{ github.base_ref }}
run: |
  ...
  -Dsonar.pullrequest.branch=$PR_HEAD_REF \
  -Dsonar.pullrequest.base=$PR_BASE_REF"
```

`SONAR_ARGS` ends up with the same content, so the scan is configured identically. I left `github.event_name` and `pull_request.number` interpolated on purpose — one is a fixed GitHub-controlled string and the other is a number, so neither carries this problem.

On scope: `pull_request` means a fork PR has a read-only token and no secrets, so this is hardening rather than a live exploit.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the step and the Scan step that consumes its output myself.
