### PR TITLE
TT-17623: Add kv aware checker to allow kv inline syntax on schema's URI reference types

### DIFF
--- a/apidef/oas/validator.go
+++ b/apidef/oas/validator.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	pkgver "github.com/hashicorp/go-version"
 
+	"github.com/TykTechnologies/storage/kv/resolver"
+
 	tykerrors "github.com/TykTechnologies/tyk/internal/errors"
 	"github.com/TykTechnologies/tyk/internal/service/gojsonschema"
 	logger "github.com/TykTechnologies/tyk/log"
@@ -267,9 +269,10 @@ func getMinorVersion(version string) (string, error) {
 // inlineKVRe matches an inline KV reference token, e.g. "$kv{env:API_HOST}".
 var inlineKVRe = regexp.MustCompile(`\$kv\{[^}]+\}`)
 
-// kvAwareFormatChecker wraps a stock gojsonschema format checker so that inline
-// $kv{...} KV references are accepted inside URI fields, while every other value
-// is validated exactly as before.
+// kvAwareFormatChecker wraps a stock gojsonschema format checker so that KV
+// references ($kv{...} inline tokens and kv:// whole-value references) are
+// accepted inside URI fields, while every other value is validated exactly as
+// before.
 type kvAwareFormatChecker struct {
 	base gojsonschema.FormatChecker
 }
@@ -278,6 +281,10 @@ func (c kvAwareFormatChecker) IsFormat(input any) bool {
 	s, ok := input.(string)
 	if !ok {
 		return c.base.IsFormat(input)
+	}
+
+	if err := resolver.ValidateSyntax(s); err != nil {
+		return false
 	}
 
 	if inlineKVRe.MatchString(s) {

--- a/apidef/oas/validator.go
+++ b/apidef/oas/validator.go
@@ -132,10 +132,6 @@ func validateJSON(schema, document []byte) error {
 		return err
 	}
 
-	if result.Valid() {
-		return nil
-	}
-
 	combinedErr := &multierror.Error{}
 	combinedErr.ErrorFormat = tykerrors.Formatter
 
@@ -143,8 +139,17 @@ func validateJSON(schema, document []byte) error {
 	for _, validationErr := range validationErrs {
 		combinedErr = multierror.Append(combinedErr, errors.New(validationErr.String()))
 	}
-	return combinedErr.ErrorOrNil()
 
+	// The format-scoped checkers only see uri/uri-reference fields, but the
+	// gateway resolves KV references in every string of the definition. Validate
+	// the whole document so a malformed reference in a non-URL field (e.g. a
+	// request-header transform value) is rejected here rather than failing
+	// the resolver at gateway load.
+	if kvErr := resolver.ValidateSyntaxAll(document); kvErr != nil {
+		combinedErr = multierror.Append(combinedErr, kvErr)
+	}
+
+	return combinedErr.ErrorOrNil()
 }
 
 // ValidateOASObject validates an OAS document against a particular OAS version.

--- a/apidef/oas/validator.go
+++ b/apidef/oas/validator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -119,6 +120,8 @@ func loadOASSchema() error {
 }
 
 func validateJSON(schema, document []byte) error {
+	registerKVAwareFormatsOnce.Do(registerKVAwareFormats)
+
 	schemaLoader := gojsonschema.NewBytesLoader(schema)
 	documentLoader := gojsonschema.NewBytesLoader(document)
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
@@ -259,4 +262,37 @@ func getMinorVersion(version string) (string, error) {
 
 	segments := v.Segments()
 	return fmt.Sprintf("%d.%d", segments[0], segments[1]), nil
+}
+
+// inlineKVRe matches an inline KV reference token, e.g. "$kv{env:API_HOST}".
+var inlineKVRe = regexp.MustCompile(`\$kv\{[^}]+\}`)
+
+// kvAwareFormatChecker wraps a stock gojsonschema format checker so that inline
+// $kv{...} KV references are accepted inside URI fields, while every other value
+// is validated exactly as before.
+type kvAwareFormatChecker struct {
+	base gojsonschema.FormatChecker
+}
+
+func (c kvAwareFormatChecker) IsFormat(input any) bool {
+	s, ok := input.(string)
+	if !ok {
+		return c.base.IsFormat(input)
+	}
+
+	if inlineKVRe.MatchString(s) {
+		s = inlineKVRe.ReplaceAllString(s, "kvref")
+	}
+
+	return c.base.IsFormat(s)
+}
+
+var registerKVAwareFormatsOnce sync.Once
+
+// registerKVAwareFormats overrides the stock "uri" and "uri-reference" format
+// checkers on the registry with the KV-aware variant.
+func registerKVAwareFormats() {
+	gojsonschema.FormatCheckers.
+		Add("uri", kvAwareFormatChecker{gojsonschema.URIFormatChecker{}}).
+		Add("uri-reference", kvAwareFormatChecker{gojsonschema.URIReferenceFormatChecker{}})
 }

--- a/apidef/oas/validator_test.go
+++ b/apidef/oas/validator_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/TykTechnologies/tyk/internal/service/gojsonschema"
 	"github.com/buger/jsonparser"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
@@ -506,4 +507,102 @@ func TestGetOASSchema(t *testing.T) {
 		defsKey := GetDefinitionsKey(schema)
 		assert.Equal(t, "$defs", defsKey)
 	})
+}
+
+func TestUpstreamURL_KVReferences(t *testing.T) {
+	base := func(url string) []byte {
+		return []byte(`{
+			"openapi": "3.0.3",
+			"info": {"title": "t", "version": "1"},
+			"paths": {},
+			"x-tyk-api-gateway": {
+				"info": {"name": "t", "state": {"active": true}},
+				"server": {"listenPath": {"value": "/t"}},
+				"upstream": {"url": "` + url + `"}
+			}
+		}`)
+	}
+
+	t.Run("inline kv reference in host position", func(t *testing.T) {
+		err := ValidateOASObject(base(`http://$kv{random-consul:target_url_host}:8888`), "3.0.3")
+		assert.NoError(t, err)
+	})
+
+	t.Run("inline kv reference as the whole host", func(t *testing.T) {
+		err := ValidateOASObject(base(`http://$kv{consul:host}`), "3.0.3")
+		assert.NoError(t, err)
+	})
+
+	t.Run("inline kv reference in the path", func(t *testing.T) {
+		err := ValidateOASObject(base(`https://example.com/$kv{consul:path}`), "3.0.3")
+		assert.NoError(t, err)
+	})
+
+	t.Run("whole-value kv reference", func(t *testing.T) {
+		err := ValidateOASObject(base(`kv://consul/services/redis`), "3.0.3")
+		assert.NoError(t, err)
+	})
+
+	t.Run("whole-value kv reference with fragment", func(t *testing.T) {
+		err := ValidateOASObject(base(`kv://consul/services/redis#host`), "3.0.3")
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects malformed url around an inline kv token", func(t *testing.T) {
+		err := ValidateOASObject(base(`http://$kv{consul:host}:8888 broken`), "3.0.3")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects a plain invalid url with no kv reference", func(t *testing.T) {
+		err := ValidateOASObject(base(`http://exa mple.com`), "3.0.3")
+		require.Error(t, err)
+	})
+
+	t.Run("accepts an ordinary url with no kv reference", func(t *testing.T) {
+		err := ValidateOASObject(base(`https://example.com/api`), "3.0.3")
+		assert.NoError(t, err)
+	})
+}
+
+func TestKVAwareFormatChecker(t *testing.T) {
+	c := kvAwareFormatChecker{base: gojsonschema.URIReferenceFormatChecker{}}
+
+	tests := []struct {
+		name  string
+		input any
+		valid bool
+	}{
+		{"inline token in host", "http://$kv{consul:host}:8888", true},
+		{"inline token as the whole host", "http://$kv{consul:host}", true},
+		{"inline token in path", "https://example.com/$kv{consul:path}", true},
+		{"inline token in query", "https://example.com/api?h=$kv{consul:host}", true},
+		{"inline token with #fragment", "http://$kv{consul:host#field}:8888", true},
+		{"multiple inline tokens", "https://example.com/$kv{a:b}/$kv{c:d}", true},
+
+		{"whole-value kv reference", "kv://consul/services/redis", true},
+		{"whole-value kv reference with fragment", "kv://consul/services/redis#host", true},
+
+		{"ordinary url without a kv reference", "https://example.com/api", true},
+		{"invalid url with a space", "http://exa mple.com", false},
+		{"backslash rejected even alongside a token", `http://$kv{a:b}\x`, false},
+		{"backslash rejected without a token", `http://a\b`, false},
+		{"non-string input", 123, false},
+
+		// Known limitation: a token standing in for the whole port becomes the
+		// non-numeric placeholder "kvref", which url.Parse rejects as a port.
+		{"token as the whole port is not supported", "http://host:$kv{consul:port}", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.valid, c.IsFormat(tt.input))
+		})
+	}
+}
+
+func TestKVAwareFormatChecker_URIBaseKeepsSchemeRequirement(t *testing.T) {
+	c := kvAwareFormatChecker{base: gojsonschema.URIFormatChecker{}}
+
+	assert.True(t, c.IsFormat("http://$kv{consul:host}:8888"))
+	assert.False(t, c.IsFormat("$kv{consul:host}/path"))
 }

--- a/apidef/oas/validator_test.go
+++ b/apidef/oas/validator_test.go
@@ -564,6 +564,37 @@ func TestUpstreamURL_KVReferences(t *testing.T) {
 	})
 }
 
+func TestUpstreamURL_KVReferences_RejectsMalformed(t *testing.T) {
+	base := func(url string) []byte {
+		return []byte(`{
+			"openapi": "3.0.3",
+			"info": {"title": "t", "version": "1"},
+			"paths": {},
+			"x-tyk-api-gateway": {
+				"info": {"name": "t", "state": {"active": true}},
+				"server": {"listenPath": {"value": "/t"}},
+				"upstream": {"url": "` + url + `"}
+			}
+		}`)
+	}
+
+	tests := map[string]string{
+		"inline unclosed token in path (reviewer point 1)": `https://example.com/$kv{unclosed`,
+		"inline token missing store separator":             `https://example.com/$kv{missingcolon}`,
+		"inline token empty store":                         `https://$kv{:onlypath}/x`,
+		"inline token empty path":                          `https://$kv{store:}/x`,
+		"whole-value kv reference without path separator":  `kv://no-path-separator`,
+		"whole-value kv reference empty path":              `kv://vault/`,
+	}
+
+	for name, url := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateOASObject(base(url), "3.0.3")
+			require.Error(t, err, "malformed KV reference %q must be rejected by validation", url)
+		})
+	}
+}
+
 func TestKVAwareFormatChecker(t *testing.T) {
 	c := kvAwareFormatChecker{base: gojsonschema.URIReferenceFormatChecker{}}
 
@@ -591,6 +622,14 @@ func TestKVAwareFormatChecker(t *testing.T) {
 		// Known limitation: a token standing in for the whole port becomes the
 		// non-numeric placeholder "kvref", which url.Parse rejects as a port.
 		{"token as the whole port is not supported", "http://host:$kv{consul:port}", false},
+
+		{"inline unclosed token in path", "https://example.com/$kv{unclosed", false},
+		{"inline token missing store separator", "https://example.com/$kv{missingcolon}", false},
+		{"inline token empty store", "https://$kv{:onlypath}/x", false},
+		{"inline token empty path", "https://$kv{store:}/x", false},
+		{"whole-value kv reference without path separator", "kv://no-path-separator", false},
+		{"whole-value kv reference empty path", "kv://vault/", false},
+		{"whole-value kv reference empty everything", "kv://", false},
 	}
 
 	for _, tt := range tests {
@@ -600,9 +639,40 @@ func TestKVAwareFormatChecker(t *testing.T) {
 	}
 }
 
-func TestKVAwareFormatChecker_URIBaseKeepsSchemeRequirement(t *testing.T) {
+func TestKVAwareFormatChecker_URIBase(t *testing.T) {
 	c := kvAwareFormatChecker{base: gojsonschema.URIFormatChecker{}}
 
-	assert.True(t, c.IsFormat("http://$kv{consul:host}:8888"))
-	assert.False(t, c.IsFormat("$kv{consul:host}/path"))
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		// valid: a scheme is present (either the URL's own or kv://)
+		{"inline token in host with scheme", "http://$kv{consul:host}:8888", true},
+		{"inline token in path with scheme", "https://example.com/$kv{consul:path}", true},
+		{"ordinary absolute url", "https://example.com/api", true},
+		{"whole-value kv reference has kv scheme", "kv://consul/services/redis", true},
+		{"whole-value kv reference with fragment", "kv://consul/services/redis#host", true},
+
+		// invalid: no scheme (the uri-vs-uri-reference distinction)
+		{"bare inline token as whole value has no scheme", "$kv{consul:host}/path", false},
+		{"bare inline token only has no scheme", "$kv{consul:host}", false},
+		{"scheme-relative reference has no scheme", "example.com/api", false},
+
+		// invalid: malformed KV reference, rejected before the scheme check
+		{"inline unclosed token", "https://example.com/$kv{unclosed", false},
+		{"inline token missing store separator", "https://example.com/$kv{missingcolon}", false},
+		{"inline token empty path", "https://$kv{store:}/x", false},
+		{"whole-value kv reference without path separator", "kv://no-path-separator", false},
+		{"whole-value kv reference empty path", "kv://vault/", false},
+
+		// invalid: plain bad url, no KV involved
+		{"invalid url with a space", "http://exa mple.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.valid, c.IsFormat(tt.input))
+		})
+	}
 }

--- a/apidef/oas/validator_test.go
+++ b/apidef/oas/validator_test.go
@@ -595,6 +595,41 @@ func TestUpstreamURL_KVReferences_RejectsMalformed(t *testing.T) {
 	}
 }
 
+func TestValidateOASObject_KVSyntaxInNonURLField(t *testing.T) {
+	doc := func(headerValue string) []byte {
+		return []byte(`{
+			"openapi": "3.0.3",
+			"info": {"title": "t", "version": "1"},
+			"paths": {},
+			"x-tyk-api-gateway": {
+				"info": {"name": "t", "state": {"active": true}},
+				"server": {"listenPath": {"value": "/t"}},
+				"upstream": {"url": "http://upstream.url"},
+				"middleware": {
+					"operations": {
+						"getOp": {
+							"transformRequestHeaders": {
+								"enabled": true,
+								"add": [{"name": "X-KV", "value": "` + headerValue + `"}]
+							}
+						}
+					}
+				}
+			}
+		}`)
+	}
+
+	t.Run("accepts a well-formed kv reference in a header value", func(t *testing.T) {
+		err := ValidateOASObject(doc(`kv://vault/db/password`), "3.0.3")
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects a malformed kv reference in a header value", func(t *testing.T) {
+		err := ValidateOASObject(doc(`kv://random-gcpdb-password`), "3.0.3")
+		require.Error(t, err)
+	})
+}
+
 func TestKVAwareFormatChecker(t *testing.T) {
 	c := kvAwareFormatChecker{base: gojsonschema.URIReferenceFormatChecker{}}
 

--- a/internal/service/gojsonschema/gojsonschema.go
+++ b/internal/service/gojsonschema/gojsonschema.go
@@ -5,11 +5,14 @@ import (
 )
 
 type (
-	JSONLoader              = gojsonschema.JSONLoader
-	ResultError             = gojsonschema.ResultError
-	Result                  = gojsonschema.Result
-	FormatCheckerChain      = gojsonschema.FormatCheckerChain
-	DoesNotMatchFormatError = gojsonschema.DoesNotMatchFormatError
+	JSONLoader                = gojsonschema.JSONLoader
+	ResultError               = gojsonschema.ResultError
+	Result                    = gojsonschema.Result
+	FormatCheckerChain        = gojsonschema.FormatCheckerChain
+	DoesNotMatchFormatError   = gojsonschema.DoesNotMatchFormatError
+	FormatChecker             = gojsonschema.FormatChecker
+	URIFormatChecker          = gojsonschema.URIFormatChecker
+	URIReferenceFormatChecker = gojsonschema.URIReferenceFormatChecker
 )
 
 var (


### PR DESCRIPTION
## Description
Ticket: https://tyktech.atlassian.net/browse/TT-17623

URI and URI-Reference formats on OAS schema don't allow kv inline syntax symbols - curly braces. This change is adding a wrapper for URI based checkers which permit new kv inline syntax.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why



<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17623" title="TT-17623" target="_blank">TT-17623</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | Adapt Dashboard UI for a new kv:// syntax |

Generated at: 2026-07-30 07:10:30

</details>

<!---TykTechnologies/jira-linter ends here-->


