### PR TITLE
TT-18007: Make MCP filtering cache-safe

### DIFF
--- a/gateway/mcp_cache_safety_test.go
+++ b/gateway/mcp_cache_safety_test.go
@@ -1,0 +1,124 @@
+package gateway
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/internal/httpctx"
+	"github.com/TykTechnologies/tyk/internal/mcp"
+	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+type cacheReadCountingStore struct {
+	*storage.DummyStorage
+	getCalls int
+}
+
+func (s *cacheReadCountingStore) GetKey(key string) (string, error) {
+	s.getCalls++
+	return s.DummyStorage.GetKey(key)
+}
+
+func TestRedisCacheMiddleware_BypassesCredentialSpecificMCPFiltering(t *testing.T) {
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.APIID = "mcp-api"
+		spec.MarkAsMCP()
+		spec.CacheOptions.EnableCache = true
+	})[0]
+	store := &cacheReadCountingStore{DummyStorage: storage.NewDummyStorage()}
+	middleware := &RedisCacheMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec}, store: store}
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList})
+	setSessionForTest(req, &user.SessionState{AccessRights: map[string]user.AccessDefinition{
+		spec.APIID: {
+			APIID: spec.APIID,
+			MCPAccessRights: user.MCPAccessRights{
+				Tools: user.AccessControlRules{Allowed: []string{"visible"}},
+			},
+		},
+	}})
+
+	err, status := middleware.ProcessRequest(httptest.NewRecorder(), req, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Zero(t, store.getCalls)
+	assert.Nil(t, ctxGetCacheOptions(req), "bypassed reads must not arm the cache writer")
+}
+
+func TestCredentialSpecificMCPFilteringApplies(t *testing.T) {
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.APIID = "mcp-api"
+		spec.MarkAsMCP()
+	})[0]
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	session := &user.SessionState{AccessRights: map[string]user.AccessDefinition{
+		spec.APIID: {
+			APIID: spec.APIID,
+			MCPAccessRights: user.MCPAccessRights{
+				Tools: user.AccessControlRules{Blocked: []string{"secret"}},
+			},
+		},
+	}}
+
+	httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList})
+	assert.True(t, credentialSpecificMCPFilteringApplies(spec, req, session))
+
+	httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodPromptsList})
+	assert.False(t, credentialSpecificMCPFilteringApplies(spec, req, session), "unrestricted primitive types remain cacheable")
+
+	session.AccessRights[spec.APIID] = user.AccessDefinition{
+		APIID: spec.APIID,
+		JSONRPCMethodsAccessRights: user.AccessControlRules{
+			Blocked: []string{mcp.MethodToolsCall},
+		},
+	}
+	httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodInitialize})
+	assert.True(t, credentialSpecificMCPFilteringApplies(spec, req, session))
+
+	assert.False(t, credentialSpecificMCPFilteringApplies(spec, req, nil))
+
+	nonMCP := BuildAPI(func(spec *APISpec) { spec.APIID = "http-api" })[0]
+	assert.False(t, credentialSpecificMCPFilteringApplies(nonMCP, req, session))
+}
+
+func TestResponseCacheMiddleware_SkipsEditedAndStreamingMCPResponses(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		contentType    string
+		responseEdited bool
+	}{
+		{name: "credential-specific JSON", contentType: "application/json", responseEdited: true},
+		{name: "SSE", contentType: "text/event-stream", responseEdited: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store := storage.NewDummyStorage()
+			spec := BuildAPI(func(spec *APISpec) {
+				spec.APIID = "mcp-api"
+				spec.MarkAsMCP()
+				spec.CacheOptions.EnableCache = true
+			})[0]
+			middleware := &ResponseCacheMiddleware{
+				BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec},
+				store:                  store,
+			}
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			ctxSetCacheOptions(req, &cacheOptions{key: "cache-key", timeout: 60, responseEdited: tt.responseEdited})
+			res := &http.Response{
+				StatusCode:    http.StatusOK,
+				Header:        http.Header{"Content-Type": []string{tt.contentType}},
+				Body:          io.NopCloser(bytes.NewBufferString("payload")),
+				ContentLength: 7,
+			}
+
+			require.NoError(t, middleware.HandleResponse(httptest.NewRecorder(), res, req, nil))
+			assert.Empty(t, store.Data)
+		})
+	}
+}

--- a/gateway/mcp_discovery_rules.go
+++ b/gateway/mcp_discovery_rules.go
@@ -1,16 +1,42 @@
 package gateway
 
 import (
+	"net/http"
 	stdregexp "regexp"
 	"strings"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/jsonrpc"
 	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/user"
 )
 
 const oasJSONRPCMethodOperationPrefix = "json-rpc-method:"
+
+func credentialSpecificMCPFilteringApplies(spec *APISpec, req *http.Request, ses *user.SessionState) bool {
+	if spec == nil || req == nil || ses == nil || !spec.IsMCP() {
+		return false
+	}
+
+	state := httpctx.GetJSONRPCRoutingState(req)
+	if state == nil {
+		return false
+	}
+	if cfg := listConfigForMCPMethod(state.Method); cfg != nil {
+		return !sessionMCPRules(spec, ses, cfg).IsEmpty()
+	}
+	if state.Method == mcp.MethodInitialize {
+		return !sessionJSONRPCMethodRules(spec, ses).IsEmpty()
+	}
+	return false
+}
+
+func markMCPResponseEdited(req *http.Request) {
+	if options := ctxGetCacheOptions(req); options != nil {
+		options.responseEdited = true
+	}
+}
 
 func effectiveMCPListRuleSets(spec *APISpec, ses *user.SessionState, cfg *mcp.ListFilterConfig) []user.AccessControlRules {
 	ruleSets := make([]user.AccessControlRules, 0, 2)

--- a/gateway/mcp_synthetic_runtime_test.go
+++ b/gateway/mcp_synthetic_runtime_test.go
@@ -157,11 +157,29 @@ func TestRESTAsMCPToolView_RewritesToolsListForCallerProxy(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	require.Contains(t, body, "result", "response body: %s", rec.Body.String())
 	result := body["result"].(map[string]any)
+	assert.Equal(t, "private", result["cacheScope"])
+	assert.EqualValues(t, 0, result["ttlMs"])
 	tools := result["tools"].([]any)
 	require.Len(t, tools, 1)
 	tool := tools[0].(map[string]any)
 	assert.Equal(t, "orders", tool["name"])
 	assert.Equal(t, "proxy one list", tool["description"])
+}
+
+func TestRewriteMCPToolsListResponse_PreservesUnchangedBytesAndHints(t *testing.T) {
+	view := oas.MCPToolView{Tools: []oas.DerivedTool{{
+		Name:        "orders",
+		Description: "list orders",
+		InputSchema: map[string]any{"type": "object"},
+	}}}
+	tools, err := json.Marshal(view.Tools)
+	require.NoError(t, err)
+	original := []byte("{\n  \"jsonrpc\": \"2.0\", \"id\": 1, \"result\": {\"tools\": " + string(tools) + ", \"cacheScope\": \"public\", \"ttlMs\": 5000}\n}")
+
+	rewritten, changed, err := rewriteMCPToolsListResponse(original, view)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Equal(t, original, rewritten)
 }
 
 func TestWriteSyntheticMCPToolsListResponse_FailsClosedWhenRewriteFails(t *testing.T) {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -242,12 +242,7 @@ func (gw *Gateway) isDisabledForMCP(mw TykMiddleware) bool {
 		return false
 	}
 
-	switch mw.(type) {
-	case *RedisCacheMiddleware:
-		return true
-	default:
-		return false
-	}
+	return false
 }
 
 func (gw *Gateway) mwAppendEnabled(chain *[]alice.Constructor, mw TykMiddleware) bool {

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -906,7 +906,7 @@ func TestRecordAccessLog_OriginalPath(t *testing.T) {
 func TestGateway_isDisabledForMCP(t *testing.T) {
 	gw := &Gateway{}
 
-	t.Run("RedisCacheMiddleware disabled for MCP APIs", func(t *testing.T) {
+	t.Run("RedisCacheMiddleware enabled for MCP APIs with request-level safety", func(t *testing.T) {
 		mcpSpec := BuildAPI(func(spec *APISpec) {
 			spec.APIID = "mcp-test"
 			spec.MarkAsMCP()
@@ -919,7 +919,7 @@ func TestGateway_isDisabledForMCP(t *testing.T) {
 		}
 
 		result := gw.isDisabledForMCP(cacheMW)
-		assert.True(t, result, "RedisCacheMiddleware should be disabled for MCP APIs")
+		assert.False(t, result, "MCP cache safety is evaluated per request")
 	})
 
 	t.Run("RedisCacheMiddleware enabled for non-MCP APIs", func(t *testing.T) {
@@ -955,7 +955,7 @@ func TestGateway_isDisabledForMCP(t *testing.T) {
 func TestGateway_mwAppendEnabled_MCP(t *testing.T) {
 	gw := &Gateway{}
 
-	t.Run("does not append cache middleware for MCP APIs", func(t *testing.T) {
+	t.Run("appends cache middleware for MCP APIs", func(t *testing.T) {
 		mcpSpec := BuildAPI(func(spec *APISpec) {
 			spec.APIID = "mcp-test"
 			spec.CacheOptions.EnableCache = true // Even if enabled in config
@@ -971,8 +971,8 @@ func TestGateway_mwAppendEnabled_MCP(t *testing.T) {
 		var chain []alice.Constructor
 		result := gw.mwAppendEnabled(&chain, cacheMW)
 
-		assert.False(t, result, "mwAppendEnabled should return false for restricted MCP middleware")
-		assert.Empty(t, chain, "Chain should be empty - cache middleware should not be added for MCP")
+		assert.True(t, result, "cache middleware should evaluate MCP safety per request")
+		assert.Len(t, chain, 1)
 	})
 
 	t.Run("appends cache middleware for non-MCP APIs", func(t *testing.T) {

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -393,33 +394,62 @@ func (m *JSONRPCMiddleware) syntheticMCPToolViewForCaller(r *http.Request) (oas.
 func (m *JSONRPCMiddleware) writeSyntheticMCPToolsListResponse(w http.ResponseWriter, r *http.Request, rec *bufferedResponseWriter, view oas.MCPToolView, filter bool, policyCtx *restAsMCPPolicyContext) {
 	body := rec.body.Bytes()
 	if filter && rec.statusCode < http.StatusBadRequest {
-		rewritten, err := rewriteMCPToolsListResponse(body, view)
+		rewritten, changed, err := rewriteMCPToolsListResponse(body, view)
 		if err != nil {
 			m.Logger().WithError(err).Warn("failed to rewrite REST-as-MCP tools/list response")
 			m.writeJSONRPCError(w, r, nil, mcp.JSONRPCInternalError, "Internal error", nil)
 			return
 		}
 		body = rewritten
+		if changed {
+			markMCPResponseEdited(r)
+		}
 	}
 	if rec.statusCode < http.StatusBadRequest {
 		if filtered, ok := filterRESTAsMCPListResponse(body, policyCtx); ok {
 			body = filtered
+			markMCPResponseEdited(r)
 		}
 	}
 	rec.writeTo(w, body)
 }
 
-func rewriteMCPToolsListResponse(body []byte, view oas.MCPToolView) ([]byte, error) {
+func rewriteMCPToolsListResponse(body []byte, view oas.MCPToolView) ([]byte, bool, error) {
 	var envelope map[string]any
 	if err := json.Unmarshal(body, &envelope); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	result, ok := envelope["result"].(map[string]any)
 	if !ok {
-		return body, nil
+		return body, false, nil
+	}
+	currentTools, err := json.Marshal(result["tools"])
+	if err != nil {
+		return nil, false, err
+	}
+	callerTools, err := json.Marshal(view.Tools)
+	if err != nil {
+		return nil, false, err
+	}
+	if jsonBytesEqual(currentTools, callerTools) {
+		return body, false, nil
 	}
 	result["tools"] = view.Tools
-	return json.Marshal(envelope)
+	result["cacheScope"] = "private"
+	result["ttlMs"] = 0
+	rewritten, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, false, err
+	}
+	return rewritten, true, nil
+}
+
+func jsonBytesEqual(left, right []byte) bool {
+	var leftValue, rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
 }
 
 // bufferedResponseWriter is intentionally local to synthetic REST-as-MCP

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
@@ -138,6 +138,11 @@ func TestRESTAsMCPPolicy_FiltersToolsListResponseForCallerView(t *testing.T) {
 	tools := jsonRPCToolsList(t, rec.Body.Bytes())
 	assert.Equal(t, []string{"orders"}, tools)
 	assert.NotContains(t, rec.Body.String(), "make_order")
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+	result := envelope["result"].(map[string]any)
+	assert.Equal(t, "private", result["cacheScope"])
+	assert.EqualValues(t, 0, result["ttlMs"])
 }
 
 func TestRESTAsMCPPolicy_EndpointRateLimitBlocksToolCall(t *testing.T) {

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -147,11 +147,16 @@ type cacheOptions struct {
 	key                    string
 	cacheOnlyResponseCodes []int
 	timeout                int64
+	responseEdited         bool
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	t1 := time.Now()
+	if credentialSpecificMCPFilteringApplies(m.Spec, r, ctxGetSession(r)) {
+		m.Logger().Debug("Bypassing response cache for credential-specific MCP filtering")
+		return nil, http.StatusOK
+	}
 
 	var stat RequestStatus
 	var cacheKeyRegex string

--- a/gateway/res_cache.go
+++ b/gateway/res_cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/TykTechnologies/tyk/storage"
@@ -70,6 +71,14 @@ func (m *ResponseCacheMiddleware) HandleResponse(w http.ResponseWriter, res *htt
 	options := ctxGetCacheOptions(r)
 	if options == nil {
 		m.logger().Debug("Request is not cacheable")
+		return nil
+	}
+	if options.responseEdited {
+		m.logger().Debug("Response was edited for the MCP caller and is not cacheable")
+		return nil
+	}
+	if strings.HasPrefix(res.Header.Get("Content-Type"), "text/event-stream") {
+		m.logger().Debug("Streaming response is not cacheable")
 		return nil
 	}
 

--- a/gateway/res_handler_mcp_list_filter.go
+++ b/gateway/res_handler_mcp_list_filter.go
@@ -91,6 +91,7 @@ func (h *MCPListFilterResponseHandler) HandleResponse(_ http.ResponseWriter, res
 	res.Body = io.NopCloser(bytes.NewReader(newBody))
 	res.ContentLength = int64(len(newBody))
 	res.Header.Set("Content-Length", strconv.Itoa(len(newBody)))
+	markMCPResponseEdited(req)
 
 	return nil
 }

--- a/gateway/res_handler_mcp_list_filter_test.go
+++ b/gateway/res_handler_mcp_list_filter_test.go
@@ -1076,6 +1076,50 @@ func TestMCPListFilterResponseHandler_HandleResponse_ContentLengthUpdated(t *tes
 		"Content-Length header should match actual body size")
 }
 
+func TestMCPListFilterResponseHandler_CacheSafetyTracksActualEdits(t *testing.T) {
+	h := buildMCPListFilterHandler("api-1", true)
+	session := &user.SessionState{AccessRights: map[string]user.AccessDefinition{
+		"api-1": {
+			APIID: "api-1",
+			MCPAccessRights: user.MCPAccessRights{
+				Tools: user.AccessControlRules{Allowed: []string{"visible"}},
+			},
+		},
+	}}
+
+	t.Run("removed item makes result private and disables cache write", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList, ID: 1})
+		options := &cacheOptions{}
+		ctxSetCacheOptions(req, options)
+		res := makeHTTPResponse([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"visible"},{"name":"hidden"}],"nextCursor":"two","cacheScope":"public","ttlMs":5000}}`))
+
+		require.NoError(t, h.HandleResponse(httptest.NewRecorder(), res, req, session))
+		body := readResponseBody(t, res)
+		var envelope mcp.JSONRPCResponse
+		require.NoError(t, json.Unmarshal(body, &envelope))
+		var result map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(envelope.Result, &result))
+		assert.JSONEq(t, `"private"`, string(result["cacheScope"]))
+		assert.JSONEq(t, `0`, string(result["ttlMs"]))
+		assert.JSONEq(t, `"two"`, string(result["nextCursor"]))
+		assert.True(t, options.responseEdited)
+	})
+
+	t.Run("fully authorized result preserves bytes and cache hints", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList, ID: 1})
+		options := &cacheOptions{}
+		ctxSetCacheOptions(req, options)
+		original := []byte("{\n  \"jsonrpc\": \"2.0\", \"id\": 1, \"result\": {\"tools\": [{\"name\": \"visible\"}], \"cacheScope\": \"public\", \"ttlMs\": 5000}\n}")
+		res := makeHTTPResponse(original)
+
+		require.NoError(t, h.HandleResponse(httptest.NewRecorder(), res, req, session))
+		assert.Equal(t, original, readResponseBody(t, res))
+		assert.False(t, options.responseEdited)
+	})
+}
+
 func TestMCPListFilterResponseHandler_HandleResponse_WrongAPIID(t *testing.T) {
 	h := buildMCPListFilterHandler("api-1", true)
 	rw := httptest.NewRecorder()

--- a/gateway/sse_hook_mcp_list_filter_test.go
+++ b/gateway/sse_hook_mcp_list_filter_test.go
@@ -223,6 +223,12 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 
 		names := extractToolNames(t, strings.Join(modified.Data, "\n"))
 		assert.ElementsMatch(t, []string{"get_weather", "get_forecast"}, names)
+		var envelope mcp.JSONRPCResponse
+		require.NoError(t, json.Unmarshal([]byte(strings.Join(modified.Data, "\n")), &envelope))
+		var result map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(envelope.Result, &result))
+		assert.JSONEq(t, `"private"`, string(result["cacheScope"]))
+		assert.JSONEq(t, `0`, string(result["ttlMs"]))
 	})
 
 	t.Run("filters tools by denylist", func(t *testing.T) {

--- a/internal/mcp/list_filter.go
+++ b/internal/mcp/list_filter.go
@@ -117,9 +117,9 @@ func ReencodeEnvelope(envelope *JSONRPCResponse, result map[string]json.RawMessa
 }
 
 // FilterJSONRPCBody parses a JSON-RPC response body, filters the list items
-// according to the given config and rules, and returns the re-encoded body.
-// Returns (nil, false) when any parsing or marshalling step fails, signalling
-// that the caller should pass through the original body unmodified.
+// according to the given config and rules, and returns the re-encoded body only
+// when at least one item was removed. Returns (nil, false) for parse failures or
+// unchanged content, signalling that the caller must retain the original bytes.
 func FilterJSONRPCBody(body []byte, cfg *ListFilterConfig, rules user.AccessControlRules) ([]byte, bool) {
 	return FilterJSONRPCBodyWithRuleSets(body, cfg, []user.AccessControlRules{rules})
 }
@@ -147,7 +147,7 @@ func FilterJSONRPCBodyWithRuleSets(body []byte, cfg *ListFilterConfig, ruleSets 
 
 // FilterParsedJSONRPC filters items in an already-parsed JSON-RPC result and
 // re-encodes the envelope. Returns (nil, false) when the array key is missing,
-// items cannot be parsed, or re-encoding fails.
+// items cannot be parsed, no items were removed, or re-encoding fails.
 func FilterParsedJSONRPC(envelope *JSONRPCResponse, result map[string]json.RawMessage, cfg *ListFilterConfig, rules user.AccessControlRules) ([]byte, bool) {
 	return FilterParsedJSONRPCWithRuleSets(envelope, result, cfg, []user.AccessControlRules{rules})
 }
@@ -166,6 +166,11 @@ func FilterParsedJSONRPCWithRuleSets(envelope *JSONRPCResponse, result map[strin
 	}
 
 	filtered := FilterItemsWithRuleSets(items, cfg.NameField, ruleSets)
+	if len(filtered) == len(items) {
+		return nil, false
+	}
+
+	SetPrivateCacheHints(result)
 
 	newBody, err := ReencodeEnvelope(envelope, result, cfg.ArrayKey, filtered)
 	if err != nil {
@@ -173,6 +178,15 @@ func FilterParsedJSONRPCWithRuleSets(envelope *JSONRPCResponse, result map[strin
 	}
 
 	return newBody, true
+}
+
+// SetPrivateCacheHints prevents an authorization-specific MCP result from
+// being reused for a different caller. It operates on the raw result map so
+// unknown fields and pagination cursors are preserved when the envelope is
+// re-encoded.
+func SetPrivateCacheHints(result map[string]json.RawMessage) {
+	result["cacheScope"] = json.RawMessage(`"private"`)
+	result["ttlMs"] = json.RawMessage(`0`)
 }
 
 // InferListConfigFromResult determines the list type by inspecting which
@@ -247,6 +261,7 @@ func FilterInitializeCapabilitiesParsed(envelope *JSONRPCResponse, result map[st
 	if !changed {
 		return nil, false
 	}
+	SetPrivateCacheHints(result)
 
 	capabilitiesBytes, err := json.Marshal(capabilities)
 	if err != nil {

--- a/internal/mcp/list_filter_test.go
+++ b/internal/mcp/list_filter_test.go
@@ -270,6 +270,28 @@ func TestFilterItemsWithRuleSets(t *testing.T) {
 }
 
 func TestFilterJSONRPCBody(t *testing.T) {
+	t.Run("unchanged list preserves original bytes and cache hints", func(t *testing.T) {
+		body := []byte("{\n  \"jsonrpc\": \"2.0\", \"id\": 1, \"result\": {\"tools\": [{\"name\": \"allowed\"}], \"cacheScope\": \"public\", \"ttlMs\": 3000}\n}")
+		result, changed := FilterJSONRPCBody(body, ListFilterConfigs["tools"], user.AccessControlRules{Allowed: []string{"allowed"}})
+		assert.False(t, changed)
+		assert.Nil(t, result, "caller must retain the original bytes when nothing was removed")
+	})
+
+	t.Run("edited paginated list receives private zero-TTL hints", func(t *testing.T) {
+		body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed"},{"name":"secret"}],"nextCursor":"page-2","cacheScope":"public","ttlMs":3000,"extension":{"kept":true}}}`)
+		result, changed := FilterJSONRPCBody(body, ListFilterConfigs["tools"], user.AccessControlRules{Allowed: []string{"allowed"}})
+		require.True(t, changed)
+
+		var envelope JSONRPCResponse
+		require.NoError(t, json.Unmarshal(result, &envelope))
+		var responseResult map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(envelope.Result, &responseResult))
+		assert.JSONEq(t, `"private"`, string(responseResult["cacheScope"]))
+		assert.JSONEq(t, `0`, string(responseResult["ttlMs"]))
+		assert.JSONEq(t, `"page-2"`, string(responseResult["nextCursor"]))
+		assert.JSONEq(t, `{"kept":true}`, string(responseResult["extension"]))
+	})
+
 	t.Run("batch JSON-RPC array passes through (returns false)", func(t *testing.T) {
 		// JSON-RPC batch = top-level array. Not supported for filtering.
 		batch := `[{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a"}]}},{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"b"}]}}]`
@@ -339,6 +361,15 @@ func TestFilterInitializeCapabilitiesBody(t *testing.T) {
 	assert.NotContains(t, capabilities, "tools")
 	assert.Contains(t, capabilities, "resources")
 	assert.Contains(t, capabilities, "prompts")
+	assert.JSONEq(t, `"private"`, string(responseResult["cacheScope"]))
+	assert.JSONEq(t, `0`, string(responseResult["ttlMs"]))
+
+	t.Run("unchanged capabilities preserve original response", func(t *testing.T) {
+		unchangedBody := []byte("{\n\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"capabilities\":{\"tools\":{}},\"cacheScope\":\"public\",\"ttlMs\":42}}")
+		unchanged, changed := FilterInitializeCapabilitiesBody(unchangedBody, []user.AccessControlRules{{Allowed: []string{".*"}}})
+		assert.False(t, changed)
+		assert.Nil(t, unchanged)
+	})
 }
 
 func TestInferListConfigFromResult(t *testing.T) {


### PR DESCRIPTION
## Description

Makes MCP discovery/list filtering cache-safe: unchanged payloads preserve original bytes and cache hints; credential-specific edits become private with zero TTL and bypass Gateway cache reads/writes. Dashboard adds two-credential JSON/SSE/pagination isolation coverage.

## Related Issue

- [TT-18007](https://tyktech.atlassian.net/browse/TT-18007)
- [Gateway PR #8589](https://github.com/TykTechnologies/tyk/pull/8589)
- [Dashboard PR #6117](https://github.com/TykTechnologies/tyk-analytics/pull/6117)
- [Gateway branch](https://github.com/TykTechnologies/tyk/tree/TT-18007-mcp-cache-safety)
- [Dashboard branch](https://github.com/TykTechnologies/tyk-analytics/tree/TT-18007-mcp-cache-safety)

## Motivation and Context

Filtered MCP discovery is credential-specific and must never leak through shared caches.

## How This Has Been Tested

- `GOCACHE=/private/tmp/tt18006-go-cache go test ./internal/mcp/... ./internal/jsonrpc/errors -count=1` — pass on the complete Gateway stack.
- `GOCACHE=/private/tmp/tt18006-go-cache go test ./gateway -run 'TestMCP' -count=1` — pass on the complete Gateway stack.
- `python3 -m compileall -q tests/api/mcp_client.py tests/api/tests/mcp` — pass on the complete Dashboard stack.
- The documented `.venv/bin/pytest -c pytest_local.ini tests/mcp/ ...` Docker gate was not run: the release virtualenv and live Gateway/Dashboard/MCP services are unavailable locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] Documentation impact is described in the ticket; no public setting is added.
- [x] Dashboard go.mod temporarily pins the matching Gateway draft commit so the stacked tests compile against the owning implementation.
- [ ] Full release test matrix completed.


[TT-18007]: https://tyktech.atlassian.net/browse/TT-18007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ