### PR TITLE
fix: prevent IP ACL nil.Equal(nil) bypass

### DIFF
--- a/gateway/mw_ip_blacklist.go
+++ b/gateway/mw_ip_blacklist.go
@@ -26,6 +26,11 @@ func (i *IPBlackListMiddleware) EnabledForSpec() bool {
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (i *IPBlackListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	remoteIP := net.ParseIP(request.RealIP(r))
+	// net.IP.Equal treats two nil IPs as equal. Skip matching when the client IP or an
+	// ACL entry is unparseable so invalid config cannot blacklist every request.
+	if remoteIP == nil {
+		return nil, http.StatusOK
+	}
 
 	// Enabled, check incoming IP address
 	for _, ip := range i.Spec.BlacklistedIPs {
@@ -42,7 +47,7 @@ func (i *IPBlackListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 		}
 
 		// We parse the IP to manage IPv4 and IPv6 easily
-		if blockedIP.Equal(remoteIP) {
+		if blockedIP != nil && blockedIP.Equal(remoteIP) {
 			return i.handleError(r, remoteIP.String())
 		}
 	}

--- a/gateway/mw_ip_blacklist_test.go
+++ b/gateway/mw_ip_blacklist_test.go
@@ -133,6 +133,22 @@ func TestIPBlacklistMiddleware(t *testing.T) {
 	}
 }
 
+func TestIPBlackListMiddleware_NilIPDoesNotMatchInvalidEntry(t *testing.T) {
+	// BlacklistedIPs includes the invalid entry "bob". Previously nil.Equal(nil)
+	// treated every unparseable client IP as blacklisted.
+	spec := testPrepareIPBlacklistMiddleware()
+	mw := &IPBlackListMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec}}
+
+	rec := httptest.NewRecorder()
+	req := TestReq(t, "GET", "/", nil)
+	req.RemoteAddr = "not-an-ip"
+	req.Header.Del(header.XRealIP)
+	req.Header.Del(header.XForwardFor)
+
+	_, code := mw.ProcessRequest(rec, req, nil)
+	assert.Equal(t, http.StatusOK, code)
+}
+
 func BenchmarkIPBlacklistMiddleware(b *testing.B) {
 	b.ReportAllocs()
 

--- a/gateway/mw_ip_whitelist.go
+++ b/gateway/mw_ip_whitelist.go
@@ -26,6 +26,13 @@ func (i *IPWhiteListMiddleware) EnabledForSpec() bool {
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	remoteIP := net.ParseIP(request.RealIP(r))
+	// net.IP.Equal treats two nil IPs as equal. Reject unparseable client IPs and
+	// skip invalid ACL entries so a bad config entry cannot accidentally allow traffic.
+	if remoteIP == nil {
+		AuthFailed(i, r, request.RealIP(r))
+		reportHealthValue(i.Spec, KeyFailure, "-1")
+		return errors.New("access from this IP has been disallowed"), http.StatusForbidden
+	}
 
 	// Enabled, check incoming IP address
 	for _, ip := range i.Spec.AllowedIPs {
@@ -42,7 +49,7 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 		}
 
 		// We parse the IP to manage IPv4 and IPv6 easily
-		if allowedIP.Equal(remoteIP) {
+		if allowedIP != nil && allowedIP.Equal(remoteIP) {
 			// matched, pass through
 			return nil, http.StatusOK
 		}

--- a/gateway/mw_ip_whitelist_test.go
+++ b/gateway/mw_ip_whitelist_test.go
@@ -134,6 +134,22 @@ func TestIPMiddlewarePass(t *testing.T) {
 	}
 }
 
+func TestIPWhiteListMiddleware_NilIPDoesNotBypass(t *testing.T) {
+	// AllowedIPs includes the invalid entry "bob". Previously nil.Equal(nil) let
+	// requests with an empty/unparseable client IP through the whitelist.
+	spec := testPrepareIPMiddlewarePass()
+	mw := &IPWhiteListMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec}}
+
+	rec := httptest.NewRecorder()
+	req := TestReq(t, "GET", "/", nil)
+	req.RemoteAddr = "not-an-ip"
+	req.Header.Del(header.XRealIP)
+	req.Header.Del(header.XForwardFor)
+
+	_, code := mw.ProcessRequest(rec, req, nil)
+	assert.Equal(t, http.StatusForbidden, code)
+}
+
 func BenchmarkIPMiddlewarePass(b *testing.B) {
 	b.ReportAllocs()
 


### PR DESCRIPTION
## Summary
- `net.IP.Equal` treats two nil IPs as equal, so an unparseable client IP combined with an invalid ACL entry could whitelist-bypass or blacklist every request.
- Reject nil client IPs on whitelist and skip nil ACL entries on both whitelist and blacklist.
- Adds regression tests for empty/unparseable client IPs when ACL lists contain invalid entries.

## Test plan
- [x] `go test ./gateway/ -run 'TestIPMiddlewarePass|TestIPWhiteListMiddleware_NilIP|TestIPBlacklistMiddleware|TestIPBlackListMiddleware_NilIP'`
- [x] Confirm whitelist still allows exact/CIDR matches and denies non-matches
- [x] Confirm blacklist still blocks exact/CIDR matches and allows non-matches