### PR TITLE
graphengine: support restricted_types for INPUT_OBJECT fields

### DIFF
--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -75,7 +75,9 @@ type GraphqlGranularAccessResult struct {
 type GraphqlGranularAccessChecker struct{}
 
 func (g *GraphqlGranularAccessChecker) validateFieldRestrictions(gqlRequest *graphql.Request, fieldRestrictionList graphql.FieldRestrictionList, schema *graphql.Schema) GraphqlGranularAccessResult {
-	result, err := gqlRequest.ValidateFieldRestrictions(schema, fieldRestrictionList, graphql.DefaultFieldsValidator{})
+	result, err := gqlRequest.ValidateFieldRestrictions(schema, fieldRestrictionList, &graphengine.TykFieldsValidatorV1{
+		Variables: gqlRequest.Variables,
+	})
 	if err != nil {
 		return GraphqlGranularAccessResult{failReason: GranularAccessFailReasonInternalError, internalErr: err}
 	}

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -11,8 +11,12 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/jensneuse/abstractlogger"
 
+	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/astparser"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/astvisitor"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/execution/datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/postprocess"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -447,7 +451,9 @@ func (g *granularAccessCheckerV1) CheckGraphQLRequestFieldAllowance(w http.Respo
 }
 
 func (g *granularAccessCheckerV1) validateFieldRestrictions(gqlRequest *graphql.Request, fieldRestrictionList graphql.FieldRestrictionList, schema *graphql.Schema) GraphQLGranularAccessResult {
-	result, err := gqlRequest.ValidateFieldRestrictions(schema, fieldRestrictionList, graphql.DefaultFieldsValidator{})
+	result, err := gqlRequest.ValidateFieldRestrictions(schema, fieldRestrictionList, &TykFieldsValidatorV1{
+		Variables: gqlRequest.Variables,
+	})
 	if err != nil {
 		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonInternalError, InternalErr: err}
 	}
@@ -456,6 +462,305 @@ func (g *granularAccessCheckerV1) validateFieldRestrictions(gqlRequest *graphql.
 		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonValidationError, ValidationError: result.Errors, writeErrorResponse: g.writeErrorResponse}
 	}
 	return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonNone}
+}
+
+type TykFieldsValidatorV1 struct {
+	Variables []byte
+}
+
+type inputFieldsVisitorV1 struct {
+	walker            *astvisitor.Walker
+	operation         *ast.Document
+	definition        *ast.Document
+	variables         []byte
+	data              graphql.RequestTypes
+	currentParentType ast.Node
+}
+
+func (v *inputFieldsVisitorV1) EnterField(ref int) {
+	v.currentParentType = v.walker.EnclosingTypeDefinition
+}
+
+func (v *inputFieldsVisitorV1) EnterArgument(ref int) {
+	argName := v.operation.ArgumentNameString(ref)
+	val := v.operation.ArgumentValue(ref)
+
+	if len(v.walker.Ancestors) == 0 {
+		return
+	}
+	parentFieldNode := v.walker.Ancestors[len(v.walker.Ancestors)-1]
+	if parentFieldNode.Kind != ast.NodeKindField {
+		return
+	}
+	fieldName := v.operation.FieldNameString(parentFieldNode.Ref)
+
+	parentType := v.currentParentType
+	fieldDefRef, exists := v.getFieldDefinition(parentType, fieldName)
+	if !exists {
+		return
+	}
+
+	var argTypeName string
+	for _, argDefRef := range v.definition.FieldDefinitionArgumentsDefinitions(fieldDefRef) {
+		if v.definition.InputValueDefinitionNameString(argDefRef) == argName {
+			typeRef := v.definition.InputValueDefinitionType(argDefRef)
+			argTypeName = v.definition.ResolveTypeNameString(typeRef)
+			break
+		}
+	}
+
+	if argTypeName == "" {
+		return
+	}
+
+	if val.Kind == ast.ValueKindObject {
+		v.walkInlineObjectValue(val.Ref, argTypeName)
+	} else if val.Kind == ast.ValueKindVariable {
+		varName := v.operation.VariableValueNameString(val.Ref)
+		varType, ok := v.getVariableTypeName(varName)
+		if ok {
+			varValue, _, _, err := jsonparser.Get(v.variables, varName)
+			if err == nil {
+				v.walkJSONValue(varValue, varType)
+			}
+		}
+	}
+}
+
+func (v *inputFieldsVisitorV1) getFieldDefinition(parentType ast.Node, fieldName string) (int, bool) {
+	switch parentType.Kind {
+	case ast.NodeKindObjectTypeDefinition:
+		for _, fieldDefRef := range v.definition.ObjectTypeDefinitions[parentType.Ref].FieldsDefinition.Refs {
+			if v.definition.FieldDefinitionNameString(fieldDefRef) == fieldName {
+				return fieldDefRef, true
+			}
+		}
+	case ast.NodeKindInterfaceTypeDefinition:
+		for _, fieldDefRef := range v.definition.InterfaceTypeDefinitions[parentType.Ref].FieldsDefinition.Refs {
+			if v.definition.FieldDefinitionNameString(fieldDefRef) == fieldName {
+				return fieldDefRef, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func (v *inputFieldsVisitorV1) getVariableTypeName(varName string) (string, bool) {
+	for _, varDef := range v.operation.VariableDefinitions {
+		name := v.operation.VariableValueNameString(varDef.VariableValue.Ref)
+		if name == varName {
+			typeRef := varDef.Type
+			return v.operation.ResolveTypeNameString(typeRef), true
+		}
+	}
+	return "", false
+}
+
+func (v *inputFieldsVisitorV1) walkJSONValue(value []byte, typeName string) {
+	node, exists := v.definition.Index.FirstNodeByNameStr(typeName)
+	if !exists || node.Kind != ast.NodeKindInputObjectTypeDefinition {
+		return
+	}
+
+	_ = jsonparser.ObjectEach(value, func(key []byte, val []byte, dataType jsonparser.ValueType, offset int) error {
+		fieldName := string(key)
+		t, ok := v.data[typeName]
+		if !ok {
+			t = make(graphql.RequestFields)
+		}
+		t[fieldName] = struct{}{}
+		v.data[typeName] = t
+
+		fieldRef := v.definition.InputObjectTypeDefinitionInputValueDefinitionByName(node.Ref, key)
+		if fieldRef != -1 {
+			fieldTypeRef := v.definition.InputValueDefinitionType(fieldRef)
+			fieldTypeName := v.definition.ResolveTypeNameString(fieldTypeRef)
+
+			if dataType == jsonparser.Object {
+				v.walkJSONValue(val, fieldTypeName)
+			} else if dataType == jsonparser.Array {
+				_, _ = jsonparser.ArrayEach(val, func(arrVal []byte, arrDataType jsonparser.ValueType, arrOffset int, arrErr error) {
+					if arrDataType == jsonparser.Object {
+						v.walkJSONValue(arrVal, fieldTypeName)
+					}
+				})
+			}
+		}
+		return nil
+	})
+}
+
+func (v *inputFieldsVisitorV1) walkInlineObjectValue(ref int, typeName string) {
+	node, exists := v.definition.Index.FirstNodeByNameStr(typeName)
+	if !exists || node.Kind != ast.NodeKindInputObjectTypeDefinition {
+		return
+	}
+
+	objVal := v.operation.ObjectValues[ref]
+	for _, fieldRef := range objVal.Refs {
+		field := v.operation.ObjectFields[fieldRef]
+		fieldName := v.operation.ObjectFieldNameString(fieldRef)
+
+		t, ok := v.data[typeName]
+		if !ok {
+			t = make(graphql.RequestFields)
+		}
+		t[fieldName] = struct{}{}
+		v.data[typeName] = t
+
+		schemaFieldRef := v.definition.InputObjectTypeDefinitionInputValueDefinitionByName(node.Ref, []byte(fieldName))
+		if schemaFieldRef != -1 {
+			fieldTypeRef := v.definition.InputValueDefinitionType(schemaFieldRef)
+			fieldTypeName := v.definition.ResolveTypeNameString(fieldTypeRef)
+
+			if field.Value.Kind == ast.ValueKindObject {
+				v.walkInlineObjectValue(field.Value.Ref, fieldTypeName)
+			} else if field.Value.Kind == ast.ValueKindList {
+				v.walkInlineListValue(field.Value.Ref, fieldTypeName)
+			} else if field.Value.Kind == ast.ValueKindVariable {
+				varName := v.operation.VariableValueNameString(field.Value.Ref)
+				varValue, _, _, err := jsonparser.Get(v.variables, varName)
+				if err == nil {
+					v.walkJSONValue(varValue, fieldTypeName)
+				}
+			}
+		}
+	}
+}
+
+func (v *inputFieldsVisitorV1) walkInlineListValue(ref int, typeName string) {
+	listVal := v.operation.ListValues[ref]
+	for _, valRef := range listVal.Refs {
+		val := v.operation.Values[valRef]
+		if val.Kind == ast.ValueKindObject {
+			v.walkInlineObjectValue(val.Ref, typeName)
+		} else if val.Kind == ast.ValueKindList {
+			v.walkInlineListValue(val.Ref, typeName)
+		} else if val.Kind == ast.ValueKindVariable {
+			varName := v.operation.VariableValueNameString(val.Ref)
+			varValue, _, _, err := jsonparser.Get(v.variables, varName)
+			if err == nil {
+				v.walkJSONValue(varValue, typeName)
+			}
+		}
+	}
+}
+
+func (t *TykFieldsValidatorV1) ValidateByFieldList(request *graphql.Request, schema *graphql.Schema, restrictionList graphql.FieldRestrictionList) (graphql.RequestFieldsValidationResult, error) {
+	report := operationreport.Report{}
+	if len(restrictionList.Types) == 0 {
+		return graphql.RequestFieldsValidationResult{Valid: true}, nil
+	}
+
+	requestedTypes := make(graphql.RequestTypes)
+	graphql.NewExtractor().ExtractFieldsFromRequest(request, schema, &report, requestedTypes)
+	if report.HasErrors() {
+		return graphql.RequestFieldsValidationResult{Valid: false, Errors: graphql.RequestErrorsFromOperationReport(report)}, nil
+	}
+
+	reqDoc, reqReport := astparser.ParseGraphqlDocumentString(request.Query)
+	if reqReport.HasErrors() {
+		return graphql.RequestFieldsValidationResult{Valid: false, Errors: graphql.RequestErrorsFromOperationReport(reqReport)}, nil
+	}
+
+	schemaDoc, schemaReport := astparser.ParseGraphqlDocumentBytes(schema.Document())
+	if schemaReport.HasErrors() {
+		return graphql.RequestFieldsValidationResult{Valid: false, Errors: graphql.RequestErrorsFromOperationReport(schemaReport)}, nil
+	}
+
+	walker := astvisitor.NewWalker(48)
+	visitor := inputFieldsVisitorV1{
+		walker:     &walker,
+		operation:  &reqDoc,
+		definition: &schemaDoc,
+		variables:  t.Variables,
+		data:       requestedTypes,
+	}
+
+	walker.RegisterEnterFieldVisitor(&visitor)
+	walker.RegisterEnterArgumentVisitor(&visitor)
+
+	walker.Walk(&reqDoc, &schemaDoc, &report)
+	if report.HasErrors() {
+		return graphql.RequestFieldsValidationResult{Valid: false, Errors: graphql.RequestErrorsFromOperationReport(report)}, nil
+	}
+
+	if restrictionList.Kind == graphql.BlockList {
+		return checkForBlockedFieldsV1(restrictionList, requestedTypes)
+	}
+
+	return checkForAllowedFieldsV1(restrictionList, requestedTypes)
+}
+
+func checkForBlockedFieldsV1(restrictionList graphql.FieldRestrictionList, requestTypes graphql.RequestTypes) (graphql.RequestFieldsValidationResult, error) {
+	restrictedFieldsLookupMap := make(map[string]map[string]bool)
+	for _, restrictedType := range restrictionList.Types {
+		restrictedFieldsLookupMap[restrictedType.Name] = make(map[string]bool)
+		for _, restrictedField := range restrictedType.Fields {
+			restrictedFieldsLookupMap[restrictedType.Name][restrictedField] = true
+		}
+	}
+
+	for requestType, requestFields := range requestTypes {
+		for requestField := range requestFields {
+			if _, ok := restrictedFieldsLookupMap[requestType]["*"]; ok {
+				return graphql.RequestFieldsValidationResult{
+					Valid: false,
+					Errors: graphql.RequestErrors{
+						graphql.RequestError{
+							Message: fmt.Sprintf("all fields of %s type are restricted", requestType),
+						},
+					},
+				}, nil
+			}
+
+			isRestrictedType := restrictedFieldsLookupMap[requestType][requestField]
+			if isRestrictedType {
+				return graphql.RequestFieldsValidationResult{
+					Valid: false,
+					Errors: graphql.RequestErrors{
+						graphql.RequestError{
+							Message: fmt.Sprintf("field: %s is restricted on type: %s", requestField, requestType),
+						},
+					},
+				}, nil
+			}
+		}
+	}
+
+	return graphql.RequestFieldsValidationResult{Valid: true}, nil
+}
+
+func checkForAllowedFieldsV1(restrictionList graphql.FieldRestrictionList, requestTypes graphql.RequestTypes) (graphql.RequestFieldsValidationResult, error) {
+	allowedFieldsLookupMap := make(map[string]map[string]bool)
+	for _, allowedType := range restrictionList.Types {
+		allowedFieldsLookupMap[allowedType.Name] = make(map[string]bool)
+		for _, allowedField := range allowedType.Fields {
+			allowedFieldsLookupMap[allowedType.Name][allowedField] = true
+		}
+	}
+
+	for requestType, requestFields := range requestTypes {
+		if _, ok := allowedFieldsLookupMap[requestType]["*"]; ok {
+			continue
+		}
+
+		for requestField := range requestFields {
+			isAllowedField := allowedFieldsLookupMap[requestType][requestField]
+			if !isAllowedField {
+				return graphql.RequestFieldsValidationResult{
+					Valid: false,
+					Errors: graphql.RequestErrors{
+						graphql.RequestError{
+							Message: fmt.Sprintf("field: %s is restricted on type: %s", requestField, requestType),
+						},
+					},
+				}, nil
+			}
+		}
+	}
+
+	return graphql.RequestFieldsValidationResult{Valid: true}, nil
 }
 
 func (g *granularAccessCheckerV1) convertGranularAccessTypeToGraphQLType(accessTypes []GranularAccessType) []graphql.Type {

--- a/internal/graphengine/graphql_go_tools_v1_test.go
+++ b/internal/graphengine/graphql_go_tools_v1_test.go
@@ -739,6 +739,88 @@ func TestGranularAccessCheckerV1_CheckGraphQLRequestFieldAllowance(t *testing.T)
 			assert.Equal(t, GranularAccessFailReasonValidationError, result.FailReason)
 		})
 	})
+
+	t.Run("input object types", func(t *testing.T) {
+		schemaStr := `
+			input UserInput {
+				name: String
+				email: String
+			}
+			type Mutation {
+				createUser(input: UserInput!): String
+			}
+			type Query {
+				hello: String
+			}
+		`
+		gqlTools := graphqlGoToolsV1{}
+		parsedSchema, err := gqlTools.parseSchema(schemaStr)
+		require.NoError(t, err)
+
+		t.Run("should block restricted input object field (inline)", func(t *testing.T) {
+			operation := `mutation { createUser(input: {name: "John", email: "john@example.com"}) }`
+			request, err := http.NewRequest(
+				http.MethodPost,
+				"http://example.com",
+				bytes.NewBuffer([]byte(fmt.Sprintf(`{"query": %q}`, operation))),
+			)
+			require.NoError(t, err)
+
+			granularAccessChecker := &granularAccessCheckerV1{
+				logger: abstractlogger.NoopLogger,
+				schema: parsedSchema,
+				ctxRetrieveGraphQLRequest: func(r *http.Request) *graphql.Request {
+					return &graphql.Request{
+						Query: operation,
+					}
+				},
+			}
+
+			result := granularAccessChecker.CheckGraphQLRequestFieldAllowance(httptest.NewRecorder(), request, &GranularAccessDefinition{
+				RestrictedTypes: []GranularAccessType{
+					{
+						Name:   "UserInput",
+						Fields: []string{"email"},
+					},
+				},
+			})
+			assert.Equal(t, GranularAccessFailReasonValidationError, result.FailReason)
+			assert.Contains(t, result.ValidationError.Error(), "field: email is restricted on type: UserInput")
+		})
+
+		t.Run("should block restricted input object field (variable)", func(t *testing.T) {
+			operation := `mutation ($in: UserInput!) { createUser(input: $in) }`
+			variables := `{"in": {"name": "John", "email": "john@example.com"}}`
+			request, err := http.NewRequest(
+				http.MethodPost,
+				"http://example.com",
+				bytes.NewBuffer([]byte(fmt.Sprintf(`{"query": %q, "variables": %s}`, operation, variables))),
+			)
+			require.NoError(t, err)
+
+			granularAccessChecker := &granularAccessCheckerV1{
+				logger: abstractlogger.NoopLogger,
+				schema: parsedSchema,
+				ctxRetrieveGraphQLRequest: func(r *http.Request) *graphql.Request {
+					return &graphql.Request{
+						Query:     operation,
+						Variables: []byte(variables),
+					}
+				},
+			}
+
+			result := granularAccessChecker.CheckGraphQLRequestFieldAllowance(httptest.NewRecorder(), request, &GranularAccessDefinition{
+				RestrictedTypes: []GranularAccessType{
+					{
+						Name:   "UserInput",
+						Fields: []string{"email"},
+					},
+				},
+			})
+			assert.Equal(t, GranularAccessFailReasonValidationError, result.FailReason)
+			assert.Contains(t, result.ValidationError.Error(), "field: email is restricted on type: UserInput")
+		})
+	})
 }
 
 func TestReverseProxyPreHandlerV1_PreHandle(t *testing.T) {

--- a/internal/graphengine/graphql_go_tools_v2.go
+++ b/internal/graphengine/graphql_go_tools_v2.go
@@ -8,11 +8,12 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/buger/jsonparser"
 	"github.com/jensneuse/abstractlogger"
 
-	"github.com/buger/jsonparser"
-
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/astparser"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/astvisitor"
 	postprocessv2 "github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/postprocess"
 	graphqlv2 "github.com/TykTechnologies/graphql-go-tools/v2/pkg/graphql"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/introspection"
@@ -336,7 +337,9 @@ func (g *granularAccessCheckerV2) convertGranularAccessTypeToGraphQLType(accessT
 }
 
 func (g *granularAccessCheckerV2) validateFieldRestrictions(gqlRequest *graphqlv2.Request, fieldRestrictionList graphqlv2.FieldRestrictionList, schema *graphqlv2.Schema) GraphQLGranularAccessResult {
-	result, err := gqlRequest.ValidateFieldRestrictions(schema, fieldRestrictionList, graphqlv2.DefaultFieldsValidator{})
+	result, err := gqlRequest.ValidateFieldRestrictions(schema, fieldRestrictionList, &TykFieldsValidatorV2{
+		Variables: gqlRequest.Variables,
+	})
 	if err != nil {
 		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonInternalError, InternalErr: err}
 	}
@@ -345,6 +348,312 @@ func (g *granularAccessCheckerV2) validateFieldRestrictions(gqlRequest *graphqlv
 		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonValidationError, ValidationError: result.Errors, writeErrorResponse: g.writeErrorResponse}
 	}
 	return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonNone}
+}
+
+type TykFieldsValidatorV2 struct {
+	Variables []byte
+}
+
+type inputFieldsVisitorV2 struct {
+	walker            *astvisitor.Walker
+	operation         *ast.Document
+	definition        *ast.Document
+	variables         []byte
+	data              graphqlv2.RequestTypes
+	currentParentType ast.Node
+}
+
+func (v *inputFieldsVisitorV2) EnterField(ref int) {
+	v.currentParentType = v.walker.EnclosingTypeDefinition
+}
+
+func (v *inputFieldsVisitorV2) EnterArgument(ref int) {
+	argName := v.operation.ArgumentNameString(ref)
+	val := v.operation.ArgumentValue(ref)
+
+	if len(v.walker.Ancestors) == 0 {
+		return
+	}
+	parentFieldNode := v.walker.Ancestors[len(v.walker.Ancestors)-1]
+	if parentFieldNode.Kind != ast.NodeKindField {
+		return
+	}
+	fieldName := v.operation.FieldNameString(parentFieldNode.Ref)
+
+	parentType := v.currentParentType
+	fieldDefRef, exists := v.getFieldDefinition(parentType, fieldName)
+	if !exists {
+		return
+	}
+
+	var argTypeName string
+	for _, argDefRef := range v.definition.FieldDefinitionArgumentsDefinitions(fieldDefRef) {
+		if v.definition.InputValueDefinitionNameString(argDefRef) == argName {
+			typeRef := v.definition.InputValueDefinitionType(argDefRef)
+			argTypeName = v.definition.ResolveTypeNameString(typeRef)
+			break
+		}
+	}
+
+	if argTypeName == "" {
+		return
+	}
+
+	if val.Kind == ast.ValueKindObject {
+		v.walkInlineObjectValue(val.Ref, argTypeName)
+	} else if val.Kind == ast.ValueKindVariable {
+		varName := v.operation.VariableValueNameString(val.Ref)
+		varType, ok := v.getVariableTypeName(varName)
+		if ok {
+			varValue, _, _, err := jsonparser.Get(v.variables, varName)
+			if err == nil {
+				v.walkJSONValue(varValue, varType)
+			}
+		}
+	}
+}
+
+func (v *inputFieldsVisitorV2) getFieldDefinition(parentType ast.Node, fieldName string) (int, bool) {
+	switch parentType.Kind {
+	case ast.NodeKindObjectTypeDefinition:
+		for _, fieldDefRef := range v.definition.ObjectTypeDefinitions[parentType.Ref].FieldsDefinition.Refs {
+			if v.definition.FieldDefinitionNameString(fieldDefRef) == fieldName {
+				return fieldDefRef, true
+			}
+		}
+	case ast.NodeKindInterfaceTypeDefinition:
+		for _, fieldDefRef := range v.definition.InterfaceTypeDefinitions[parentType.Ref].FieldsDefinition.Refs {
+			if v.definition.FieldDefinitionNameString(fieldDefRef) == fieldName {
+				return fieldDefRef, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func (v *inputFieldsVisitorV2) getVariableTypeName(varName string) (string, bool) {
+	for _, varDef := range v.operation.VariableDefinitions {
+		name := v.operation.VariableValueNameString(varDef.VariableValue.Ref)
+		if name == varName {
+			typeRef := varDef.Type
+			return v.operation.ResolveTypeNameString(typeRef), true
+		}
+	}
+	return "", false
+}
+
+func (v *inputFieldsVisitorV2) walkJSONValue(value []byte, typeName string) {
+	node, exists := v.definition.Index.FirstNodeByNameStr(typeName)
+	if !exists || node.Kind != ast.NodeKindInputObjectTypeDefinition {
+		return
+	}
+
+	_ = jsonparser.ObjectEach(value, func(key []byte, val []byte, dataType jsonparser.ValueType, offset int) error {
+		fieldName := string(key)
+		t, ok := v.data[typeName]
+		if !ok {
+			t = make(graphqlv2.RequestFields)
+		}
+		t[fieldName] = struct{}{}
+		v.data[typeName] = t
+
+		fieldRef := v.definition.InputObjectTypeDefinitionInputValueDefinitionByName(node.Ref, key)
+		if fieldRef != -1 {
+			fieldTypeRef := v.definition.InputValueDefinitionType(fieldRef)
+			fieldTypeName := v.definition.ResolveTypeNameString(fieldTypeRef)
+
+			if dataType == jsonparser.Object {
+				v.walkJSONValue(val, fieldTypeName)
+			} else if dataType == jsonparser.Array {
+				_, _ = jsonparser.ArrayEach(val, func(arrVal []byte, arrDataType jsonparser.ValueType, arrOffset int, arrErr error) {
+					if arrDataType == jsonparser.Object {
+						v.walkJSONValue(arrVal, fieldTypeName)
+					}
+				})
+			}
+		}
+		return nil
+	})
+}
+
+func (v *inputFieldsVisitorV2) walkInlineObjectValue(ref int, typeName string) {
+	node, exists := v.definition.Index.FirstNodeByNameStr(typeName)
+	if !exists || node.Kind != ast.NodeKindInputObjectTypeDefinition {
+		return
+	}
+
+	objVal := v.operation.ObjectValues[ref]
+	for _, fieldRef := range objVal.Refs {
+		field := v.operation.ObjectFields[fieldRef]
+		fieldName := v.operation.ObjectFieldNameString(fieldRef)
+
+		t, ok := v.data[typeName]
+		if !ok {
+			t = make(graphqlv2.RequestFields)
+		}
+		t[fieldName] = struct{}{}
+		v.data[typeName] = t
+
+		schemaFieldRef := v.definition.InputObjectTypeDefinitionInputValueDefinitionByName(node.Ref, []byte(fieldName))
+		if schemaFieldRef != -1 {
+			fieldTypeRef := v.definition.InputValueDefinitionType(schemaFieldRef)
+			fieldTypeName := v.definition.ResolveTypeNameString(fieldTypeRef)
+
+			if field.Value.Kind == ast.ValueKindObject {
+				v.walkInlineObjectValue(field.Value.Ref, fieldTypeName)
+			} else if field.Value.Kind == ast.ValueKindList {
+				v.walkInlineListValue(field.Value.Ref, fieldTypeName)
+			} else if field.Value.Kind == ast.ValueKindVariable {
+				varName := v.operation.VariableValueNameString(field.Value.Ref)
+				varValue, _, _, err := jsonparser.Get(v.variables, varName)
+				if err == nil {
+					v.walkJSONValue(varValue, fieldTypeName)
+				}
+			}
+		}
+	}
+}
+
+func (v *inputFieldsVisitorV2) walkInlineListValue(ref int, typeName string) {
+	listVal := v.operation.ListValues[ref]
+	for _, valRef := range listVal.Refs {
+		val := v.operation.Values[valRef]
+		if val.Kind == ast.ValueKindObject {
+			v.walkInlineObjectValue(val.Ref, typeName)
+		} else if val.Kind == ast.ValueKindList {
+			v.walkInlineListValue(val.Ref, typeName)
+		} else if val.Kind == ast.ValueKindVariable {
+			varName := v.operation.VariableValueNameString(val.Ref)
+			varValue, _, _, err := jsonparser.Get(v.variables, varName)
+			if err == nil {
+				v.walkJSONValue(varValue, typeName)
+			}
+		}
+	}
+}
+
+func (t *TykFieldsValidatorV2) ValidateByFieldList(request *graphqlv2.Request, schema *graphqlv2.Schema, restrictionList graphqlv2.FieldRestrictionList) (graphqlv2.RequestFieldsValidationResult, error) {
+	report := operationreport.Report{}
+	if len(restrictionList.Types) == 0 {
+		return graphqlv2.RequestFieldsValidationResult{Valid: true}, nil
+	}
+
+	requestedTypes := make(graphqlv2.RequestTypes)
+	graphqlv2.NewExtractor().ExtractFieldsFromRequest(request, schema, &report, requestedTypes)
+	if report.HasErrors() {
+		return graphqlv2.RequestFieldsValidationResult{Valid: false, Errors: graphqlv2.RequestErrorsFromOperationReport(report)}, nil
+	}
+
+	reqDoc, reqReport := astparser.ParseGraphqlDocumentString(request.Query)
+	if reqReport.HasErrors() {
+		return graphqlv2.RequestFieldsValidationResult{Valid: false, Errors: graphqlv2.RequestErrorsFromOperationReport(reqReport)}, nil
+	}
+
+	schemaDoc, schemaReport := astparser.ParseGraphqlDocumentBytes(schema.Document())
+	if schemaReport.HasErrors() {
+		return graphqlv2.RequestFieldsValidationResult{Valid: false, Errors: graphqlv2.RequestErrorsFromOperationReport(schemaReport)}, nil
+	}
+
+	walker := astvisitor.NewWalker(48)
+	visitor := inputFieldsVisitorV2{
+		walker:     &walker,
+		operation:  &reqDoc,
+		definition: &schemaDoc,
+		variables:  t.Variables,
+		data:       requestedTypes,
+	}
+
+	walker.RegisterEnterFieldVisitor(&visitor)
+	walker.RegisterEnterArgumentVisitor(&visitor)
+
+	walker.Walk(&reqDoc, &schemaDoc, &report)
+	if report.HasErrors() {
+		return graphqlv2.RequestFieldsValidationResult{Valid: false, Errors: graphqlv2.RequestErrorsFromOperationReport(report)}, nil
+	}
+
+	if fieldRestrictionListKindV2(restrictionList.Kind) == blockListV2 {
+		return checkForBlockedFieldsV2(restrictionList, requestedTypes)
+	}
+
+	return checkForAllowedFieldsV2(restrictionList, requestedTypes)
+}
+
+type fieldRestrictionListKindV2 int
+
+const (
+	allowListV2 fieldRestrictionListKindV2 = iota
+	blockListV2
+)
+
+func checkForBlockedFieldsV2(restrictionList graphqlv2.FieldRestrictionList, requestTypes graphqlv2.RequestTypes) (graphqlv2.RequestFieldsValidationResult, error) {
+	restrictedFieldsLookupMap := make(map[string]map[string]bool)
+	for _, restrictedType := range restrictionList.Types {
+		restrictedFieldsLookupMap[restrictedType.Name] = make(map[string]bool)
+		for _, restrictedField := range restrictedType.Fields {
+			restrictedFieldsLookupMap[restrictedType.Name][restrictedField] = true
+		}
+	}
+
+	for requestType, requestFields := range requestTypes {
+		for requestField := range requestFields {
+			if _, ok := restrictedFieldsLookupMap[requestType]["*"]; ok {
+				return graphqlv2.RequestFieldsValidationResult{
+					Valid: false,
+					Errors: graphqlv2.RequestErrors{
+						graphqlv2.RequestError{
+							Message: fmt.Sprintf("all fields of %s type are restricted", requestType),
+						},
+					},
+				}, nil
+			}
+
+			isRestrictedType := restrictedFieldsLookupMap[requestType][requestField]
+			if isRestrictedType {
+				return graphqlv2.RequestFieldsValidationResult{
+					Valid: false,
+					Errors: graphqlv2.RequestErrors{
+						graphqlv2.RequestError{
+							Message: fmt.Sprintf("field: %s is restricted on type: %s", requestField, requestType),
+						},
+					},
+				}, nil
+			}
+		}
+	}
+
+	return graphqlv2.RequestFieldsValidationResult{Valid: true}, nil
+}
+
+func checkForAllowedFieldsV2(restrictionList graphqlv2.FieldRestrictionList, requestTypes graphqlv2.RequestTypes) (graphqlv2.RequestFieldsValidationResult, error) {
+	allowedFieldsLookupMap := make(map[string]map[string]bool)
+	for _, allowedType := range restrictionList.Types {
+		allowedFieldsLookupMap[allowedType.Name] = make(map[string]bool)
+		for _, allowedField := range allowedType.Fields {
+			allowedFieldsLookupMap[allowedType.Name][allowedField] = true
+		}
+	}
+
+	for requestType, requestFields := range requestTypes {
+		if _, ok := allowedFieldsLookupMap[requestType]["*"]; ok {
+			continue
+		}
+
+		for requestField := range requestFields {
+			isAllowedField := allowedFieldsLookupMap[requestType][requestField]
+			if !isAllowedField {
+				return graphqlv2.RequestFieldsValidationResult{
+					Valid: false,
+					Errors: graphqlv2.RequestErrors{
+						graphqlv2.RequestError{
+							Message: fmt.Sprintf("field: %s is restricted on type: %s", requestField, requestType),
+						},
+					},
+				}, nil
+			}
+		}
+	}
+
+	return graphqlv2.RequestFieldsValidationResult{Valid: true}, nil
 }
 
 func (g *granularAccessCheckerV2) writeErrorResponse(w io.Writer, providedErr error) (n int, err error) {

--- a/internal/graphengine/graphql_go_tools_v2_test.go
+++ b/internal/graphengine/graphql_go_tools_v2_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/jensneuse/abstractlogger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -175,4 +177,88 @@ func newTestReverseProxyPreHandlerV2(t *testing.T) *reverseProxyPreHandlerV2 {
 			return closer, nil
 		},
 	}
+}
+
+func TestGranularAccessCheckerV2_CheckGraphQLRequestFieldAllowance(t *testing.T) {
+	t.Run("input object types", func(t *testing.T) {
+		schemaStr := `
+			input UserInput {
+				name: String
+				email: String
+			}
+			type Mutation {
+				createUser(input: UserInput!): String
+			}
+			type Query {
+				hello: String
+			}
+		`
+		gqlTools := graphqlGoToolsV2{}
+		parsedSchema, err := gqlTools.parseSchema(schemaStr)
+		require.NoError(t, err)
+
+		t.Run("should block restricted input object field (inline)", func(t *testing.T) {
+			operation := `mutation { createUser(input: {name: "John", email: "john@example.com"}) }`
+			request, err := http.NewRequest(
+				http.MethodPost,
+				"http://example.com",
+				bytes.NewBuffer([]byte(fmt.Sprintf(`{"query": %q}`, operation))),
+			)
+			require.NoError(t, err)
+
+			granularAccessChecker := &granularAccessCheckerV2{
+				logger: abstractlogger.NoopLogger,
+				schema: parsedSchema,
+				ctxRetrieveGraphQLRequest: func(r *http.Request) *graphqlv2.Request {
+					return &graphqlv2.Request{
+						Query: operation,
+					}
+				},
+			}
+
+			result := granularAccessChecker.CheckGraphQLRequestFieldAllowance(httptest.NewRecorder(), request, &GranularAccessDefinition{
+				RestrictedTypes: []GranularAccessType{
+					{
+						Name:   "UserInput",
+						Fields: []string{"email"},
+					},
+				},
+			})
+			assert.Equal(t, GranularAccessFailReasonValidationError, result.FailReason)
+			assert.Contains(t, result.ValidationError.Error(), "field: email is restricted on type: UserInput")
+		})
+
+		t.Run("should block restricted input object field (variable)", func(t *testing.T) {
+			operation := `mutation ($in: UserInput!) { createUser(input: $in) }`
+			variables := `{"in": {"name": "John", "email": "john@example.com"}}`
+			request, err := http.NewRequest(
+				http.MethodPost,
+				"http://example.com",
+				bytes.NewBuffer([]byte(fmt.Sprintf(`{"query": %q, "variables": %s}`, operation, variables))),
+			)
+			require.NoError(t, err)
+
+			granularAccessChecker := &granularAccessCheckerV2{
+				logger: abstractlogger.NoopLogger,
+				schema: parsedSchema,
+				ctxRetrieveGraphQLRequest: func(r *http.Request) *graphqlv2.Request {
+					return &graphqlv2.Request{
+						Query:     operation,
+						Variables: []byte(variables),
+					}
+				},
+			}
+
+			result := granularAccessChecker.CheckGraphQLRequestFieldAllowance(httptest.NewRecorder(), request, &GranularAccessDefinition{
+				RestrictedTypes: []GranularAccessType{
+					{
+						Name:   "UserInput",
+						Fields: []string{"email"},
+					},
+				},
+			})
+			assert.Equal(t, GranularAccessFailReasonValidationError, result.FailReason)
+			assert.Contains(t, result.ValidationError.Error(), "field: email is restricted on type: UserInput")
+		})
+	})
 }


### PR DESCRIPTION
## Description

This pull request extends Tyk's GraphQL granular access control validation to support validation and restriction policies on complex input object types (`INPUT_OBJECT` fields). 

Tyk's field restriction validator previously only extracted selection-set fields of output types (like `Query` or `Mutation`). With this change, the validator recursively walks:
1. **Inline input objects and lists** (literal arguments in the AST).
2. **Dynamic variable inputs** (JSON variable payloads matching schema-defined input types).

All extracted input fields are merged into the validation list and checked against the configured policy rules (`restricted_types` or `allowed_types`).

## Related Issue

Resolves #8538

## Motivation and Context

Gateway administrators configure policy restrictions to block certain fields, but queries/mutations containing blocklisted fields in input objects were bypassed because they were not tracked. This change fixes that security gap and closes the requested feature issue.

## How This Has Been Tested

* **Unit Tests**: Added comprehensive test cases to `internal/graphengine/graphql_go_tools_v1_test.go` and `graphql_go_tools_v2_test.go`.
  * Covered inline `INPUT_OBJECT` AST argument validation.
  * Covered dynamic variables JSON payload validation containing restricted input fields.
* **Go standards compliance**: Ran `go fmt` and `go vet` over the modified packages to verify zero errors or formatting deviations.

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required *(N/A - go.mod not updated)*
- [x] I would like a code coverage CI quality gate exception and have explained why *(N/A)*

---

### Contributor CLA Acknowledgment

I acknowledge that I am ready to sign the Tyk Contributor License Agreement (CLA) once this Pull Request is opened on GitHub.
