### PR TITLE
[TT-14684] The listen path recorded in analytics changes when an API response comes from cache

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -2566,6 +2566,17 @@ func (a *APISpec) PrepareRequestToLog(r *http.Request) *http.Request {
 	return dup
 }
 
+func (a *APISpec) PrepareRequestToLogShallowClone(r *http.Request) *http.Request {
+	dup := *r
+
+	if r.URL != nil {
+		dup.URL = new(*r.URL)
+	}
+
+	a.PrepareRequestToLogInPlace(&dup)
+	return &dup
+}
+
 func (a *APISpec) PrepareRequestToLogInPlace(r *http.Request) {
 	a.SanitizeProxyPaths(r)
 

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -2560,6 +2560,21 @@ func (a *APISpec) SanitizeProxyPaths(r *http.Request) {
 	log.Debug("Upstream path is: ", r.URL.Path)
 }
 
+func (a *APISpec) PrepareRequestToLog(r *http.Request) *http.Request {
+	dup := r.Clone(r.Context())
+	a.SanitizeProxyPaths(dup)
+
+	// appends path if upstream ha path e.g. http://httpbin.org/anything
+	if a.target != nil && a.target.Path != "" {
+		dup.URL.Path = singleJoiningSlash(a.target.Path, dup.URL.Path, a.Proxy.DisableStripSlash)
+		if dup.URL.RawPath != "" {
+			dup.URL.RawPath = singleJoiningSlash(a.target.Path, dup.URL.RawPath, a.Proxy.DisableStripSlash)
+		}
+	}
+
+	return dup
+}
+
 func (a *APISpec) getRedirectTargetUrl(inputUrl *url.URL) (*url.URL, error) {
 	if inputUrl == nil {
 		return nil, errors.New("input url is nil")

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -2562,17 +2562,20 @@ func (a *APISpec) SanitizeProxyPaths(r *http.Request) {
 
 func (a *APISpec) PrepareRequestToLog(r *http.Request) *http.Request {
 	dup := r.Clone(r.Context())
-	a.SanitizeProxyPaths(dup)
+	a.PrepareRequestToLogInPlace(dup)
+	return dup
+}
+
+func (a *APISpec) PrepareRequestToLogInPlace(r *http.Request) {
+	a.SanitizeProxyPaths(r)
 
 	// appends path if upstream ha path e.g. http://httpbin.org/anything
 	if a.target != nil && a.target.Path != "" {
-		dup.URL.Path = singleJoiningSlash(a.target.Path, dup.URL.Path, a.Proxy.DisableStripSlash)
-		if dup.URL.RawPath != "" {
-			dup.URL.RawPath = singleJoiningSlash(a.target.Path, dup.URL.RawPath, a.Proxy.DisableStripSlash)
+		r.URL.Path = singleJoiningSlash(a.target.Path, r.URL.Path, a.Proxy.DisableStripSlash)
+		if r.URL.RawPath != "" {
+			r.URL.RawPath = singleJoiningSlash(a.target.Path, r.URL.RawPath, a.Proxy.DisableStripSlash)
 		}
 	}
-
-	return dup
 }
 
 func (a *APISpec) getRedirectTargetUrl(inputUrl *url.URL) (*url.URL, error) {

--- a/gateway/api_definition_bench_test.go
+++ b/gateway/api_definition_bench_test.go
@@ -5,8 +5,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
 )
 
 func BenchmarkPrepareRequestToLog_Clone(b *testing.B) {

--- a/gateway/api_definition_bench_test.go
+++ b/gateway/api_definition_bench_test.go
@@ -1,0 +1,60 @@
+package gateway
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkPrepareRequestToLog_Clone(b *testing.B) {
+
+	a := APISpec{APIDefinition: &apidef.APIDefinition{}}
+	a.Proxy.ListenPath = "/listen/"
+	a.Proxy.StripListenPath = true
+
+	var err error
+	a.target, err = url.Parse("http://upstream.com/base")
+	require.NoError(b, err)
+
+	ctx := b.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://proxy.com/listen/get%20it", nil)
+	require.NoError(b, err)
+
+	prepareReq := func() *http.Request {
+		r := req.WithContext(ctx)
+		r.URL.Path = "/listen/get it"
+		r.URL.RawPath = "/listen/get%20it"
+
+		return r
+	}
+
+	b.Run("clone", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			_ = a.PrepareRequestToLog(prepareReq())
+		}
+	})
+
+	b.Run("shallow_clone", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			_ = a.PrepareRequestToLogShallowClone(prepareReq())
+		}
+	})
+
+	b.Run("in_places", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			a.PrepareRequestToLogInPlace(prepareReq())
+		}
+	})
+}

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -3363,7 +3363,7 @@ func TestGatewayWriteSpecFiles_WritesCompanionsOnlyForOASAPIs(t *testing.T) {
 	}, names)
 }
 
-func TestAPISpec_PrepareRequestToLog(t *testing.T) {
+func TestAPISpec_PrepareRequestToLog_and_ShallowClone(t *testing.T) {
 	t.Run("without target path", func(t *testing.T) {
 		a := APISpec{APIDefinition: &apidef.APIDefinition{}}
 		a.Proxy.ListenPath = "/listen/"
@@ -3373,6 +3373,12 @@ func TestAPISpec_PrepareRequestToLog(t *testing.T) {
 		assert.NoError(t, err)
 
 		dup := a.PrepareRequestToLog(r)
+
+		assert.NotSame(t, r, dup)
+		assert.Equal(t, "/get", dup.URL.Path)
+		assert.Equal(t, "", dup.URL.RawPath)
+
+		dup = a.PrepareRequestToLogShallowClone(r)
 
 		assert.NotSame(t, r, dup)
 		assert.Equal(t, "/get", dup.URL.Path)
@@ -3396,6 +3402,12 @@ func TestAPISpec_PrepareRequestToLog(t *testing.T) {
 		assert.NotSame(t, r, dup)
 		assert.Equal(t, "/base/get", dup.URL.Path)
 		assert.Equal(t, "", dup.URL.RawPath)
+
+		dup = a.PrepareRequestToLogShallowClone(r)
+
+		assert.NotSame(t, r, dup)
+		assert.Equal(t, "/base/get", dup.URL.Path)
+		assert.Equal(t, "", dup.URL.RawPath)
 	})
 
 	t.Run("with target path and raw path", func(t *testing.T) {
@@ -3414,6 +3426,12 @@ func TestAPISpec_PrepareRequestToLog(t *testing.T) {
 		r.URL.RawPath = "/listen/get%20it"
 
 		dup := a.PrepareRequestToLog(r)
+
+		assert.NotSame(t, r, dup)
+		assert.Equal(t, "/base/get it", dup.URL.Path)
+		assert.Equal(t, "/base/get%20it", dup.URL.RawPath)
+
+		dup = a.PrepareRequestToLogShallowClone(r)
 
 		assert.NotSame(t, r, dup)
 		assert.Equal(t, "/base/get it", dup.URL.Path)

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -3360,4 +3361,52 @@ func TestGatewayWriteSpecFiles_WritesCompanionsOnlyForOASAPIs(t *testing.T) {
 		"mcp2.json",
 		"mcp2-mcp.json",
 	}, names)
+}
+
+func TestAPISpec_PrepareRequestToLog(t *testing.T) {
+	t.Run("without target path", func(t *testing.T) {
+		a := APISpec{APIDefinition: &apidef.APIDefinition{}}
+		a.Proxy.ListenPath = "/listen/"
+		a.Proxy.StripListenPath = true
+
+		r, _ := http.NewRequest(http.MethodGet, "https://proxy.com/listen/get", nil)
+
+		dup := a.PrepareRequestToLog(r)
+
+		assert.NotSame(t, r, dup)
+		assert.Equal(t, "/get", dup.URL.Path)
+		assert.Equal(t, "", dup.URL.RawPath)
+	})
+
+	t.Run("with target path", func(t *testing.T) {
+		a := APISpec{APIDefinition: &apidef.APIDefinition{}}
+		a.Proxy.ListenPath = "/listen/"
+		a.Proxy.StripListenPath = true
+		a.target, _ = url.Parse("http://upstream.com/base")
+
+		r, _ := http.NewRequest(http.MethodGet, "https://proxy.com/listen/get", nil)
+
+		dup := a.PrepareRequestToLog(r)
+
+		assert.NotSame(t, r, dup)
+		assert.Equal(t, "/base/get", dup.URL.Path)
+		assert.Equal(t, "", dup.URL.RawPath)
+	})
+
+	t.Run("with target path and raw path", func(t *testing.T) {
+		a := APISpec{APIDefinition: &apidef.APIDefinition{}}
+		a.Proxy.ListenPath = "/listen/"
+		a.Proxy.StripListenPath = true
+		a.target, _ = url.Parse("http://upstream.com/base")
+
+		r, _ := http.NewRequest(http.MethodGet, "https://proxy.com/listen/get%20it", nil)
+		r.URL.Path = "/listen/get it"
+		r.URL.RawPath = "/listen/get%20it"
+
+		dup := a.PrepareRequestToLog(r)
+
+		assert.NotSame(t, r, dup)
+		assert.Equal(t, "/base/get it", dup.URL.Path)
+		assert.Equal(t, "/base/get%20it", dup.URL.RawPath)
+	})
 }

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -3369,7 +3369,8 @@ func TestAPISpec_PrepareRequestToLog(t *testing.T) {
 		a.Proxy.ListenPath = "/listen/"
 		a.Proxy.StripListenPath = true
 
-		r, _ := http.NewRequest(http.MethodGet, "https://proxy.com/listen/get", nil)
+		r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://proxy.com/listen/get", nil)
+		assert.NoError(t, err)
 
 		dup := a.PrepareRequestToLog(r)
 
@@ -3379,12 +3380,16 @@ func TestAPISpec_PrepareRequestToLog(t *testing.T) {
 	})
 
 	t.Run("with target path", func(t *testing.T) {
+		var err error
+
 		a := APISpec{APIDefinition: &apidef.APIDefinition{}}
 		a.Proxy.ListenPath = "/listen/"
 		a.Proxy.StripListenPath = true
-		a.target, _ = url.Parse("http://upstream.com/base")
+		a.target, err = url.Parse("http://upstream.com/base")
+		assert.NoError(t, err)
 
-		r, _ := http.NewRequest(http.MethodGet, "https://proxy.com/listen/get", nil)
+		r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://proxy.com/listen/get", nil)
+		assert.NoError(t, err)
 
 		dup := a.PrepareRequestToLog(r)
 
@@ -3394,12 +3399,17 @@ func TestAPISpec_PrepareRequestToLog(t *testing.T) {
 	})
 
 	t.Run("with target path and raw path", func(t *testing.T) {
+		var err error
+
 		a := APISpec{APIDefinition: &apidef.APIDefinition{}}
 		a.Proxy.ListenPath = "/listen/"
 		a.Proxy.StripListenPath = true
-		a.target, _ = url.Parse("http://upstream.com/base")
+		a.target, err = url.Parse("http://upstream.com/base")
+		assert.NoError(t, err)
 
-		r, _ := http.NewRequest(http.MethodGet, "https://proxy.com/listen/get%20it", nil)
+		r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://proxy.com/listen/get%20it", nil)
+		assert.NoError(t, err)
+
 		r.URL.Path = "/listen/get it"
 		r.URL.RawPath = "/listen/get%20it"
 

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -268,7 +268,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	if !m.Spec.DoNotTrack {
 		ms := DurationToMillisecond(time.Since(t1))
 		latency := analytics.Latency{Total: int64(ms), Upstream: 0, Gateway: int64(ms)}
-		m.Spec.PrepareRequestToLogInPlace(r)
+		r = m.Spec.PrepareRequestToLogShallowClone(r)
 		m.sh.RecordHit(r, latency, newRes.StatusCode, newRes, true)
 		m.sh.RecordAccessLog(r, newRes, latency)
 		m.sh.Base().RecordMetrics(w, r, newRes.StatusCode, latency, newRes)

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -268,7 +268,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	if !m.Spec.DoNotTrack {
 		ms := DurationToMillisecond(time.Since(t1))
 		latency := analytics.Latency{Total: int64(ms), Upstream: 0, Gateway: int64(ms)}
-		r = m.Spec.PrepareRequestToLog(r)
+		m.Spec.PrepareRequestToLogInPlace(r)
 		m.sh.RecordHit(r, latency, newRes.StatusCode, newRes, true)
 		m.sh.RecordAccessLog(r, newRes, latency)
 		m.sh.Base().RecordMetrics(w, r, newRes.StatusCode, latency, newRes)

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -268,6 +268,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	if !m.Spec.DoNotTrack {
 		ms := DurationToMillisecond(time.Since(t1))
 		latency := analytics.Latency{Total: int64(ms), Upstream: 0, Gateway: int64(ms)}
+		r = m.Spec.PrepareRequestToLog(r)
 		m.sh.RecordHit(r, latency, newRes.StatusCode, newRes, true)
 		m.sh.RecordAccessLog(r, newRes, latency)
 		m.sh.Base().RecordMetrics(w, r, newRes.StatusCode, latency, newRes)

--- a/gateway/mw_redis_cache_test.go
+++ b/gateway/mw_redis_cache_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -589,4 +590,74 @@ func countAccessLogEntries(hook *logrustest.Hook) int {
 		}
 	}
 	return count
+}
+
+func TestRedisCacheMiddleware_AnalyticsPath(t *testing.T) {
+	// https://tyktech.atlassian.net/browse/TT-14684
+
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.AnalyticsConfig.EnableDetailedRecording = true
+	})
+	defer ts.Close()
+
+	setTestValue(t, &ts.Gw.Analytics.mockEnabled, true)
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/my-cache-api/"
+		spec.Proxy.StripListenPath = true
+		spec.Proxy.TargetURL = TestHttpAny + "/anything"
+		spec.CacheOptions.CacheTimeout = 60
+		spec.CacheOptions.EnableCache = true
+		spec.CacheOptions.CacheAllSafeRequests = true
+	})
+
+	var hits struct {
+		calls []*analytics.AnalyticsRecord
+		mu    sync.Mutex
+	}
+
+	ts.Gw.Analytics.mockRecordHit = func(record *analytics.AnalyticsRecord) {
+		hits.mu.Lock()
+		defer hits.mu.Unlock()
+		hits.calls = append(hits.calls, record)
+	}
+
+	requestPath := "/my-cache-api/get?cache-test=" + uuid.NewHex()
+
+	resp1, _ := ts.Run(t, test.TestCase{
+		Path: requestPath, Code: http.StatusOK,
+	})
+	require.Equal(t, http.StatusOK, resp1.StatusCode)
+
+	client := &http.Client{}
+	defer client.CloseIdleConnections()
+
+	require.Eventually(t, func() bool {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+requestPath, nil)
+		if err != nil {
+			return false
+		}
+
+		candidate, err := client.Do(req)
+		if err != nil {
+			return false
+		}
+		defer candidate.Body.Close()
+
+		if candidate.Header.Get("X-Tyk-Cached-Response") != "1" {
+			return false
+		}
+		return true
+	}, 5*time.Second, 10*time.Millisecond, "response was not stored in cache")
+
+	hits.mu.Lock()
+	defer hits.mu.Unlock()
+
+	require.Len(t, hits.calls, 2, "expected 2 analytics hits")
+
+	assert.Equal(t, "/anything/get", hits.calls[0].Path, "first request should have upstream path")
+	assert.Equal(t, "/anything/get", hits.calls[0].RawPath, "first request should have upstream raw path")
+
+	assert.Equal(t, "/anything/get", hits.calls[1].Path, "cached request should have upstream path")
+	assert.Equal(t, "/anything/get", hits.calls[1].RawPath, "cached request should have upstream raw path")
 }

--- a/gateway/mw_redis_cache_test.go
+++ b/gateway/mw_redis_cache_test.go
@@ -593,7 +593,7 @@ func countAccessLogEntries(hook *logrustest.Hook) int {
 }
 
 func TestRedisCacheMiddleware_AnalyticsPath(t *testing.T) {
-	// https://tyktech.atlassian.net/browse/TT-14684
+	// Test covers bug described here https://tyktech.atlassian.net/browse/TT-14684
 
 	ts := StartTest(func(globalConf *config.Config) {
 		globalConf.AnalyticsConfig.EnableDetailedRecording = true
@@ -644,10 +644,7 @@ func TestRedisCacheMiddleware_AnalyticsPath(t *testing.T) {
 		}
 		defer candidate.Body.Close()
 
-		if candidate.Header.Get("X-Tyk-Cached-Response") != "1" {
-			return false
-		}
-		return true
+		return candidate.Header.Get("X-Tyk-Cached-Response") == "1"
 	}, 5*time.Second, 10*time.Millisecond, "response was not stored in cache")
 
 	hits.mu.Lock()

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -2320,3 +2320,13 @@ func installFakeKVStores(t *testing.T, gw *Gateway, stores map[string]map[string
 
 	installKVRegistry(t, gw, storeCfgs, factories)
 }
+
+func setTestValue[T any](t *testing.T, ptr *T, value T) {
+	t.Helper()
+
+	prev := *ptr
+	*ptr = value
+	t.Cleanup(func() {
+		*ptr = prev
+	})
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why











<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-14684" title="TT-14684" target="_blank">TT-14684</a>
</summary>

|         |    |
|---------|----|
| Status  | Ready for Testing |
| Summary | The listen path recorded in analytics changes when an API response comes from cache |

Generated at: 2026-09-01 09:42:14

</details>

<!---TykTechnologies/jira-linter ends here-->











---
Requested by: <@U08QWRUM11Q>
Trace: f97f6be483e37ea7f28d6310fa24cd16
Generated with Visor AI Assistant
Slack thread: https://tyktech.slack.com/archives/D0AF7G82CSV/p1785750504640339