### PR TITLE
fix: allow colon characters in Basic Auth passwords

### DIFF
--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -112,7 +112,8 @@ func (k *BasicAuthKeyIsValid) basicAuthHeaderCredentials(w http.ResponseWriter, 
 		return
 	}
 
-	authValues := strings.Split(string(authvaluesStr), ":")
+	// RFC 7617: credentials are "userid:password" where password may contain ':'.
+	authValues := strings.SplitN(string(authvaluesStr), ":", 2)
 	if len(authValues) != 2 {
 		// Header malformed
 		logger.Info("Attempted access with malformed header, values not in basic auth format.")

--- a/gateway/mw_basic_auth_test.go
+++ b/gateway/mw_basic_auth_test.go
@@ -4,11 +4,14 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
@@ -49,7 +52,9 @@ func TestBasicAuth(t *testing.T) {
 
 	validPassword := map[string]string{"Authorization": genAuthHeader("user", "password")}
 	wrongPassword := map[string]string{"Authorization": genAuthHeader("user", "wrong")}
-	wrongFormat := map[string]string{"Authorization": genAuthHeader("user", "password:more")}
+	// RFC 7617 allows ':' in the password; wrong password yields 401, not 400 malformed.
+	passwordWithColon := map[string]string{"Authorization": genAuthHeader("user", "password:more")}
+	missingColon := map[string]string{"Authorization": "Basic " + base64.StdEncoding.EncodeToString([]byte("usernocolon"))}
 	malformed := map[string]string{"Authorization": "not base64"}
 
 	ts.Run(t, []test.TestCase{
@@ -58,9 +63,43 @@ func TestBasicAuth(t *testing.T) {
 		{Method: "GET", Path: "/", Code: 401, BodyMatch: `Authorization field missing`},
 		{Method: "GET", Path: "/", Headers: validPassword, Code: 200},
 		{Method: "GET", Path: "/", Headers: wrongPassword, Code: 401},
-		{Method: "GET", Path: "/", Headers: wrongFormat, Code: 400, BodyMatch: `Attempted access with malformed header, values not in basic auth format`},
+		{Method: "GET", Path: "/", Headers: passwordWithColon, Code: 401},
+		{Method: "GET", Path: "/", Headers: missingColon, Code: 400, BodyMatch: `Attempted access with malformed header, values not in basic auth format`},
 		{Method: "GET", Path: "/", Headers: malformed, Code: 400, BodyMatch: `Attempted access with malformed header, auth data not encoded correctly`},
 	}...)
+}
+
+func TestBasicAuthHeaderCredentials_RFC7617PasswordColon(t *testing.T) {
+	gw := &Gateway{}
+	gw.SetConfig(config.Config{})
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{
+		AuthConfigs: map[string]apidef.AuthConfig{
+			apidef.BasicType: {},
+		},
+	}}
+	k := &BasicAuthKeyIsValid{BaseMiddleware: &BaseMiddleware{Spec: spec, Gw: gw}}
+
+	t.Run("password containing colon is valid", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", genAuthHeader("user", "p@ss:word:extra"))
+
+		username, password, err, code := k.basicAuthHeaderCredentials(rec, req)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, code)
+		assert.Equal(t, "user", username)
+		assert.Equal(t, "p@ss:word:extra", password)
+	})
+
+	t.Run("missing colon is malformed", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("usernocolon")))
+
+		_, _, err, code := k.basicAuthHeaderCredentials(rec, req)
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, code)
+	})
 }
 
 func TestBasicAuthFromBody(t *testing.T) {


### PR DESCRIPTION
## Summary
- RFC 7617 defines Basic credentials as `userid:password` where only the first colon separates the fields.
- `strings.Split` rejected valid passwords containing `:` as malformed (HTTP 400).
- Switch to `SplitN(..., 2)` and add unit coverage for colon passwords and missing-colon malformed headers.

## Test plan
- [x] `go test ./gateway/ -run 'TestBasicAuthHeaderCredentials_RFC7617PasswordColon'`
- [x] Authenticate with a Basic Auth password containing `:` and confirm success (or 401 on wrong password, not 400)