### PR TITLE
fix: recognise MCP Content-Type case-insensitively to close ACL bypass

### DIFF
--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -77,8 +78,23 @@ func (m *JSONRPCMiddleware) validateJSONRPCRequest(r *http.Request) bool {
 		return false
 	}
 
-	contentType := r.Header.Get(headerContentType)
-	return strings.HasPrefix(contentType, contentTypeJSON)
+	return isJSONRPCContentType(r.Header.Get(headerContentType))
+}
+
+// isJSONRPCContentType reports whether the Content-Type identifies a JSON body
+// for JSON-RPC/MCP routing. HTTP media types are case-insensitive (RFC 9110
+// §8.3.1), and the MCP execution engine (go-sdk) accepts them case-insensitively
+// via mime.ParseMediaType. The security gate MUST use the same case-insensitive
+// recognition as the engine: a byte-exact prefix check here fails open on
+// variants like "Application/json", letting a request slip past MCP access
+// control while the engine still executes it.
+func isJSONRPCContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(contentType))
+	if err != nil {
+		return false
+	}
+	// mime.ParseMediaType already lower-cases the media type.
+	return mediaType == contentTypeJSON || strings.HasSuffix(mediaType, "+json")
 }
 
 // readAndParseJSONRPC reads the request body and parses it as JSON-RPC 2.0.

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/jsonrpc"
@@ -67,7 +66,11 @@ func parseSyntheticAdapterJSONRPC(r *http.Request) (*JSONRPCRequest, bool, error
 	if r == nil || r.Method != http.MethodPost || r.Body == nil {
 		return nil, false, nil
 	}
-	if !strings.HasPrefix(r.Header.Get(headerContentType), contentTypeJSON) {
+	// Case-insensitive media-type recognition, matching the MCP execution
+	// engine (RFC 9110 §8.3.1). A byte-exact check here would let a
+	// case-variant Content-Type (e.g. "Application/json") skip REST-as-MCP
+	// policy while the SDK adapter still executes the request.
+	if !isJSONRPCContentType(r.Header.Get(headerContentType)) {
 		return nil, false, nil
 	}
 

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
@@ -84,6 +84,54 @@ func TestRESTAsMCPPolicy_DeniesBlockedToolBeforeSDK(t *testing.T) {
 	assert.Equal(t, "orders", ctxGetMCPPrimitiveName(req))
 }
 
+// TestRESTAsMCPPolicy_DeniesBlockedToolWithCaseVariantContentType is the
+// regression test for the Content-Type case differential (CHAIN 2): a
+// low-privilege caller must not bypass Tool-Based Access Control by sending
+// "Content-Type: Application/json" (capital A). The SDK adapter accepts the
+// case variant, so the policy gate must recognise it identically — otherwise
+// the request runs unrouted and the denied tool executes.
+func TestRESTAsMCPPolicy_DeniesBlockedToolWithCaseVariantContentType(t *testing.T) {
+	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
+	called := false
+	var err error
+	adapterSpec.MCPAdapter.SDKAdapter, err = mcpadapter.NewSDKAdapter(mcpadapter.SDKServerConfig{
+		Name:  adapterSpec.Name,
+		Tools: adapterSpec.MCPAdapter.UnionTools,
+		CallTool: func(context.Context, *oas.DerivedTool, map[string]any) (*mcpadapter.Recorder, error) {
+			called = true
+			return mcpadapter.NewRecorder(), nil
+		},
+	})
+	require.NoError(t, err)
+
+	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}
+	sessionID := initializeSyntheticAdapterSession(t, mw, "proxy-1")
+	req := restAsMCPPolicyRequest(t, sessionID, `{
+		"jsonrpc":"2.0",
+		"id":2,
+		"method":"tools/call",
+		"params":{"name":"orders","arguments":{}}
+	}`)
+	// The exploit: a single capital letter in the media type.
+	req.Header.Set("Content-Type", "Application/json")
+	ctxSetMCPAdapterCallerProxyID(req, "proxy-1")
+	setSessionForTest(req, restAsMCPSession("proxy-1", user.AccessDefinition{
+		APIID: "proxy-1",
+		MCPAccessRights: user.MCPAccessRights{
+			Tools: user.AccessControlRules{Blocked: []string{"orders"}},
+		},
+	}))
+	rec := httptest.NewRecorder()
+
+	err, status := mw.ProcessRequest(rec, req, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, middleware.StatusRespond, status)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "tool 'orders' is not available")
+	assert.False(t, called, "blocked tool must not reach the SDK adapter")
+}
+
 func TestRESTAsMCPPolicy_MethodDeniedBeforeSDK(t *testing.T) {
 	gw, adapterSpec, _ := syntheticAdapterGatewayForCallTest(t)
 	mw := &JSONRPCMiddleware{BaseMiddleware: &BaseMiddleware{Spec: adapterSpec, Gw: gw}}

--- a/gateway/mw_jsonrpc_test.go
+++ b/gateway/mw_jsonrpc_test.go
@@ -175,6 +175,72 @@ func TestJSONRPCMiddleware_ProcessRequest_NonJSONPassthrough(t *testing.T) {
 	assert.Equal(t, http.StatusOK, code)
 }
 
+// TestIsJSONRPCContentType guards the security gate against a parser
+// differential: HTTP media types are case-insensitive (RFC 9110 §8.3.1) and the
+// MCP execution engine accepts them case-insensitively, so the gate must too. A
+// byte-exact check would fail open on variants like "Application/json", letting
+// a request skip MCP access control while the engine still executes it.
+func TestIsJSONRPCContentType(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{"lowercase", "application/json", true},
+		{"capital A", "Application/json", true},
+		{"uppercase", "APPLICATION/JSON", true},
+		{"mixed with charset", "Application/JSON; charset=utf-8", true},
+		{"leading whitespace", "  application/json", true},
+		{"structured suffix", "application/vnd.api+json", true},
+		{"structured suffix mixed case", "Application/VND.api+JSON", true},
+		{"plain text", "text/plain", false},
+		{"empty", "", false},
+		{"json substring not media type", "text/json-ish", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isJSONRPCContentType(tt.contentType))
+		})
+	}
+}
+
+// TestJSONRPCMiddleware_ProcessRequest_CaseInsensitiveContentType ensures a
+// case-variant Content-Type is still recognised as JSON-RPC and routed (so
+// downstream MCP access control runs) rather than passed through unrouted.
+func TestJSONRPCMiddleware_ProcessRequest_CaseInsensitiveContentType(t *testing.T) {
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			ApplicationProtocol: apidef.AppProtocolMCP,
+			JsonRpcVersion:      apidef.JsonRPC20,
+		},
+		MCPPrimitives: map[string]string{
+			"tool:get-weather": mcp.ToolPrefix + "get-weather",
+		},
+		JSONRPCRouter: mcp.NewRouter(),
+	}
+
+	m := &JSONRPCMiddleware{
+		BaseMiddleware: &BaseMiddleware{Spec: spec},
+	}
+
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get-weather","arguments":{}}}`)
+	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "Application/json")
+	w := httptest.NewRecorder()
+
+	err, code := m.ProcessRequest(w, r, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	// Routing state must exist: this is what every downstream MCP access-control
+	// gate keys on. Without it (the fail-open bug) the gates all no-op.
+	state := httpctx.GetJSONRPCRoutingState(r)
+	require.NotNil(t, state, "case-variant Content-Type must still be routed")
+	assert.Equal(t, "tools/call", state.Method)
+	assert.Equal(t, mcp.PrimitiveTypeTool, state.PrimitiveType)
+}
+
 func TestJSONRPCMiddleware_ProcessRequest_InvalidJSON(t *testing.T) {
 	spec := &APISpec{
 		APIDefinition: &apidef.APIDefinition{


### PR DESCRIPTION
## Description

The JSON-RPC/MCP security gate recognised a request as JSON-RPC only via a byte-exact `strings.HasPrefix(contentType, "application/json")` check and failed open when it did not match. HTTP media types are case-insensitive (RFC 9110 §8.3.1) and the MCP execution engine (bundled go-sdk) accepts them case-insensitively via `mime.ParseMediaType`. This parser differential let an authenticated low-privilege caller send `Content-Type: Application/json` (capital A): the gate created no routing state, so every downstream MCP access-control gate no-op'd, while the engine still executed the request — bypassing Tool-Based Access Control (and per-endpoint rate limits on the REST-as-MCP adapter) and enumerating the unfiltered catalogue.

Both recognition sites (`validateJSONRPCMiddleware.validateJSONRPCRequest` and `parseSyntheticAdapterJSONRPC`) now use a shared `isJSONRPCContentType` helper that parses the media type case-insensitively, matching the engine so the gate and the engine can no longer disagree on a single byte.

Adds unit coverage for the helper, a routing-state assertion for the generic MCP path, and a full synthetic REST-as-MCP regression test proving a blocked tool is denied (403) and never reaches the SDK when sent with a case-variant Content-Type. All three fail against the pre-fix code.

## Related Issue

#8539 

## Motivation and Context

An authenticated low-privilege MCP consumer could bypass the exact access-control guarantee the feature exists to provide — Tool-Based Access Control, per-endpoint rate limits, and catalogue filtering — by flipping a single byte in the `Content-Type` header. The gate (case-sensitive) and the execution engine (case-insensitive) disagreed on what counts as a JSON-RPC request; this change aligns the gate to the engine so they can no longer diverge.

## How This Has Been Tested

- `go build ./gateway/...` — clean.
- `go test ./gateway/ -run 'MCP|JSONRPC'` — passes (requires local Redis for the integration tests).
- `go vet`, `gofmt`, and `golangci-lint run ./gateway/ --new-from-rev=HEAD` — no issues.
- New tests (`TestIsJSONRPCContentType`, `TestJSONRPCMiddleware_ProcessRequest_CaseInsensitiveContentType`, `TestRESTAsMCPPolicy_DeniesBlockedToolWithCaseVariantContentType`) verified to **fail against the pre-fix code** and pass after the fix.

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required <!-- N/A — no go.mod changes -->
- [ ] I would like a code coverage CI quality gate exception and have explained why
