### PR TITLE
Fix response header path rewriting

### DIFF
--- a/gateway/res_handler_header_transform.go
+++ b/gateway/res_handler_header_transform.go
@@ -43,6 +43,64 @@ func (h *HeaderTransform) Init(c interface{}, spec *APISpec) error {
 func (h *HeaderTransform) HandleError(rw http.ResponseWriter, req *http.Request) {
 }
 
+func replaceHeaderPathPrefix(value, oldPath, newPath string) string {
+	rewriteURL := func(raw string) (string, bool) {
+		pathStart := -1
+		switch {
+		case strings.HasPrefix(raw, "/") && !strings.HasPrefix(raw, "//"):
+			pathStart = 0
+		default:
+			authorityStart := -1
+			if schemeEnd := strings.Index(raw, "://"); schemeEnd > 0 && !strings.ContainsAny(raw[:schemeEnd], "<> ,;\t") {
+				authorityStart = schemeEnd + 3
+			} else if strings.HasPrefix(raw, "//") {
+				authorityStart = 2
+			}
+			if authorityStart < 0 {
+				return raw, false
+			}
+			i := strings.IndexAny(raw[authorityStart:], "/?#")
+			if i < 0 || raw[authorityStart+i] != '/' {
+				return raw, false
+			}
+			pathStart = authorityStart + i
+		}
+
+		path := raw[pathStart:]
+		if !strings.HasPrefix(path, oldPath) {
+			return raw, false
+		}
+		return raw[:pathStart] + newPath + raw[pathStart+len(oldPath):], true
+	}
+
+	if rewritten, ok := rewriteURL(value); ok {
+		return rewritten
+	}
+
+	// Link-style headers can contain multiple URL references in angle brackets.
+	for offset := 0; offset < len(value); {
+		open := strings.IndexByte(value[offset:], '<')
+		if open < 0 {
+			break
+		}
+		open += offset
+		close := strings.IndexByte(value[open+1:], '>')
+		if close < 0 {
+			break
+		}
+		close += open + 1
+
+		resource := value[open+1 : close]
+		if rewritten, ok := rewriteURL(resource); ok {
+			value = value[:open+1] + rewritten + value[close:]
+			close += len(rewritten) - len(resource)
+		}
+		offset = close + 1
+	}
+
+	return value
+}
+
 func (h *HeaderTransform) HandleResponse(rw http.ResponseWriter,
 	res *http.Response, req *http.Request, ses *user.SessionState) error {
 
@@ -65,15 +123,15 @@ func (h *HeaderTransform) HandleResponse(rw http.ResponseWriter,
 		// Transform path
 		if h.Spec.Proxy.StripListenPath {
 			if len(h.Spec.target.Path) != 0 {
-				val = strings.Replace(val, h.Spec.target.Path,
-					h.Spec.Proxy.ListenPath, -1)
+				val = replaceHeaderPathPrefix(val, h.Spec.target.Path,
+					h.Spec.Proxy.ListenPath)
 			} else {
 				val = strings.Replace(val, req.URL.Path,
 					h.Spec.Proxy.ListenPath+req.URL.Path, -1)
 			}
 		} else {
 			if len(h.Spec.target.Path) != 0 {
-				val = strings.Replace(val, h.Spec.target.Path, "/", -1)
+				val = replaceHeaderPathPrefix(val, h.Spec.target.Path, "/")
 			}
 		}
 		setCustomHeader(res.Header, name, val, ignoreCanonical)

--- a/gateway/res_handler_transform_test.go
+++ b/gateway/res_handler_transform_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -295,6 +296,117 @@ func TestHeaderTransformBase(t *testing.T) {
 
 	// Check that the returned base is indeed the BaseTykResponseHandler of ht
 	require.Equal(t, &ht.BaseTykResponseHandler, base, "Base method did not return the expected BaseTykResponseHandler")
+}
+
+func TestHeaderTransformResponsePath(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		targetURL   string
+		stripListen bool
+		headerName  string
+		headerValue string
+		wantHeader  string
+	}{
+		{
+			name:        "relative location with root target",
+			targetURL:   "https://upstream.example/",
+			stripListen: true,
+			headerName:  "Location",
+			headerValue: "/some/path",
+			wantHeader:  "/foo/bar/some/path",
+		},
+		{
+			name:        "absolute location with root target",
+			targetURL:   "https://upstream.example/",
+			stripListen: true,
+			headerName:  "Location",
+			headerValue: "https://upstream.example/some/path",
+			wantHeader:  "https://gateway.example/foo/bar/some/path",
+		},
+		{
+			name:        "protocol relative location",
+			targetURL:   "https://upstream.example/",
+			stripListen: true,
+			headerName:  "Location",
+			headerValue: "//upstream.example/some/path",
+			wantHeader:  "//gateway.example/foo/bar/some/path",
+		},
+		{
+			name:        "query and fragment are preserved",
+			targetURL:   "https://upstream.example/",
+			stripListen: true,
+			headerName:  "Location",
+			headerValue: "https://upstream.example/some/path?next=/other/path#section/one",
+			wantHeader:  "https://gateway.example/foo/bar/some/path?next=/other/path#section/one",
+		},
+		{
+			name:        "target path is replaced when stripping listen path",
+			targetURL:   "https://upstream.example/api/",
+			stripListen: true,
+			headerName:  "Location",
+			headerValue: "/api/some/path",
+			wantHeader:  "/foo/bar/some/path",
+		},
+		{
+			name:        "target path is removed without stripping listen path",
+			targetURL:   "https://upstream.example/api/",
+			stripListen: false,
+			headerName:  "Location",
+			headerValue: "https://upstream.example/api/some/path",
+			wantHeader:  "https://gateway.example/some/path",
+		},
+		{
+			name:        "multiple link resources are rewritten",
+			targetURL:   "https://upstream.example/",
+			stripListen: true,
+			headerName:  "Link",
+			headerValue: `<https://upstream.example/one/path?x=/y>; rel="next", </two/path#frag>; rel="prev"`,
+			wantHeader:  `<https://gateway.example/foo/bar/one/path?x=/y>; rel="next", </foo/bar/two/path#frag>; rel="prev"`,
+		},
+		{
+			name:        "non resource header text is left alone",
+			targetURL:   "https://upstream.example/",
+			stripListen: true,
+			headerName:  "X-Debug",
+			headerValue: "segment/one / segment/two",
+			wantHeader:  "segment/one / segment/two",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			target, err := url.Parse(tc.targetURL)
+			require.NoError(t, err)
+
+			spec := &APISpec{
+				APIDefinition: &apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath:      "/foo/bar/",
+						StripListenPath: tc.stripListen,
+					},
+				},
+				target: target,
+			}
+
+			h := &HeaderTransform{
+				BaseTykResponseHandler: BaseTykResponseHandler{
+					Spec: spec,
+					Gw:   NewGateway(config.Config{}, nil),
+				},
+				config: HeaderTransformOptions{
+					RevProxyTransform: RevProxyTransform{
+						Headers:     []string{tc.headerName},
+						Target_host: "https://gateway.example",
+					},
+				},
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "https://gateway.example/foo/bar/request", nil)
+			res := &http.Response{Header: make(http.Header)}
+			res.Header.Set(tc.headerName, tc.headerValue)
+
+			require.NoError(t, h.HandleResponse(nil, res, req, nil))
+			assert.Equal(t, tc.wantHeader, res.Header.Get(tc.headerName))
+		})
+	}
 }
 
 func TestResponseTransformMiddleware(t *testing.T) {


### PR DESCRIPTION
## Description

Fix response header path rewriting so the target path is replaced only at the start of a resource path. This prevents a target path of `/` from rewriting every slash in `Location` values or corrupting `https://` in absolute URLs.

The same path handling is applied to URL references in `Link` headers, while query strings, fragments, and unrelated header text are left unchanged.

## Related Issue

Fixes #5548

## Motivation and Context

`HeaderTransform` used `strings.Replace(..., -1)` for path rewriting. With target path `/` and listen path `/foo/bar/`, `/some/path` became `/foo/bar/some/foo/bar/path`. Absolute URLs could also have their scheme separators rewritten.

## How This Has Been Tested

Added table-driven coverage for relative, absolute, and protocol-relative `Location` values, target paths `/` and `/api/`, strip listen path on and off, query and fragment preservation, multiple `Link` resources, and unrelated header text.

Tests run:

- `go test -race ./gateway -run '^TestHeaderTransformResponsePath$' -count=1`
- `go test ./gateway -run '^(TestHeaderTransformBase|TestHeaderTransformResponsePath|TestResponseTransformMiddleware)$' -count=1` with Redis
- `go vet ./gateway`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] No documentation changes are required
- [x] `go.mod` is unchanged
- [x] No code coverage CI quality gate exception is requested
