### PR TITLE
TT-17641: docs: document the opt-in next-generation plugin compiler

### DIFF
--- a/docs/plugins/go-development-flow.md
+++ b/docs/plugins/go-development-flow.md
@@ -162,6 +162,15 @@ Supplying the argument `build_id` to the *Plugin Compiler* ensures the same plug
 
 Continue with [Tyk Plugin Compiler](https://tyk.io/docs/product-stack/tyk-gateway/advanced-configurations/plugins/golang/go-plugin-compiler/).
 
+{{< note success >}} **Note**
+
+An opt-in next-generation compiler image is published alongside the one described
+above, under the same repositories with a `-ng` tag suffix. It takes the same
+arguments and mounts, and adds cross-compilation, a pinned glibc floor and
+post-build validation. It does **not** rewrite your `go.mod` module path when
+`plugin_id` is supplied, which differs from the behaviour described in this
+section. See [Next-generation Go plugin compiler](go-plugin-compiler-ng.md). {{< /note >}}
+
 ### Using Incorrect Build Flags
 
 When working with Go plugins, it's easy to miss the restriction that the plugin at the very least must be built with the same Go version, and the same flags (notably `-trimpath`) as the Tyk Gateway on which it is to be used.

--- a/docs/plugins/go-plugin-compiler-ng.md
+++ b/docs/plugins/go-plugin-compiler-ng.md
@@ -21,14 +21,15 @@ At the time of writing, NG images are published on alpha tags only, the most rec
 
 ## What NG is and why it exists
 
-The plugin compiler exists because a Go plugin must be built with the same toolchain, build tags and build flags as the Gateway that loads it. NG keeps that contract and adds four things:
+A Go plugin must be built with the same toolchain, build tags and build flags as the Gateway that loads it. That is why the plugin compiler exists, and NG keeps that contract exactly. What it changes is everything around it.
 
-- **Cross-compilation from a single image.** One NG image can target `linux/amd64`, `linux/arm64` and `linux/s390x`.
-- **A pinned glibc link sysroot.** The C library, C runtime objects and headers used for the link come from a sysroot pinned to glibc 2.17, not from the image's own (newer) base OS. Plugins therefore keep the same low glibc symbol floor even though the image itself is built on a modern base.
-- **Post-build validation.** After a successful build the artifact is inspected and the build *fails* with an actionable message if the architecture, Go version, edition build tags, FIPS mode or glibc ceiling do not match what was requested. Set `VALIDATE=0` to skip.
-- **A Docker Hardened Images (DHI) base.** The C toolchain is provisioned by Docker into the base image. There is no build-time `apt-get` in the compiler image, and the image build fails closed if the base is missing a tool it expects.
+**A much smaller vulnerability surface.** NG is built on a Docker Hardened Image. Its toolchain is provided by Docker rather than installed at build time, and Docker publishes assessments for the packages it ships. Scanned with Tyk's published VEX feed applied, the NG image reports **0 Critical and 0 High** findings. This applies to the FIPS image too, so a FIPS build no longer means accepting a larger set of findings. See [Scanning the image](#scanning-the-image-for-vulnerabilities) to reproduce it yourself.
 
-Scanned with Tyk's published VEX feed applied, the NG image reports 0 CRITICAL and 0 HIGH findings. See [Scanning the image](#scanning-the-image-for-vulnerabilities) for how to reproduce that.
+**Builds for more architectures from one image.** A single NG image targets `linux/amd64`, `linux/arm64` and `linux/s390x`, so you no longer need a separate build path per architecture.
+
+**Problems surface at build time, not at load time.** After a build, NG checks the plugin it produced: the architecture, Go version, edition, FIPS mode and glibc requirements. If any of them do not match what the Gateway expects, the build fails with a message explaining why, instead of the plugin failing later when the Gateway tries to load it.
+
+**Compatibility with older Linux distributions is preserved.** Plugins are linked against glibc 2.17, so they keep running on the same range of systems as before even though the image itself is built on a modern base.
 
 ## Choosing between the two compilers
 
@@ -178,7 +179,7 @@ Each of these would otherwise surface as an opaque `plugin was built with a diff
 
 ## Scanning the image for vulnerabilities
 
-NG is built on a Docker Hardened Images base, and Docker publishes affectedness decisions (VEX statements) for the packages it provisions. Those decisions are what make the difference between a raw scan and the reported result.
+NG is built on a Docker Hardened Image. Docker publishes assessments (VEX statements) saying which reported vulnerabilities actually affect the packages it ships. Applying those assessments is what turns a long raw scan result into an accurate one.
 
 Scanning without VEX gives 84 HIGH/CRITICAL rows across 60 distinct CVEs. Essentially all of them are in kernel headers (`linux-libc-dev`), `perl`, `busybox` and `libcurl4t64` — packages Docker has assessed as not affecting the image.
 
@@ -213,15 +214,19 @@ Three things are easy to get wrong here:
 2. If you have other VEX repositories configured, list `tyk-dhi` **first**. A repository that merely lists a package shadows lower-priority repositories for that package, even when it carries no statement for the CVE in question. This was reported upstream as `aquasecurity/trivy` discussion 11083, with a fix proposed in PR 11082.
 3. Pass `--show-suppressed`. Without it, suppressed findings disappear from the report with no indication that anything was suppressed. {{< /note >}}
 
-## Known limitations
+## Things to know before you switch
 
-- NG images are published on alpha tags at the time of writing. They are not published for released Gateway versions.
-- The compiler images are `linux/amd64` only; on an arm64 host they run under emulation.
-- Each image ships one glibc sysroot set (2.17 in published images). There is no run-time switch to a different glibc target.
-- The edition is fixed per image. `EDITION=ee` or `EDITION=ee-fips` fails in an image that was not built for that edition.
-- `linux/s390x` is only available for the CE edition, because EE and FIPS Gateways are not published for that architecture.
-- Published NG images deliberately contain no Gateway executable. The existing compiler image installs one, which means it ships the Gateway inside a build tool; NG builds it only into unpublished gate images used by CI to prove a plugin loads, and the release build fails if the binary is present. The practical consequence is that you cannot run `tyk plugin load` inside the compiler container -- load the plugin into a Gateway container instead.
-- `plugin_id` no longer rewrites your module path or import paths (see [Positional arguments](#positional-arguments)).
+**Alpha tags only, for now.** NG images are published on alpha tags. The existing compiler remains the image used for released Gateway versions.
+
+**Choose the image that matches your edition.** Edition is fixed per image, so use the CE, EE or FIPS image that matches the Gateway you are building for. The build stops with a clear message if they do not match, rather than producing a plugin that will not load.
+
+**Architecture coverage follows the Gateway.** `linux/s390x` is available for CE only, because EE and FIPS Gateways are not published for that architecture.
+
+**On Apple silicon and other ARM64 machines**, the compiler image runs through emulation. Builds work but are slower, and you should pass `GOARCH` explicitly rather than relying on the host architecture.
+
+**Test your plugin in a Gateway container.** The NG image does not include a Gateway binary, so load and exercise your plugin in a Gateway container rather than inside the compiler.
+
+**`plugin_id` no longer rewrites your module path.** If you supply `plugin_id`, it names the build directory only; your `go.mod` and import paths are left alone. See [Positional arguments](#positional-arguments) if you relied on the previous behaviour.
 
 ## Relationship to the existing plugin compiler
 

--- a/docs/plugins/go-plugin-compiler-ng.md
+++ b/docs/plugins/go-plugin-compiler-ng.md
@@ -1,0 +1,239 @@
+---
+title: Next-generation Go plugin compiler (NG)
+tags:
+    - custom plugin
+    - golang
+    - go plugin
+    - plugin compiler
+    - cross compilation
+    - fips
+description: Opt-in next-generation Tyk plugin compiler image, published alongside the existing plugin compiler
+date: "2026-08-14"
+---
+
+The *next-generation plugin compiler* (referred to as *NG*) is a second build of the Tyk plugin compiler image. It is published from the same repositories as the existing compiler, with a `-ng` suffix on the tag, and it takes the same arguments. It is opt-in: both compilers are maintained in parallel and nothing about the existing compiler changes.
+
+If you are new to building Go plugins, start with [Custom Go plugin development flow]({{< ref "product-stack/tyk-gateway/advanced-configurations/plugins/golang/go-development-flow" >}}) and [Tyk Plugin Compiler]({{< ref "product-stack/tyk-gateway/advanced-configurations/plugins/golang/go-plugin-compiler" >}}). This page only describes what NG adds and how it differs.
+
+{{< note success >}} **Note**
+
+At the time of writing, NG images are published on alpha tags only, the most recent being `v5.15.0-alpha11-ng`. The existing plugin compiler remains the image used for released Gateway versions. {{< /note >}}
+
+## What NG is and why it exists
+
+The plugin compiler exists because a Go plugin must be built with the same toolchain, build tags and build flags as the Gateway that loads it. NG keeps that contract and adds four things:
+
+- **Cross-compilation from a single image.** One NG image can target `linux/amd64`, `linux/arm64` and `linux/s390x`.
+- **A pinned glibc link sysroot.** The C library, C runtime objects and headers used for the link come from a sysroot pinned to glibc 2.17, not from the image's own (newer) base OS. Plugins therefore keep the same low glibc symbol floor even though the image itself is built on a modern base.
+- **Post-build validation.** After a successful build the artifact is inspected and the build *fails* with an actionable message if the architecture, Go version, edition build tags, FIPS mode or glibc ceiling do not match what was requested. Set `VALIDATE=0` to skip.
+- **A Docker Hardened Images (DHI) base.** The C toolchain is provisioned by Docker into the base image. There is no build-time `apt-get` in the compiler image, and the image build fails closed if the base is missing a tool it expects.
+
+Scanned with Tyk's published VEX feed applied, the NG image reports 0 CRITICAL and 0 HIGH findings. See [Scanning the image](#scanning-the-image-for-vulnerabilities) for how to reproduce that.
+
+## Choosing between the two compilers
+
+| | Existing plugin compiler | NG plugin compiler |
+|---|---|---|
+| Image tag | `tykio/tyk-plugin-compiler:<version>` | same repository, `-ng` suffix: `tykio/tyk-plugin-compiler:<version>-ng` |
+| Published for | released Gateway versions | alpha tags at the time of writing |
+| Invocation | `/build.sh <plugin_name> [plugin_id] [GOOS] [GOARCH]`, source at `/plugin-source` | identical |
+| Target architectures | `linux/amd64`, `linux/arm64` | `linux/amd64`, `linux/arm64`, `linux/s390x` (CE); `linux/amd64`, `linux/arm64` (EE and FIPS) |
+| glibc floor of the produced plugin | follows the image's base OS | pinned by a glibc 2.17 link sysroot shipped in the image |
+| Post-build checks | none | architecture, Go version, edition tags, FIPS evidence, glibc ceiling, linked libraries |
+| `plugin_id` behaviour | rewrites the plugin `go.mod` module path and Go import paths | only names the build directory; an existing `go.mod` is never rewritten |
+| Base image | `tykio/golang-cross` | Docker Hardened Images customization with a Docker-provisioned toolchain |
+| Gateway test binary inside the image | present (`/usr/local/bin/tyk`) | not present in published images |
+
+Use the existing compiler if you are building plugins for a released Gateway version and your build works today. Try NG if you want to build for more than one architecture from one image, want the build to fail early rather than at `plugin.Open` time, or need the vulnerability posture of the hardened base. Because the interface is identical, trying NG is usually just changing the image tag.
+
+## Image variants
+
+NG is published from the same three Docker Hub repositories as the existing compiler:
+
+| Edition | Image | Default `EDITION` |
+|---|---|---|
+| Community | `tykio/tyk-plugin-compiler:<version>-ng` | `ce` |
+| Enterprise | `tykio/tyk-plugin-compiler-ee:<version>-ng` | `ee` |
+| Enterprise + FIPS | `tykio/tyk-plugin-compiler-fips:<version>-ng` | `ee-fips` |
+
+The edition is baked into each image, together with the build tags, `GOFIPS140`/`GOEXPERIMENT` settings and the list of architectures that edition's Gateway is published for. You do not need to set `EDITION` yourself; you cannot use the CE image to produce an EE or FIPS plugin, and the build fails with an explicit message if you try.
+
+Match the image to the Gateway you will load the plugin into. An `ee` plugin will not load into a CE Gateway, and a FIPS Gateway will reject a plugin built without FIPS crypto.
+
+{{< note success >}} **Note**
+
+The DHI base used by NG is a supply-chain hardening measure. It is not in itself a FIPS compliance claim: FIPS plugin crypto comes from the FIPS Gateway's Go toolchain and the edition settings baked into the FIPS image. {{< /note >}}
+
+## Quick start
+
+Mount your plugin source at `/plugin-source` and pass the output name. The entrypoint is `/build.sh`, the working directory is `/go/src/github.com/TykTechnologies/tyk` and the container runs as root, exactly as with the existing compiler:
+
+```bash
+docker run --rm -v "$(pwd):/plugin-source" \
+  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so
+```
+
+The built plugin is moved back into `/plugin-source`, so it appears in your working directory. The output file name is `{plugin_name%.*}_{GATEWAY_VERSION}_{GOOS}_{GOARCH}.so` — for the example above, `plugin_v5.15.0_linux_amd64.so`.
+
+For Enterprise or FIPS plugins, change the repository:
+
+```bash
+docker run --rm -v "$(pwd):/plugin-source" \
+  tykio/tyk-plugin-compiler-ee:v5.15.0-alpha11-ng plugin.so
+
+docker run --rm -v "$(pwd):/plugin-source" \
+  tykio/tyk-plugin-compiler-fips:v5.15.0-alpha11-ng plugin.so
+```
+
+### Positional arguments
+
+The four positional arguments are unchanged from the existing compiler:
+
+1. `plugin_name` — the output name, for example `vendor-plugin.so`. It must be a bare file name, not a path.
+2. `plugin_id` — optional. It selects the build directory inside the container, and it is used in the generated module name when your plugin has no `go.mod`.
+3. `GOOS` — optional override.
+4. `GOARCH` — optional override.
+
+```bash
+docker run --rm -v "$(pwd):/plugin-source" \
+  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so "$(date +%s)"
+```
+
+{{< note success >}} **Note**
+
+NG never rewrites an existing plugin `go.mod` module path or the import paths in your Go sources. The existing compiler rewrites both when `plugin_id` is supplied. If your workflow relied on that rewrite to build the same plugin twice into one Gateway, set the module path in your own `go.mod` instead. {{< /note >}}
+
+### Environment variables
+
+| Variable | Effect |
+|---|---|
+| `VALIDATE` | `VALIDATE=0` skips post-build validation. Any other value (or unset) runs it. |
+| `EDITION` | `ce`, `ee` or `ee-fips`. Defaults to the edition baked into the image. `FIPS=1` is accepted as an alias for `EDITION=ee-fips`. |
+| `GOOS`, `GOARCH` | Alternative to the third and fourth positional arguments. |
+| `BUILD_TAG` | Extra build tags, appended to the `goplugin` tag and any edition tag. |
+| `GO_GET` | `GO_GET=1` runs `go get github.com/TykTechnologies/tyk@<gateway sha>` before building. |
+| `GO_TIDY` | `GO_TIDY=1` runs `go mod tidy` before building. |
+| `DEBUG` | `DEBUG=1` turns on shell tracing and prints a diff of the prepared build directory. |
+| `PLUGIN_SOURCE_PATH` | Source mount point. Defaults to `/plugin-source`. |
+| `PLUGIN_BUILD_PATH` | Build directory inside the container. Defaults to a directory derived from `plugin_name` and `plugin_id`. |
+| `PLUGIN_TRIMPATH` | Overrides the `-trimpath` setting derived from the Gateway. Only needed for old Gateway releases whose binaries do not record the flag. |
+| `PLUGIN_BUILD_METHOD` | `auto` (default), `workspace`, `replace` or `gopath`. `auto` picks a Go workspace on Go 1.18 and newer; the other methods exist for older Gateway releases. |
+
+The glibc target (`TYK_GLIBC_TARGET`) is a property of the image, not a runtime knob: each image ships exactly one sysroot set, and published NG images ship glibc 2.17. Overriding the variable at run time fails because no other sysroot is present.
+
+## Cross-compiling
+
+Pass the target as the third and fourth positional arguments:
+
+```bash
+docker run --rm -v "$(pwd):/plugin-source" \
+  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so "" linux arm64
+```
+
+or as environment variables:
+
+```bash
+docker run --rm -e GOOS=linux -e GOARCH=arm64 -v "$(pwd):/plugin-source" \
+  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so
+```
+
+Both forms produce `plugin_v5.15.0_linux_arm64.so`. `s390x` works the same way with the CE image:
+
+```bash
+docker run --rm -e GOARCH=s390x -v "$(pwd):/plugin-source" \
+  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so
+```
+
+The set of allowed target architectures is checked against the architectures the chosen edition's Gateway is published for. Asking the EE or FIPS image for `s390x` fails with a message listing the architectures that edition supports, because no such Gateway exists to load the plugin.
+
+The published compiler images themselves are `linux/amd64`. On an arm64 host (for example Apple silicon) Docker runs them through emulation, so do not rely on the host architecture to select the target — pass `GOARCH` explicitly.
+
+## Post-build validation
+
+After the build, and before the artifact is moved back to `/plugin-source`, NG inspects the produced `.so` and checks:
+
+- it is a 64-bit ELF shared object built with `-buildmode=plugin`;
+- the ELF machine type matches the requested `GOARCH`;
+- the Go toolchain recorded in the plugin matches the Gateway's Go version;
+- for `ee` and `ee-fips`, that the `ee` build tag is present;
+- for `ee-fips`, that the binary carries FIPS crypto evidence (an enabled `GOFIPS140` setting or explicit boringcrypto evidence);
+- the linked libraries — a plugin linked against musl or `libpython` is rejected, because the Gateway image provides neither;
+- the highest required `GLIBC_x.y` symbol version is not newer than the image's glibc target;
+- as a warning only, that the `github.com/TykTechnologies/tyk` revision the plugin links matches the Gateway revision.
+
+Successful checks are printed as `[ok]` lines, for example a line reporting the architecture and a line reporting `GLIBC ceiling: 2.17 <= 2.17`, and the run ends with `== validation OK: <file> ==`.
+
+### Interpreting a failure
+
+Failures are printed as `ERROR (plugin validation): ...` and stop the build with a non-zero exit code. The common ones:
+
+- **`Go toolchain mismatch: plugin=..., gateway=...`** — the plugin was built with a different Go version than the Gateway. Use the compiler image whose tag matches your Gateway release.
+- **`GOARCH mismatch: built ..., expected ...`** — the produced object is for a different architecture than requested. Check that you did not set `GOARCH` in two places at once.
+- **`plugin requires GLIBC_x.y which is NEWER than the supported target GLIBC_2.17`** — your C code (or a cgo dependency) pulled in a symbol that only exists in a newer glibc. Either avoid that function or accept that the plugin needs a newer runtime than the pinned floor.
+- **`EDITION=ee ... lacks 'ee'`** — the plugin does not carry the enterprise build tag; you are probably using the CE image for an EE Gateway.
+- **`EDITION=ee-fips but the plugin shows NO FIPS crypto`** — build with the FIPS image.
+- **`plugin links musl libc`** or **`plugin links libpython...`** — the plugin depends on a library the Gateway image does not ship, and would fail to load at runtime.
+
+Each of these would otherwise surface as an opaque `plugin was built with a different version of package ...` error when the Gateway loads the plugin. If you need the artifact regardless — for example to inspect it — rerun with `-e VALIDATE=0`.
+
+## Scanning the image for vulnerabilities
+
+NG is built on a Docker Hardened Images base, and Docker publishes affectedness decisions (VEX statements) for the packages it provisions. Those decisions are what make the difference between a raw scan and the reported result.
+
+Scanning without VEX gives 84 HIGH/CRITICAL rows across 60 distinct CVEs. Essentially all of them are in kernel headers (`linux-libc-dev`), `perl`, `busybox` and `libcurl4t64` — packages Docker has assessed as not affecting the image.
+
+With Tyk's VEX repository configured the same scan reports 0 CRITICAL and 0 HIGH.
+
+### Configuring the VEX repository
+
+Create the Trivy VEX repository configuration at `$XDG_DATA_HOME/.trivy/vex/repository.yaml`, or at `$HOME/.trivy/vex/repository.yaml` when `XDG_DATA_HOME` is not set:
+
+```yaml
+repositories:
+  - name: tyk-dhi
+    url: https://tyktechnologies.github.io/tyk-vex-records
+    enabled: true
+```
+
+Download the repository, then scan with `--vex repo`:
+
+```bash
+trivy vex repo download
+
+trivy image --scanners vuln --severity HIGH,CRITICAL \
+  --vex repo --show-suppressed \
+  tykio/tyk-plugin-compiler-ee:v5.15.0-alpha11-ng
+```
+
+{{< note success >}} **Note**
+
+Three things are easy to get wrong here:
+
+1. The `url` is the site **root**. Sub-paths such as `/tyk` or `/dhi` do not exist and return 404.
+2. If you have other VEX repositories configured, list `tyk-dhi` **first**. A repository that merely lists a package shadows lower-priority repositories for that package, even when it carries no statement for the CVE in question. This was reported upstream as `aquasecurity/trivy` discussion 11083, with a fix proposed in PR 11082.
+3. Pass `--show-suppressed`. Without it, suppressed findings disappear from the report with no indication that anything was suppressed. {{< /note >}}
+
+## Known limitations
+
+- NG images are published on alpha tags at the time of writing. They are not published for released Gateway versions.
+- The compiler images are `linux/amd64` only; on an arm64 host they run under emulation.
+- Each image ships one glibc sysroot set (2.17 in published images). There is no run-time switch to a different glibc target.
+- The edition is fixed per image. `EDITION=ee` or `EDITION=ee-fips` fails in an image that was not built for that edition.
+- `linux/s390x` is only available for the CE edition, because EE and FIPS Gateways are not published for that architecture.
+- Published NG images deliberately contain no Gateway executable. The existing compiler image installs one, which means it ships the Gateway inside a build tool; NG builds it only into unpublished gate images used by CI to prove a plugin loads, and the release build fails if the binary is present. The practical consequence is that you cannot run `tyk plugin load` inside the compiler container -- load the plugin into a Gateway container instead.
+- `plugin_id` no longer rewrites your module path or import paths (see [Positional arguments](#positional-arguments)).
+
+## Relationship to the existing plugin compiler
+
+Both compilers are maintained together. NG does not replace the existing plugin compiler, and existing users need change nothing: the existing images continue to be built and published for released Gateway versions from the same repositories and tags as before.
+
+NG is opt-in and interface-compatible. Its entrypoint, working directory, positional arguments, environment variables, source mount point and output naming are the same, so moving a build to NG is normally a tag change and moving back is the same change in reverse.
+
+NG is currently published on alpha tags only. No date has been set for it to
+become the default, and none is implied by this page. Until that decision is
+made, treat NG as available for evaluation and for builds where its
+cross-compilation, validation or hardened base are useful, and treat the
+existing compiler as the path for released Gateway versions.
+
+See `plugin-compiler-ng-migration.md` in this directory for a checklist when moving an
+existing build, including how to roll back.

--- a/docs/plugins/go-plugin-compiler-ng.md
+++ b/docs/plugins/go-plugin-compiler-ng.md
@@ -17,7 +17,7 @@ If you are new to building Go plugins, start with [Custom Go plugin development 
 
 {{< note success >}} **Note**
 
-At the time of writing, NG images are published on alpha tags only, the most recent being `v5.15.0-alpha11-ng`. The existing plugin compiler remains the image used for released Gateway versions. {{< /note >}}
+At the time of writing, NG images are published on alpha tags only, the most recent being `v5.15.0-alpha12-ng`. The existing plugin compiler remains the image used for released Gateway versions. {{< /note >}}
 
 ## What NG is and why it exists
 
@@ -26,6 +26,8 @@ A Go plugin must be built with the same toolchain, build tags and build flags as
 **A much smaller vulnerability surface.** NG is built on a Docker Hardened Image. Its toolchain is provided by Docker rather than installed at build time, and Docker publishes assessments for the packages it ships. Scanned with Tyk's published VEX feed applied, the NG image reports **0 Critical and 0 High** findings. This applies to the FIPS image too, so a FIPS build no longer means accepting a larger set of findings. See [Scanning the image](#scanning-the-image-for-vulnerabilities) to reproduce it yourself.
 
 **Builds for more architectures from one image.** A single NG image targets `linux/amd64`, `linux/arm64` and `linux/s390x`, so you no longer need a separate build path per architecture.
+
+**Runs natively on ARM64 machines.** The image is published for `linux/arm64` as well as `linux/amd64`. On Apple silicon or Graviton it runs on the host architecture instead of through emulation, so builds are quicker and behave the same as they do on an x86 machine.
 
 **Problems surface at build time, not at load time.** After a build, NG checks the plugin it produced: the architecture, Go version, edition, FIPS mode and glibc requirements. If any of them do not match what the Gateway expects, the build fails with a message explaining why, instead of the plugin failing later when the Gateway tries to load it.
 
@@ -39,6 +41,7 @@ A Go plugin must be built with the same toolchain, build tags and build flags as
 | Published for | released Gateway versions | alpha tags at the time of writing |
 | Invocation | `/build.sh <plugin_name> [plugin_id] [GOOS] [GOARCH]`, source at `/plugin-source` | identical |
 | Target architectures | `linux/amd64`, `linux/arm64` | `linux/amd64`, `linux/arm64`, `linux/s390x` (CE); `linux/amd64`, `linux/arm64` (EE and FIPS) |
+| Host architectures the image runs on | `linux/amd64` | `linux/amd64`, `linux/arm64` |
 | glibc floor of the produced plugin | follows the image's base OS | pinned by a glibc 2.17 link sysroot shipped in the image |
 | Post-build checks | none | architecture, Go version, edition tags, FIPS evidence, glibc ceiling, linked libraries |
 | `plugin_id` behaviour | rewrites the plugin `go.mod` module path and Go import paths | only names the build directory; an existing `go.mod` is never rewritten |
@@ -71,7 +74,7 @@ Mount your plugin source at `/plugin-source` and pass the output name. The entry
 
 ```bash
 docker run --rm -v "$(pwd):/plugin-source" \
-  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so
+  tykio/tyk-plugin-compiler:v5.15.0-alpha12-ng plugin.so
 ```
 
 The built plugin is moved back into `/plugin-source`, so it appears in your working directory. The output file name is `{plugin_name%.*}_{GATEWAY_VERSION}_{GOOS}_{GOARCH}.so` — for the example above, `plugin_v5.15.0_linux_amd64.so`.
@@ -80,10 +83,10 @@ For Enterprise or FIPS plugins, change the repository:
 
 ```bash
 docker run --rm -v "$(pwd):/plugin-source" \
-  tykio/tyk-plugin-compiler-ee:v5.15.0-alpha11-ng plugin.so
+  tykio/tyk-plugin-compiler-ee:v5.15.0-alpha12-ng plugin.so
 
 docker run --rm -v "$(pwd):/plugin-source" \
-  tykio/tyk-plugin-compiler-fips:v5.15.0-alpha11-ng plugin.so
+  tykio/tyk-plugin-compiler-fips:v5.15.0-alpha12-ng plugin.so
 ```
 
 ### Positional arguments
@@ -97,7 +100,7 @@ The four positional arguments are unchanged from the existing compiler:
 
 ```bash
 docker run --rm -v "$(pwd):/plugin-source" \
-  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so "$(date +%s)"
+  tykio/tyk-plugin-compiler:v5.15.0-alpha12-ng plugin.so "$(date +%s)"
 ```
 
 {{< note success >}} **Note**
@@ -128,26 +131,26 @@ Pass the target as the third and fourth positional arguments:
 
 ```bash
 docker run --rm -v "$(pwd):/plugin-source" \
-  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so "" linux arm64
+  tykio/tyk-plugin-compiler:v5.15.0-alpha12-ng plugin.so "" linux arm64
 ```
 
 or as environment variables:
 
 ```bash
 docker run --rm -e GOOS=linux -e GOARCH=arm64 -v "$(pwd):/plugin-source" \
-  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so
+  tykio/tyk-plugin-compiler:v5.15.0-alpha12-ng plugin.so
 ```
 
 Both forms produce `plugin_v5.15.0_linux_arm64.so`. `s390x` works the same way with the CE image:
 
 ```bash
 docker run --rm -e GOARCH=s390x -v "$(pwd):/plugin-source" \
-  tykio/tyk-plugin-compiler:v5.15.0-alpha11-ng plugin.so
+  tykio/tyk-plugin-compiler:v5.15.0-alpha12-ng plugin.so
 ```
 
 The set of allowed target architectures is checked against the architectures the chosen edition's Gateway is published for. Asking the EE or FIPS image for `s390x` fails with a message listing the architectures that edition supports, because no such Gateway exists to load the plugin.
 
-The published compiler images themselves are `linux/amd64`. On an arm64 host (for example Apple silicon) Docker runs them through emulation, so do not rely on the host architecture to select the target — pass `GOARCH` explicitly.
+The published compiler images run natively on both `linux/amd64` and `linux/arm64`, so on Apple silicon or Graviton the build is not emulated. The target architecture is still a separate choice from the host: set `GOARCH` explicitly whenever you want something other than the machine you are on.
 
 ## Post-build validation
 
@@ -203,7 +206,7 @@ trivy vex repo download
 
 trivy image --scanners vuln --severity HIGH,CRITICAL \
   --vex repo --show-suppressed \
-  tykio/tyk-plugin-compiler-ee:v5.15.0-alpha11-ng
+  tykio/tyk-plugin-compiler-ee:v5.15.0-alpha12-ng
 ```
 
 {{< note success >}} **Note**
@@ -222,7 +225,7 @@ Three things are easy to get wrong here:
 
 **Architecture coverage follows the Gateway.** `linux/s390x` is available for CE only, because EE and FIPS Gateways are not published for that architecture.
 
-**On Apple silicon and other ARM64 machines**, the compiler image runs through emulation. Builds work but are slower, and you should pass `GOARCH` explicitly rather than relying on the host architecture.
+**On Apple silicon and other ARM64 machines**, the compiler runs natively rather than through emulation. Set `GOARCH` explicitly when the plugin you want is for a different architecture than the machine you are building on.
 
 **Test your plugin in a Gateway container.** The NG image does not include a Gateway binary, so load and exercise your plugin in a Gateway container rather than inside the compiler.
 

--- a/docs/plugins/plugin-compiler-ng-migration.md
+++ b/docs/plugins/plugin-compiler-ng-migration.md
@@ -1,0 +1,66 @@
+---
+title: Migrating a build to the next-generation plugin compiler
+tags:
+    - custom plugin
+    - golang
+    - go plugin
+    - plugin compiler
+    - migration
+description: Checklist for moving an existing plugin build to the NG compiler image, and how to roll back
+date: "2026-08-14"
+---
+
+For someone who already builds Go plugins with `tykio/tyk-plugin-compiler` (or the `-ee` / `-fips` repositories) and wants to try the next-generation (NG) image. NG is opt-in and is maintained alongside the existing compiler; you do not have to migrate.
+
+## What changes
+
+The image tag. NG is published from the same three repositories with a `-ng` suffix:
+
+| Existing | NG |
+|---|---|
+| `tykio/tyk-plugin-compiler:<version>` | `tykio/tyk-plugin-compiler:<version>-ng` |
+| `tykio/tyk-plugin-compiler-ee:<version>` | `tykio/tyk-plugin-compiler-ee:<version>-ng` |
+| `tykio/tyk-plugin-compiler-fips:<version>` | `tykio/tyk-plugin-compiler-fips:<version>-ng` |
+
+The most recent NG release at the time of writing is `v5.15.0-alpha11-ng`.
+
+```diff
+ docker run --rm -v "$(pwd):/plugin-source" \
+-  tykio/tyk-plugin-compiler-ee:v5.15.0-alpha11 plugin.so
++  tykio/tyk-plugin-compiler-ee:v5.15.0-alpha11-ng plugin.so
+```
+
+## What does not change
+
+- Entrypoint `/build.sh` and working directory `/go/src/github.com/TykTechnologies/tyk`.
+- The container runs as root (`User: 0`).
+- Plugin source is mounted at `/plugin-source`, and the built `.so` is moved back there.
+- Positional arguments: `plugin_name`, optional `plugin_id`, optional `GOOS`, optional `GOARCH`.
+- Environment variables you already use (`GOOS`, `GOARCH`, `BUILD_TAG`, `GO_GET`, `GO_TIDY`, `DEBUG`, `PLUGIN_SOURCE_PATH`, `PLUGIN_BUILD_PATH`).
+- Output naming: `{plugin_name%.*}_{GATEWAY_VERSION}_{GOOS}_{GOARCH}.so`.
+
+## One behavioural difference to check before you switch
+
+NG never rewrites an existing plugin `go.mod` module path, and never rewrites import paths in your Go sources. The existing compiler does both when `plugin_id` is supplied. `plugin_id` in NG only names the build directory (and supplies the generated module name when your plugin has no `go.mod` at all).
+
+If you pass a `plugin_id` purely to get a unique output file name, nothing changes for you. If you relied on the module-path rewrite to load two builds of the same plugin into one Gateway, set distinct module paths in your own `go.mod` files instead.
+
+## What to check after the first NG build
+
+1. **Validation output.** NG validates the artifact before it is moved back to `/plugin-source`. Confirm the run ends with `== validation OK: <file> ==` and read the `[ok]` lines. A failure is a real incompatibility, not a compiler bug — the same problem would otherwise appear as `plugin was built with a different version of package ...` when the Gateway loads the plugin. `VALIDATE=0` skips validation if you need the artifact anyway.
+2. **glibc floor.** The validation output reports the highest required GLIBC symbol version and the ceiling it is checked against (2.17 in published NG images). If your plugin now fails this check, a cgo dependency is pulling in a symbol newer than the pinned floor; that plugin would have needed a newer runtime glibc than the pinned target.
+3. **FIPS mode.** With the FIPS image, confirm the validator reports a `FIPS:` line. `EDITION=ee-fips but the plugin shows NO FIPS crypto` means the artifact would be rejected by a FIPS Gateway.
+4. **Edition tags.** With the EE or FIPS image, confirm the `edition: 'ee' build tag present` line.
+5. **Architecture.** If you cross-compile, confirm the reported ELF machine type matches your target. Remember that the compiler image itself is `linux/amd64`, so pass `GOARCH` explicitly rather than relying on the host.
+6. **Load the plugin.** Published NG images do not contain the Gateway self-test binary, so run the `tyk plugin load` check against a Gateway container rather than inside the compiler container.
+
+## Rolling back
+
+Drop the `-ng` suffix and rerun. Nothing else in your build needs to change, and the existing compiler continues to be published for released Gateway versions:
+
+```bash
+docker run --rm -v "$(pwd):/plugin-source" \
+  tykio/tyk-plugin-compiler-ee:v5.15.0-alpha11 plugin.so
+```
+
+Rebuild the plugin after rolling back rather than reusing an NG artifact, so the plugin and the toolchain that produced it stay consistent.


### PR DESCRIPTION
# docs: document the next-generation (NG) plugin compiler

Adds `docs/plugins/go-plugin-compiler-ng.md`, a user-facing page for the next-generation plugin compiler image, plus migration notes for people moving an existing build onto it.

## What this documents

The NG plugin compiler is published from the same three Docker Hub repositories as the existing compiler, with a `-ng` suffix on the tag:

- `tykio/tyk-plugin-compiler:<version>-ng`
- `tykio/tyk-plugin-compiler-ee:<version>-ng`
- `tykio/tyk-plugin-compiler-fips:<version>-ng`

The most recent NG release at the time of writing is `v5.15.0-alpha11-ng`.

The page covers what NG is, when to use it versus the existing compiler, the CE/EE/FIPS variants, a quick start, cross-compiling to `linux/amd64`, `linux/arm64` and `linux/s390x`, the post-build validation step and how to read a validation failure, how to scan the image with Trivy using Tyk's VEX feed, known limitations, and how NG relates to the existing compiler.

## What does not change

Nothing about the existing plugin compiler. It continues to be built and published for released Gateway versions from the same repositories and tags. NG is **opt-in** and both compilers are **maintained in parallel** — this is an addition, not a replacement, and existing users need change nothing.

Invocation is drop-in identical: entrypoint `/build.sh`, working directory `/go/src/github.com/TykTechnologies/tyk`, source mounted at `/plugin-source`, and the same positional arguments (`plugin_name`, optional `plugin_id`, optional `GOOS`, optional `GOARCH`). Trying NG is normally a tag change, and rolling back is the same change in reverse.

## Docs-only change

No code, workflow or image changes are in this PR. Every command in the page was checked against the image entrypoint, working directory and `/plugin-source` mount, and the examples follow the same shape as the existing plugin compiler documentation.

## Reviewer notes

- One behavioural difference is called out in both files: NG does not rewrite an existing plugin `go.mod` module path or Go import paths when `plugin_id` is supplied; `plugin_id` only names the build directory. Please confirm the wording matches the intended contract.
- The page states that NG images are currently published on alpha tags only. This needs refreshing when NG is published for a released version.
- The Trivy VEX section documents three failure modes explicitly: the feed URL is the site root (sub-paths return 404), `tyk-dhi` must be listed first when other VEX repositories are configured (upstream `aquasecurity/trivy` discussion 11083, fix proposed in PR 11082), and `--show-suppressed` is required to see what was suppressed.

These pages live in this repository rather than `tyk-docs` deliberately. The published
compiler page is `api-management/plugins/golang.mdx` in `tyk-docs`; putting an alpha,
opt-in tool on the public site would imply a level of support that has not been
decided. Both pages are written so they can move there unchanged once it is.

Discoverability is handled inside this repository: `go-development-flow.md` gains a
note beside the paragraph that describes the `plugin_id` module rewrite, which is the
one behaviour NG changes, so a reader meets the difference where it matters.

No support statement or GA date is given. The pages say NG is published on alpha tags,
that no date has been set for it to become the default, and that none is implied.

## Related work

- gromit: TykTechnologies/gromit#517
- generated code: TykTechnologies/tyk#8379


<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17641" title="TT-17641" target="_blank">TT-17641</a>
</summary>

|         |    |
|---------|----|
| Status  | Merge |
| Summary | Supply next-generation (-ng) plugin compiler for next and LTS releases |

Generated at: 2026-08-20 15:03:46

</details>

<!---TykTechnologies/jira-linter ends here-->

