### PR TITLE
fix: stop ValidateJSON mutating shared path meta

### DIFF
--- a/gateway/mw_validate_json.go
+++ b/gateway/mw_validate_json.go
@@ -65,13 +65,16 @@ func (k *ValidateJSON) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ 
 
 	// Handle Failure
 	if !result.Valid() {
-		if vPathMeta.ErrorResponseCode == 0 {
-			vPathMeta.ErrorResponseCode = http.StatusUnprocessableEntity
+		// Use a local status code so we do not mutate shared API definition
+		// metadata under concurrent request handling.
+		code := vPathMeta.ErrorResponseCode
+		if code == 0 {
+			code = http.StatusUnprocessableEntity
 		}
 		formattedErr := k.formatError(result.Errors())
 		ctx.SetErrorClassification(r, tykerrors.ClassifyJSONValidationError(tykerrors.ErrTypeSchemaValidationFailed, k.Name()).
 			WithTemplateData(map[string]any{"InvalidParams": formattedErr.Error()}))
-		return formattedErr, vPathMeta.ErrorResponseCode
+		return formattedErr, code
 	}
 
 	// Handle Success

--- a/gateway/mw_validate_json_test.go
+++ b/gateway/mw_validate_json_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -208,4 +210,41 @@ func TestValidateJSONSchemaTemplateData(t *testing.T) {
 			},
 		})
 	})
+}
+
+func TestValidateJSONDoesNotMutateSharedErrorResponseCode(t *testing.T) {
+	gw := &Gateway{}
+	gw.SetConfig(config.Config{})
+
+	var schema map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(testJsonSchema), &schema))
+
+	loader := APIDefinitionLoader{Gw: gw}
+	urlSpecs := loader.compileValidateJSONPathsSpec([]apidef.ValidatePathMeta{{
+		Path:   "/v",
+		Method: http.MethodPost,
+		Schema: schema,
+	}}, ValidateJSONRequest, config.Config{})
+	require.Len(t, urlSpecs, 1)
+	require.Equal(t, 0, urlSpecs[0].ValidatePathMeta.ErrorResponseCode)
+
+	spec := BuildAPI(func(s *APISpec) {
+		s.Proxy.ListenPath = "/"
+		UpdateAPIVersion(s, "v1", func(v *apidef.VersionInfo) {
+			v.Name = "v1"
+		})
+		s.RxPaths = map[string][]URLSpec{
+			"v1": urlSpecs,
+		}
+	})[0]
+
+	mw := &ValidateJSON{BaseMiddleware: &BaseMiddleware{Spec: spec, Gw: gw}}
+	req := httptest.NewRequest(http.MethodPost, "/v", strings.NewReader(`{"age":23}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	err, code := mw.ProcessRequest(httptest.NewRecorder(), req, nil)
+	require.Error(t, err)
+	require.Equal(t, http.StatusUnprocessableEntity, code)
+	// Shared path meta must remain unset (0), not permanently rewritten to 422.
+	assert.Equal(t, 0, urlSpecs[0].ValidatePathMeta.ErrorResponseCode)
 }


### PR DESCRIPTION
## Summary
- On schema failure, ValidateJSON wrote `ErrorResponseCode = 422` into shared `ValidatePathMeta` pointed at by RxPaths.
- That races under concurrent requests and permanently mutates loaded API config.
- Use a local status code default instead, with a unit test asserting meta stays at 0.

## Test plan
- [x] `go test ./gateway/ -run 'TestValidateJSONDoesNotMutateSharedErrorResponseCode'`
- [x] Invalid JSON schema requests still return 422 when no custom code is configured