### PR TITLE
fix: match Strip Auth cookies by exact name

### DIFF
--- a/gateway/mw_strip_auth.go
+++ b/gateway/mw_strip_auth.go
@@ -88,8 +88,11 @@ func (sa *StripAuth) stripFromHeaders(r *http.Request, config *apidef.AuthConfig
 	cookieValue := r.Header.Get("Cookie")
 
 	cookies := strings.Split(cookieValue, ";")
+	cookiePrefix := cookieName + "="
 	for i, c := range cookies {
-		if strings.HasPrefix(strings.TrimSpace(c), cookieName) {
+		// Match the cookie name exactly (name=...), not as a prefix of another
+		// cookie such as Authorization vs Authorizations or Auth vs AuthToken.
+		if strings.HasPrefix(strings.TrimSpace(c), cookiePrefix) {
 			cookies = append(cookies[:i], cookies[i+1:]...)
 			cookieValue = strings.Join(cookies, ";")
 			r.Header.Set("Cookie", cookieValue)

--- a/gateway/mw_strip_auth_test.go
+++ b/gateway/mw_strip_auth_test.go
@@ -93,6 +93,24 @@ func TestStripAuth_stripFromHeaders(t *testing.T) {
 		// whitespace between cookies
 		stripFromCookieTest(t, req, key, sa, "Dummy=DUMMY; NonDefaultName=AUTHORIZATION; Dummy2=DUMMY2", "Dummy=DUMMY; Dummy2=DUMMY2")
 	})
+
+	t.Run("does not strip cookies that only share a name prefix", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sa := StripAuth{BaseMiddleware: &BaseMiddleware{}}
+		sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
+
+		key := "Auth"
+		sa.Spec.AuthConfigs = map[string]apidef.AuthConfig{
+			apidef.AuthTokenType: {CookieName: key},
+		}
+		// AuthToken must remain; only Auth=... should be removed.
+		stripFromCookieTest(t, req, key, sa,
+			"Auth=SECRET;AuthToken=KEEP;Authorization=KEEP2",
+			"AuthToken=KEEP;Authorization=KEEP2")
+	})
 }
 
 func stripFromCookieTest(t *testing.T, req *http.Request, key string, sa StripAuth, value string, expected string) {


### PR DESCRIPTION
## Summary
- Strip Auth matched cookies with `HasPrefix(cookie, cookieName)`, so `CookieName=Auth` also stripped `AuthToken=...`.
- Require a trailing `=` so only the configured cookie name is removed.
- Adds a regression test for prefix collisions.

## Test plan
- [x] `go test ./gateway/ -run 'TestStripAuth_stripFromHeaders'`
- [x] Confirm `Auth=secret` is stripped while `AuthToken=keep` remains