### PR TITLE
[TT-16797] Unnecessary repetition of redis calls when creating keys

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -345,7 +345,7 @@ func (gw *Gateway) resetQuotaNeeded(specs []*APISpec) bool {
 	})
 }
 
-func (gw *Gateway) resetQuotaAndSavePolicy(
+func (gw *Gateway) resetQuotaAndSaveSession(
 	keyName string,
 	session *user.SessionState,
 	specs []*APISpec,
@@ -354,7 +354,7 @@ func (gw *Gateway) resetQuotaAndSavePolicy(
 
 	if forceReset {
 		session.QuotaRenews = time.Now().Unix() + session.QuotaRenewalRate
-		gw.GlobalSessionManager.ResetQuota(keyName, session, false) // io op
+		gw.GlobalSessionManager.ResetQuota(keyName, session, isHashed) // io op
 	}
 
 	lifetime := gw.ApplyLifetime(session, specs...)
@@ -362,7 +362,6 @@ func (gw *Gateway) resetQuotaAndSavePolicy(
 }
 
 func (gw *Gateway) applyPolicy(session *user.SessionState, spec *APISpec) error {
-	// use basic middleware to apply policies to key/session (it also saves it)
 	mw := &BaseMiddleware{
 		Spec: spec,
 		Gw:   gw,
@@ -456,10 +455,14 @@ func (gw *Gateway) doAddOrUpdate(keyName string, newSession *user.SessionState, 
 			if apiSpec != nil {
 				gw.checkAndApplyTrialPeriod(keyName, newSession, isHashed)
 			}
+
+			if err := gw.applyPolicy(newSession, apiSpec); err != nil {
+				return err
+			}
 		}
 
 		forceReset := !dontReset && gw.resetQuotaNeeded(apisSpecs)
-		if err := gw.resetQuotaAndSavePolicy(keyName, newSession, apisSpecs, isHashed, forceReset); err != nil {
+		if err := gw.resetQuotaAndSaveSession(keyName, newSession, apisSpecs, isHashed, forceReset); err != nil {
 			return err
 		}
 	} else {
@@ -480,7 +483,7 @@ func (gw *Gateway) doAddOrUpdate(keyName string, newSession *user.SessionState, 
 
 		gw.checkAndApplyTrialPeriod(keyName, newSession, isHashed)
 		apisSpecs := expmaps.Values(gw.apisByID)
-		if err := gw.resetQuotaAndSavePolicy(keyName, newSession, apisSpecs, isHashed, !dontReset); err != nil {
+		if err := gw.resetQuotaAndSaveSession(keyName, newSession, apisSpecs, isHashed, !dontReset); err != nil {
 			return err
 		}
 	}
@@ -2268,7 +2271,7 @@ func (gw *Gateway) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 
 		forceReset := gw.resetQuotaNeeded(apiSpecList)
 
-		if err := gw.resetQuotaAndSavePolicy(newKey, newSession, apiSpecList, false, forceReset); err != nil {
+		if err := gw.resetQuotaAndSaveSession(newKey, newSession, apiSpecList, false, forceReset); err != nil {
 			doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))
 			return
 		}
@@ -2299,7 +2302,7 @@ func (gw *Gateway) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			apiSpecs := expmaps.Values(gw.apisByID)
 			forceReset := gw.resetQuotaNeeded(apiSpecs)
 
-			if err := gw.resetQuotaAndSavePolicy(newKey, newSession, apiSpecs, false, forceReset); err != nil {
+			if err := gw.resetQuotaAndSaveSession(newKey, newSession, apiSpecs, false, forceReset); err != nil {
 				doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))
 				return
 			}

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -371,23 +371,6 @@ func (gw *Gateway) applyPolicy(session *user.SessionState, spec *APISpec) error 
 	return mw.ApplyPolicies(session)
 }
 
-func (gw *Gateway) applyPoliciesAndSave(keyName string, session *user.SessionState, spec *APISpec, isHashed bool) error {
-	// use basic middleware to apply policies to key/session (it also saves it)
-	mw := &BaseMiddleware{
-		Spec: spec,
-		Gw:   gw,
-	}
-
-	if err := mw.ApplyPolicies(session); err != nil {
-		return err
-	}
-
-	// calculate lifetime considering access rights
-	lifetime := gw.ApplyLifetime(session, spec)
-
-	return gw.GlobalSessionManager.UpdateSession(keyName, session, lifetime, isHashed)
-}
-
 // GetApiSpecsFromAccessRights from the session.AccessRights returns the collection of api specs
 func (gw *Gateway) GetApiSpecsFromAccessRights(sess *user.SessionState) []*APISpec {
 	var apis []*APISpec

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -48,12 +48,15 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gorilla/mux"
 	"github.com/lonelycode/osin"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"golang.org/x/crypto/bcrypt"
+	expmaps "golang.org/x/exp/maps"
 
 	gql "github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	gqlv2 "github.com/TykTechnologies/graphql-go-tools/v2/pkg/graphql"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/certs"
@@ -336,6 +339,38 @@ func (gw *Gateway) checkAndApplyTrialPeriod(
 	}
 }
 
+func (gw *Gateway) resetQuotaNeeded(specs []*APISpec) bool {
+	return lo.SomeBy(specs, func(item *APISpec) bool {
+		return item == nil || !item.DontSetQuotasOnCreate
+	})
+}
+
+func (gw *Gateway) resetQuotaAndSavePolicy(
+	keyName string,
+	session *user.SessionState,
+	specs []*APISpec,
+	isHashed, forceReset bool,
+) error {
+
+	if forceReset {
+		session.QuotaRenews = time.Now().Unix() + session.QuotaRenewalRate
+		gw.GlobalSessionManager.ResetQuota(keyName, session, false) // io op
+	}
+
+	lifetime := gw.ApplyLifetime(session, specs...)
+	return gw.GlobalSessionManager.UpdateSession(keyName, session, lifetime, isHashed)
+}
+
+func (gw *Gateway) applyPolicy(session *user.SessionState, spec *APISpec) error {
+	// use basic middleware to apply policies to key/session (it also saves it)
+	mw := &BaseMiddleware{
+		Spec: spec,
+		Gw:   gw,
+	}
+
+	return mw.ApplyPolicies(session)
+}
+
 func (gw *Gateway) applyPoliciesAndSave(keyName string, session *user.SessionState, spec *APISpec, isHashed bool) error {
 	// use basic middleware to apply policies to key/session (it also saves it)
 	mw := &BaseMiddleware{
@@ -427,8 +462,10 @@ func (gw *Gateway) doAddOrUpdate(keyName string, newSession *user.SessionState, 
 		resetAPILimits(newSession.AccessRights)
 
 		// We have a specific list of access rules, only add / update those
+		apisSpecs := make([]*APISpec, 0, len(newSession.AccessRights))
 		for apiId := range newSession.AccessRights {
 			apiSpec := gw.getApiSpec(apiId)
+			apisSpecs = append(apisSpecs, apiSpec)
 			if apiSpec == nil {
 				logger.WithField("api_id", apiId).Warn("Can't find active API, storing anyway")
 			}
@@ -436,20 +473,11 @@ func (gw *Gateway) doAddOrUpdate(keyName string, newSession *user.SessionState, 
 			if apiSpec != nil {
 				gw.checkAndApplyTrialPeriod(keyName, newSession, isHashed)
 			}
+		}
 
-			// Lets reset keys if they are edited by admin
-			if apiSpec == nil || !apiSpec.DontSetQuotasOnCreate {
-				// Reset quote by default
-				if !dontReset {
-					gw.GlobalSessionManager.ResetQuota(keyName, newSession, isHashed)
-					newSession.QuotaRenews = time.Now().Unix() + newSession.QuotaRenewalRate
-				}
-			}
-
-			// apply polices (if any) and save key
-			if err := gw.applyPoliciesAndSave(keyName, newSession, apiSpec, isHashed); err != nil {
-				return err
-			}
+		forceReset := !dontReset && gw.resetQuotaNeeded(apisSpecs)
+		if err := gw.resetQuotaAndSavePolicy(keyName, newSession, apisSpecs, isHashed, forceReset); err != nil {
+			return err
 		}
 	} else {
 		// nothing defined, add key to ALL
@@ -462,15 +490,15 @@ func (gw *Gateway) doAddOrUpdate(keyName string, newSession *user.SessionState, 
 		defer gw.apisMu.RUnlock()
 
 		for _, spec := range gw.apisByID {
-			if !dontReset {
-				gw.GlobalSessionManager.ResetQuota(keyName, newSession, isHashed)
-				newSession.QuotaRenews = time.Now().Unix() + newSession.QuotaRenewalRate
-			}
-			gw.checkAndApplyTrialPeriod(keyName, newSession, isHashed)
-			// apply polices (if any) and save key
-			if err := gw.applyPoliciesAndSave(keyName, newSession, spec, isHashed); err != nil {
+			if err := gw.applyPolicy(newSession, spec); err != nil {
 				return err
 			}
+		}
+
+		gw.checkAndApplyTrialPeriod(keyName, newSession, isHashed)
+		apisSpecs := expmaps.Values(gw.apisByID)
+		if err := gw.resetQuotaAndSavePolicy(keyName, newSession, apisSpecs, isHashed, !dontReset); err != nil {
+			return err
 		}
 	}
 
@@ -2228,8 +2256,6 @@ func (gw *Gateway) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 	newSession.LastUpdated = strconv.Itoa(int(time.Now().Unix()))
 	newSession.DateCreated = time.Now()
 
-	sessionManager := gw.GlobalSessionManager
-
 	mw := &BaseMiddleware{Gw: gw}
 	if err := mw.ApplyPolicies(newSession); err != nil {
 		doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))
@@ -2239,23 +2265,29 @@ func (gw *Gateway) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 	if len(newSession.AccessRights) > 0 {
 		// reset API-level limit to nil if any has a zero-value
 		resetAPILimits(newSession.AccessRights)
+
+		apiSpecList := make([]*APISpec, 0, len(newSession.AccessRights))
+
 		for apiID := range newSession.AccessRights {
 			apiSpec := gw.getApiSpec(apiID)
+			apiSpecList = append(apiSpecList, apiSpec)
+
 			if apiSpec != nil {
 				gw.checkAndApplyTrialPeriod(newKey, newSession, false)
 			}
 
-			if apiSpec == nil || !apiSpec.DontSetQuotasOnCreate {
-				// Reset quota by default
-				newSession.QuotaRenews = time.Now().Unix() + newSession.QuotaRenewalRate
-				sessionManager.ResetQuota(newKey, newSession, false)
-			}
-
 			// apply polices (if any) and save key
-			if err := gw.applyPoliciesAndSave(newKey, newSession, apiSpec, false); err != nil {
+			if err := gw.applyPolicy(newSession, apiSpec); err != nil {
 				doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))
 				return
 			}
+		}
+
+		forceReset := gw.resetQuotaNeeded(apiSpecList)
+
+		if err := gw.resetQuotaAndSavePolicy(newKey, newSession, apiSpecList, false, forceReset); err != nil {
+			doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))
+			return
 		}
 	} else {
 		if gw.GetConfig().AllowMasterKeys {
@@ -2275,15 +2307,18 @@ func (gw *Gateway) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			defer gw.apisMu.RUnlock()
 			for _, spec := range gw.apisByID {
 				gw.checkAndApplyTrialPeriod(newKey, newSession, false)
-				if !spec.DontSetQuotasOnCreate {
-					// Reset quota by default
-					sessionManager.ResetQuota(newKey, newSession, false)
-					newSession.QuotaRenews = time.Now().Unix() + newSession.QuotaRenewalRate
-				}
-				if err := gw.applyPoliciesAndSave(newKey, newSession, spec, false); err != nil {
+				if err := gw.applyPolicy(newSession, spec); err != nil {
 					doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))
 					return
 				}
+			}
+
+			apiSpecs := expmaps.Values(gw.apisByID)
+			forceReset := gw.resetQuotaNeeded(apiSpecs)
+
+			if err := gw.resetQuotaAndSavePolicy(newKey, newSession, apiSpecs, false, forceReset); err != nil {
+				doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))
+				return
 			}
 		} else {
 			log.WithFields(logrus.Fields{

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -6412,6 +6412,150 @@ func TestAPIListFilter_IncludeTypes(t *testing.T) {
 	})
 }
 
+func TestKeyHandler_CreateAndUpdate_Integration(t *testing.T) {
+	ts := StartTest(func(c *config.Config) {
+		c.AllowMasterKeys = true // Enable master keys for testing
+	})
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "test-api"
+		spec.UseKeylessAccess = false
+		spec.Auth.UseParam = true
+	})
+
+	// Add a policy
+	ts.Gw.policies.Add(user.Policy{
+		Active:           true,
+		QuotaMax:         10,
+		QuotaRenewalRate: 300,
+		AccessRights: map[string]user.AccessDefinition{"test-api": {
+			APIID: "test-api", Versions: []string{"Default"},
+		}},
+		OrgID: "default",
+		ID:    "test_policy",
+	})
+
+	// 1. createKeyHandler with AccessRights
+	t.Run("createKeyHandler with AccessRights", func(t *testing.T) {
+		session := CreateStandardSession()
+		session.AccessRights = map[string]user.AccessDefinition{"test-api": {
+			APIID: "test-api", Versions: []string{"Default"},
+		}}
+		session.ApplyPolicies = []string{"test_policy"}
+		sessionJSON := test.MarshalJSON(t)(session)
+
+		resp, _ := ts.Run(t, test.TestCase{
+			Method:    "POST",
+			Path:      "/tyk/keys/create",
+			Data:      string(sessionJSON),
+			AdminAuth: true,
+			Code:      200,
+		})
+
+		var keyResp map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&keyResp)
+		keyID := keyResp["key"].(string)
+
+		// Verify quota is applied
+		ts.Run(t, test.TestCase{
+			Method:    "GET",
+			Path:      "/tyk/keys/" + keyID + "?api_id=test-api",
+			AdminAuth: true,
+			Code:      200,
+			BodyMatch: `"quota_max":10`,
+		})
+	})
+
+	// 2. createKeyHandler with AllowMasterKeys
+	t.Run("createKeyHandler with AllowMasterKeys", func(t *testing.T) {
+		session := CreateStandardSession()
+		// No AccessRights set, should be allowed because AllowMasterKeys = true
+		sessionJSON := test.MarshalJSON(t)(session)
+
+		resp, _ := ts.Run(t, test.TestCase{
+			Method:    "POST",
+			Path:      "/tyk/keys/create",
+			Data:      string(sessionJSON),
+			AdminAuth: true,
+			Code:      200,
+		})
+
+		var keyResp map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&keyResp)
+		keyID := keyResp["key"].(string)
+
+		// Verify key is created
+		ts.Run(t, test.TestCase{
+			Method:    "GET",
+			Path:      "/tyk/keys/" + keyID,
+			AdminAuth: true,
+			Code:      200,
+		})
+	})
+
+	// 3. doAddOrUpdate with AccessRights
+	t.Run("doAddOrUpdate with AccessRights", func(t *testing.T) {
+		keyID := uuid.New()
+		session := CreateStandardSession()
+		session.AccessRights = map[string]user.AccessDefinition{"test-api": {
+			APIID: "test-api", Versions: []string{"Default"},
+		}}
+		session.ApplyPolicies = []string{"test_policy"}
+		sessionJSON := test.MarshalJSON(t)(session)
+
+		// POST to /tyk/keys/{key} uses addOrUpdateKeyHandler which calls doAddOrUpdate
+		resp, _ := ts.Run(t, test.TestCase{
+			Method:    "POST",
+			Path:      "/tyk/keys/" + keyID,
+			Data:      string(sessionJSON),
+			AdminAuth: true,
+			Code:      200,
+		})
+
+		var keyResp map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&keyResp)
+		actualKeyID := keyResp["key"].(string)
+
+		// Verify quota is applied
+		ts.Run(t, test.TestCase{
+			Method:    "GET",
+			Path:      "/tyk/keys/" + actualKeyID + "?api_id=test-api",
+			AdminAuth: true,
+			Code:      200,
+			BodyMatch: `"quota_max":10`,
+		})
+	})
+
+	// 4. doAddOrUpdate with AllowMasterKeys
+	t.Run("doAddOrUpdate with AllowMasterKeys", func(t *testing.T) {
+		keyID := uuid.New()
+		session := CreateStandardSession()
+		// No AccessRights set
+		sessionJSON := test.MarshalJSON(t)(session)
+
+		resp, _ := ts.Run(t, test.TestCase{
+			Method:    "POST",
+			Path:      "/tyk/keys/" + keyID,
+			Data:      string(sessionJSON),
+			AdminAuth: true,
+			Code:      200,
+		})
+
+		var keyResp map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&keyResp)
+		actualKeyID := keyResp["key"].(string)
+
+		// Verify key is created
+		ts.Run(t, test.TestCase{
+			Method:    "GET",
+			Path:      "/tyk/keys/" + actualKeyID,
+			AdminAuth: true,
+			Code:      200,
+		})
+	})
+}
+
 func (gw *Gateway) removePersistentPolicyById(id string) error {
 	root, err := gw.newPolicyPathRoot()
 

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -6454,17 +6454,19 @@ func TestKeyHandler_CreateAndUpdate_Integration(t *testing.T) {
 		})
 
 		var keyResp map[string]interface{}
-		json.NewDecoder(resp.Body).Decode(&keyResp)
+		err := json.NewDecoder(resp.Body).Decode(&keyResp)
+		assert.NoError(t, err)
 		keyID := keyResp["key"].(string)
 
 		// Verify quota is applied
-		ts.Run(t, test.TestCase{
+		_, err = ts.Run(t, test.TestCase{
 			Method:    "GET",
 			Path:      "/tyk/keys/" + keyID + "?api_id=test-api",
 			AdminAuth: true,
 			Code:      200,
 			BodyMatch: `"quota_max":10`,
 		})
+		assert.NoError(t, err)
 	})
 
 	// 2. createKeyHandler with AllowMasterKeys
@@ -6482,16 +6484,18 @@ func TestKeyHandler_CreateAndUpdate_Integration(t *testing.T) {
 		})
 
 		var keyResp map[string]interface{}
-		json.NewDecoder(resp.Body).Decode(&keyResp)
+		err := json.NewDecoder(resp.Body).Decode(&keyResp)
+		assert.NoError(t, err)
 		keyID := keyResp["key"].(string)
 
 		// Verify key is created
-		ts.Run(t, test.TestCase{
+		_, err = ts.Run(t, test.TestCase{
 			Method:    "GET",
 			Path:      "/tyk/keys/" + keyID,
 			AdminAuth: true,
 			Code:      200,
 		})
+		assert.NoError(t, err)
 	})
 
 	// 3. doAddOrUpdate with AccessRights
@@ -6505,26 +6509,29 @@ func TestKeyHandler_CreateAndUpdate_Integration(t *testing.T) {
 		sessionJSON := test.MarshalJSON(t)(session)
 
 		// POST to /tyk/keys/{key} uses addOrUpdateKeyHandler which calls doAddOrUpdate
-		resp, _ := ts.Run(t, test.TestCase{
+		resp, err := ts.Run(t, test.TestCase{
 			Method:    "POST",
 			Path:      "/tyk/keys/" + keyID,
 			Data:      string(sessionJSON),
 			AdminAuth: true,
 			Code:      200,
 		})
+		assert.NoError(t, err)
 
 		var keyResp map[string]interface{}
-		json.NewDecoder(resp.Body).Decode(&keyResp)
+		err = json.NewDecoder(resp.Body).Decode(&keyResp)
+		assert.NoError(t, err)
 		actualKeyID := keyResp["key"].(string)
 
 		// Verify quota is applied
-		ts.Run(t, test.TestCase{
+		_, err = ts.Run(t, test.TestCase{
 			Method:    "GET",
 			Path:      "/tyk/keys/" + actualKeyID + "?api_id=test-api",
 			AdminAuth: true,
 			Code:      200,
 			BodyMatch: `"quota_max":10`,
 		})
+		assert.NoError(t, err)
 	})
 
 	// 4. doAddOrUpdate with AllowMasterKeys
@@ -6534,25 +6541,28 @@ func TestKeyHandler_CreateAndUpdate_Integration(t *testing.T) {
 		// No AccessRights set
 		sessionJSON := test.MarshalJSON(t)(session)
 
-		resp, _ := ts.Run(t, test.TestCase{
+		resp, err := ts.Run(t, test.TestCase{
 			Method:    "POST",
 			Path:      "/tyk/keys/" + keyID,
 			Data:      string(sessionJSON),
 			AdminAuth: true,
 			Code:      200,
 		})
+		assert.NoError(t, err)
 
 		var keyResp map[string]interface{}
-		json.NewDecoder(resp.Body).Decode(&keyResp)
+		err = json.NewDecoder(resp.Body).Decode(&keyResp)
+		assert.NoError(t, err)
 		actualKeyID := keyResp["key"].(string)
 
 		// Verify key is created
-		ts.Run(t, test.TestCase{
+		_, err = ts.Run(t, test.TestCase{
 			Method:    "GET",
 			Path:      "/tyk/keys/" + actualKeyID,
 			AdminAuth: true,
 			Code:      200,
 		})
+		assert.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
### Description
This PR optimizes the creation and updating of keys by reducing unnecessary repetition of Redis calls. It consolidates the `ResetQuota` and `UpdateSession` calls to happen once at the end of the process, rather than in a loop for each API.

---
**Attribution**
Requested by: U08QWRUM11Q
Slack thread: https://tyktech.slack.com/archives/D0AF7G82CSV/p1786610386061579



<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16797" title="TT-16797" target="_blank">TT-16797</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | Unnecessary repetition of redis calls when creating keys |

Generated at: 2026-08-13 11:43:35

</details>

<!---TykTechnologies/jira-linter ends here-->


