### PR TITLE
[TT-17945] Validate GraphQL requests before normalizing them

### DIFF
--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -201,16 +201,11 @@ func (g *graphqlRequestProcessorV1) ProcessRequest(ctx context.Context, w http.R
 	}
 
 	gqlRequest := g.ctxRetrieveRequest(r)
-	normalizationResult, err := gqlRequest.Normalize(g.schema)
-	if err != nil {
-		g.logger.Error("error while normalizing GraphQL request", abstractlogger.Error(err))
-		return ProxyingRequestFailedErr, http.StatusInternalServerError
-	}
 
-	if normalizationResult.Errors != nil && normalizationResult.Errors.Count() > 0 {
-		return writeGraphQLError(g.logger, w, normalizationResult.Errors)
-	}
-
+	// Validation runs before normalization: normalization inlines fragment
+	// spreads and is not resilient to malformed operations (e.g. cyclic
+	// fragment spreads), whereas validation parses the query independently
+	// and can reject such operations safely. See TT-17945.
 	validationResult, err := gqlRequest.ValidateForSchema(g.schema)
 	if err != nil {
 		g.logger.Error("error while validating GraphQL request", abstractlogger.Error(err))
@@ -219,6 +214,16 @@ func (g *graphqlRequestProcessorV1) ProcessRequest(ctx context.Context, w http.R
 
 	if validationResult.Errors != nil && validationResult.Errors.Count() > 0 {
 		return writeGraphQLError(g.logger, w, validationResult.Errors)
+	}
+
+	normalizationResult, err := gqlRequest.Normalize(g.schema)
+	if err != nil {
+		g.logger.Error("error while normalizing GraphQL request", abstractlogger.Error(err))
+		return ProxyingRequestFailedErr, http.StatusInternalServerError
+	}
+
+	if normalizationResult.Errors != nil && normalizationResult.Errors.Count() > 0 {
+		return writeGraphQLError(g.logger, w, normalizationResult.Errors)
 	}
 
 	inputValidationResult, err := gqlRequest.ValidateInput(g.schema)
@@ -248,10 +253,13 @@ func (g *graphqlRequestProcessorWithOTelV1) ProcessRequest(ctx context.Context, 
 	g.otelExecutor.SetContext(ctx)
 	gqlRequest := g.ctxRetrieveRequest(r)
 
-	// normalization
-	err := g.otelExecutor.Normalize(gqlRequest)
+	// validation runs before normalization: normalization inlines fragment
+	// spreads and is not resilient to malformed operations (e.g. cyclic
+	// fragment spreads), whereas validation parses the query independently
+	// and can reject such operations safely. See TT-17945.
+	err := g.otelExecutor.ValidateForSchema(gqlRequest)
 	if err != nil {
-		g.logger.Error("error while normalizing GraphqlRequest", abstractlogger.Error(err))
+		g.logger.Error("error while validating GraphQL request", abstractlogger.Error(err))
 		var reqErr graphql.RequestErrors
 		if errors.As(err, &reqErr) {
 			return writeGraphQLError(g.logger, w, reqErr)
@@ -259,10 +267,10 @@ func (g *graphqlRequestProcessorWithOTelV1) ProcessRequest(ctx context.Context, 
 		return ProxyingRequestFailedErr, http.StatusInternalServerError
 	}
 
-	// validation
-	err = g.otelExecutor.ValidateForSchema(gqlRequest)
+	// normalization
+	err = g.otelExecutor.Normalize(gqlRequest)
 	if err != nil {
-		g.logger.Error("error while validating GraphQL request", abstractlogger.Error(err))
+		g.logger.Error("error while normalizing GraphqlRequest", abstractlogger.Error(err))
 		var reqErr graphql.RequestErrors
 		if errors.As(err, &reqErr) {
 			return writeGraphQLError(g.logger, w, reqErr)

--- a/internal/graphengine/graphql_go_tools_v1_test.go
+++ b/internal/graphengine/graphql_go_tools_v1_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/jensneuse/abstractlogger"
 	"github.com/sirupsen/logrus"
@@ -21,6 +22,21 @@ import (
 	internalgraphql "github.com/TykTechnologies/tyk/internal/graphql"
 	"github.com/TykTechnologies/tyk/internal/otel"
 )
+
+// cyclicFragmentSpreadQuery is a GraphQL document whose fragments spread
+// each other in a cycle. Before TT-17945, normalizing this crashed the whole
+// process with an unrecoverable stack overflow; it must now be rejected as
+// a normal validation error, before Normalize ever runs.
+const cyclicFragmentSpreadQuery = `
+query Q {
+	...frag1
+}
+fragment frag1 on Query {
+	...frag2
+}
+fragment frag2 on Query {
+	...frag1
+}`
 
 func TestGraphqlRequestProcessorV1_ProcessRequest(t *testing.T) {
 	t.Run("should return error and 500 when request is nil", func(t *testing.T) {
@@ -50,7 +66,43 @@ func TestGraphqlRequestProcessorV1_ProcessRequest(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, 400, statusCode)
-		assert.Equal(t, `{"errors":[{"message":"field: goodBye not defined on type: Query","path":["query","goodBye"]}]}`, body.String())
+		// Since TT-17945, ValidateForSchema runs before Normalize, so this
+		// error now comes from the FieldSelections validation rule rather
+		// than a normalization-time check; the message and 400 status are
+		// unchanged, but the reported path no longer includes the field name.
+		assert.Equal(t, `{"errors":[{"message":"field: goodBye not defined on type: Query","path":["query"]}]}`, body.String())
+	})
+
+	t.Run("should reject cyclic fragment spreads instead of crashing (TT-17945)", func(t *testing.T) {
+		processor := newTestGraphqlRequestProcessorV1(t)
+		processor.ctxRetrieveRequest = func(r *http.Request) *graphql.Request {
+			return &graphql.Request{
+				Query: cyclicFragmentSpreadQuery,
+			}
+		}
+
+		request, err := http.NewRequest(http.MethodPost, "http://example.com", bytes.NewBuffer([]byte(fmt.Sprintf(`{"query": %q}`, cyclicFragmentSpreadQuery))))
+		require.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
+
+		done := make(chan struct{})
+		var err2 error
+		var statusCode int
+		go func() {
+			defer close(done)
+			err2, statusCode = processor.ProcessRequest(context.Background(), recorder, request)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("ProcessRequest did not return - likely a stack overflow regression")
+		}
+
+		assert.Error(t, err2)
+		assert.Equal(t, 400, statusCode)
+		assert.Contains(t, recorder.Body.String(), "forms fragment cycle")
 	})
 
 	t.Run("should return error and 400 when input validation fails", func(t *testing.T) {
@@ -124,7 +176,43 @@ func TestGraphqlRequestProcessorWithOtelV1_ProcessRequest(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, 400, statusCode)
-		assert.Equal(t, `{"errors":[{"message":"field: goodBye not defined on type: Query","path":["query","goodBye"]}]}`, body.String())
+		// Since TT-17945, ValidateForSchema runs before Normalize, so this
+		// error now comes from the FieldSelections validation rule rather
+		// than a normalization-time check; the message and 400 status are
+		// unchanged, but the reported path no longer includes the field name.
+		assert.Equal(t, `{"errors":[{"message":"field: goodBye not defined on type: Query","path":["query"]}]}`, body.String())
+	})
+
+	t.Run("should reject cyclic fragment spreads instead of crashing (TT-17945)", func(t *testing.T) {
+		processor := newTestGraphqlRequestProcessorWithOtelV1(t)
+		processor.ctxRetrieveRequest = func(r *http.Request) *graphql.Request {
+			return &graphql.Request{
+				Query: cyclicFragmentSpreadQuery,
+			}
+		}
+
+		request, err := http.NewRequest(http.MethodPost, "http://example.com", bytes.NewBuffer([]byte(fmt.Sprintf(`{"query": %q}`, cyclicFragmentSpreadQuery))))
+		require.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
+
+		done := make(chan struct{})
+		var err2 error
+		var statusCode int
+		go func() {
+			defer close(done)
+			err2, statusCode = processor.ProcessRequest(context.Background(), recorder, request)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("ProcessRequest did not return - likely a stack overflow regression")
+		}
+
+		assert.Error(t, err2)
+		assert.Equal(t, 400, statusCode)
+		assert.Contains(t, recorder.Body.String(), "forms fragment cycle")
 	})
 
 	t.Run("should return error and 400 when input validation fails", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `graphqlRequestProcessorV1.ProcessRequest` and `graphqlRequestProcessorWithOTelV1.ProcessRequest` (`internal/graphengine/graphql_go_tools_v1.go`) called `Normalize()` before `ValidateForSchema()`.
- Normalization inlines fragment spreads and is not resilient to malformed operations. Specifically, a GraphQL document whose fragments spread each other in a cycle makes `graphql-go-tools`'s fragment-depth calculation recurse forever during `Normalize()`, crashing the whole gateway process with an unrecoverable `fatal error: stack overflow` (fixed at the library level in https://github.com/TykTechnologies/graphql-go-tools/pull/new/TT-17945/fix-fragment-spread-cycle-stack-overflow).
- `ValidateForSchema()` parses the query independently (doesn't depend on `Normalize()` having run) and already rejects fragment cycles per the GraphQL spec ("5.5.2.2 Fragment spreads must not form cycles"). Running it first means a malicious/malformed request like this is rejected with a normal 400 GraphQL error before it ever reaches the vulnerable normalizer — defense in depth on top of the library fix, so gateways still on an older `graphql-go-tools` are protected too.

Jira: https://tyktech.atlassian.net/browse/TT-17945

### Note on behavioural side effect
Reordering surfaced one observable difference in an existing test: for a query referencing an unknown field, the error now comes from the `FieldSelections` validation rule instead of a normalization-time check. Message and `400` status are unchanged, but the reported `path` no longer includes the field name (`["query"]` instead of `["query","goodBye"]`). Updated the affected test expectations and left a comment explaining why. Flagging this explicitly for review rather than treating it as incidental.

## Test plan
- [x] Added a `should reject cyclic fragment spreads instead of crashing (TT-17945)` case to both `TestGraphqlRequestProcessorV1_ProcessRequest` and `TestGraphqlRequestProcessorWithOtelV1_ProcessRequest`, guarded by a 5s timeout so a regression fails the test instead of hanging CI. Confirmed it asserts a `400` with a "forms fragment cycle" error body.
- [x] `go test ./internal/graphengine/...` — pass
- [x] `go vet ./internal/graphengine/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17945" title="TT-17945" target="_blank">TT-17945</a>
</summary>

|         |    |
|---------|----|
| Status  | Open |
| Summary | GraphQL fragment spread cycle causes unrecoverable stack overflow crash in Tyk Gateway |

Generated at: 2026-08-11 19:57:08

</details>

<!---TykTechnologies/jira-linter ends here-->
