### PR TITLE
TT-18030: Validate MCP request origins

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -18,6 +18,7 @@ import (
 	"github.com/TykTechnologies/storage/persistent/model"
 
 	"github.com/TykTechnologies/tyk/internal/event"
+	internalhttputil "github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/mcpadapter"
 
 	"github.com/TykTechnologies/tyk/internal/reflect"
@@ -697,6 +698,7 @@ type APIDefinition struct {
 	EnableProxyProtocol bool           `bson:"enable_proxy_protocol" json:"enable_proxy_protocol"`
 	JsonRpcVersion      string         `bson:"json_rpc_version,omitempty" json:"json_rpc_version,omitempty"`
 	ApplicationProtocol string         `bson:"application_protocol,omitempty" json:"application_protocol,omitempty"`
+	MCP                 *MCPConfig     `bson:"mcp,omitempty" json:"mcp,omitempty"`
 	APIID               string         `bson:"api_id" json:"api_id"`
 	OrgID               string         `bson:"org_id" json:"org_id"`
 	UseKeylessAccess    bool           `bson:"use_keyless" json:"use_keyless"`
@@ -732,39 +734,39 @@ type APIDefinition struct {
 	// CertificatePinningDisabled disables public key pinning
 	CertificatePinningDisabled bool `bson:"certificate_pinning_disabled" json:"certificate_pinning_disabled,omitempty"`
 
-	EnableJWT                            bool                   `bson:"enable_jwt" json:"enable_jwt"`
-	UseStandardAuth                      bool                   `bson:"use_standard_auth" json:"use_standard_auth"`
-	UseGoPluginAuth                      bool                   `bson:"use_go_plugin_auth" json:"use_go_plugin_auth"`       // Deprecated. Use CustomPluginAuthEnabled instead.
-	EnableCoProcessAuth                  bool                   `bson:"enable_coprocess_auth" json:"enable_coprocess_auth"` // Deprecated. Use CustomPluginAuthEnabled instead.
-	CustomPluginAuthEnabled              bool                   `bson:"custom_plugin_auth_enabled" json:"custom_plugin_auth_enabled"`
-	JWTSigningMethod                     string                 `bson:"jwt_signing_method" json:"jwt_signing_method"`
-	JWTSource                            string                 `bson:"jwt_source" json:"jwt_source"`
-	JWTJwksURIs                          []JWK                  `bson:"jwt_jwks_uris" json:"jwt_jwks_uris"`
-	JWTIdentityBaseField                 string                 `bson:"jwt_identit_base_field" json:"jwt_identity_base_field"`
-	JWTClientIDBaseField                 string                 `bson:"jwt_client_base_field" json:"jwt_client_base_field"`
-	JWTPolicyFieldName                   string                 `bson:"jwt_policy_field_name" json:"jwt_policy_field_name"`
-	JWTDefaultPolicies                   []string               `bson:"jwt_default_policies" json:"jwt_default_policies"`
-	JWTIssuedAtValidationSkew            uint64                 `bson:"jwt_issued_at_validation_skew" json:"jwt_issued_at_validation_skew"`
-	JWTExpiresAtValidationSkew           uint64                 `bson:"jwt_expires_at_validation_skew" json:"jwt_expires_at_validation_skew"`
-	JWTNotBeforeValidationSkew           uint64                 `bson:"jwt_not_before_validation_skew" json:"jwt_not_before_validation_skew"`
-	JWTSkipKid                           bool                   `bson:"jwt_skip_kid" json:"jwt_skip_kid"`
-	Scopes                               Scopes                 `bson:"scopes" json:"scopes,omitempty"`
-	IDPClientIDMappingDisabled           bool                   `bson:"idp_client_id_mapping_disabled" json:"idp_client_id_mapping_disabled"`
-	JWTScopeToPolicyMapping              map[string]string      `bson:"jwt_scope_to_policy_mapping" json:"jwt_scope_to_policy_mapping"` // Deprecated: use Scopes.JWT.ScopeToPolicy or Scopes.OIDC.ScopeToPolicy
-	JWTScopeClaimName                    string                 `bson:"jwt_scope_claim_name" json:"jwt_scope_claim_name"`               // Deprecated: use Scopes.JWT.ScopeClaimName or Scopes.OIDC.ScopeClaimName
-	NotificationsDetails                 NotificationsManager   `bson:"notifications" json:"notifications"`
-	EnableSignatureChecking              bool                   `bson:"enable_signature_checking" json:"enable_signature_checking"`
-	HmacAllowedClockSkew                 float64                `bson:"hmac_allowed_clock_skew" json:"hmac_allowed_clock_skew"`
-	HmacAllowedAlgorithms                []string               `bson:"hmac_allowed_algorithms" json:"hmac_allowed_algorithms"`
-	RequestSigning                       RequestSigningMeta     `bson:"request_signing" json:"request_signing"`
-	BaseIdentityProvidedBy               AuthTypeEnum           `bson:"base_identity_provided_by" json:"base_identity_provided_by"`
-	VersionDefinition                    VersionDefinition      `bson:"definition" json:"definition"`
-	VersionData                          VersionData            `bson:"version_data" json:"version_data"` // Deprecated. Use VersionDefinition instead.
-	UptimeTests                          UptimeTests            `bson:"uptime_tests" json:"uptime_tests"`
-	Proxy                                ProxyConfig            `bson:"proxy" json:"proxy"`
-	DisableRateLimit                     bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`
-	DisableQuota                         bool                   `bson:"disable_quota" json:"disable_quota"`
-	CustomMiddleware                     MiddlewareSection      `bson:"custom_middleware" json:"custom_middleware"`
+	EnableJWT                  bool                 `bson:"enable_jwt" json:"enable_jwt"`
+	UseStandardAuth            bool                 `bson:"use_standard_auth" json:"use_standard_auth"`
+	UseGoPluginAuth            bool                 `bson:"use_go_plugin_auth" json:"use_go_plugin_auth"`       // Deprecated. Use CustomPluginAuthEnabled instead.
+	EnableCoProcessAuth        bool                 `bson:"enable_coprocess_auth" json:"enable_coprocess_auth"` // Deprecated. Use CustomPluginAuthEnabled instead.
+	CustomPluginAuthEnabled    bool                 `bson:"custom_plugin_auth_enabled" json:"custom_plugin_auth_enabled"`
+	JWTSigningMethod           string               `bson:"jwt_signing_method" json:"jwt_signing_method"`
+	JWTSource                  string               `bson:"jwt_source" json:"jwt_source"`
+	JWTJwksURIs                []JWK                `bson:"jwt_jwks_uris" json:"jwt_jwks_uris"`
+	JWTIdentityBaseField       string               `bson:"jwt_identit_base_field" json:"jwt_identity_base_field"`
+	JWTClientIDBaseField       string               `bson:"jwt_client_base_field" json:"jwt_client_base_field"`
+	JWTPolicyFieldName         string               `bson:"jwt_policy_field_name" json:"jwt_policy_field_name"`
+	JWTDefaultPolicies         []string             `bson:"jwt_default_policies" json:"jwt_default_policies"`
+	JWTIssuedAtValidationSkew  uint64               `bson:"jwt_issued_at_validation_skew" json:"jwt_issued_at_validation_skew"`
+	JWTExpiresAtValidationSkew uint64               `bson:"jwt_expires_at_validation_skew" json:"jwt_expires_at_validation_skew"`
+	JWTNotBeforeValidationSkew uint64               `bson:"jwt_not_before_validation_skew" json:"jwt_not_before_validation_skew"`
+	JWTSkipKid                 bool                 `bson:"jwt_skip_kid" json:"jwt_skip_kid"`
+	Scopes                     Scopes               `bson:"scopes" json:"scopes,omitempty"`
+	IDPClientIDMappingDisabled bool                 `bson:"idp_client_id_mapping_disabled" json:"idp_client_id_mapping_disabled"`
+	JWTScopeToPolicyMapping    map[string]string    `bson:"jwt_scope_to_policy_mapping" json:"jwt_scope_to_policy_mapping"` // Deprecated: use Scopes.JWT.ScopeToPolicy or Scopes.OIDC.ScopeToPolicy
+	JWTScopeClaimName          string               `bson:"jwt_scope_claim_name" json:"jwt_scope_claim_name"`               // Deprecated: use Scopes.JWT.ScopeClaimName or Scopes.OIDC.ScopeClaimName
+	NotificationsDetails       NotificationsManager `bson:"notifications" json:"notifications"`
+	EnableSignatureChecking    bool                 `bson:"enable_signature_checking" json:"enable_signature_checking"`
+	HmacAllowedClockSkew       float64              `bson:"hmac_allowed_clock_skew" json:"hmac_allowed_clock_skew"`
+	HmacAllowedAlgorithms      []string             `bson:"hmac_allowed_algorithms" json:"hmac_allowed_algorithms"`
+	RequestSigning             RequestSigningMeta   `bson:"request_signing" json:"request_signing"`
+	BaseIdentityProvidedBy     AuthTypeEnum         `bson:"base_identity_provided_by" json:"base_identity_provided_by"`
+	VersionDefinition          VersionDefinition    `bson:"definition" json:"definition"`
+	VersionData                VersionData          `bson:"version_data" json:"version_data"` // Deprecated. Use VersionDefinition instead.
+	UptimeTests                UptimeTests          `bson:"uptime_tests" json:"uptime_tests"`
+	Proxy                      ProxyConfig          `bson:"proxy" json:"proxy"`
+	DisableRateLimit           bool                 `bson:"disable_rate_limit" json:"disable_rate_limit"`
+	DisableQuota               bool                 `bson:"disable_quota" json:"disable_quota"`
+	CustomMiddleware           MiddlewareSection    `bson:"custom_middleware" json:"custom_middleware"`
 	// CustomMiddlewareBundle is the bundle filename (or comma-separated list of
 	// bundle filenames) resolved against the gateway's bundle_base_url. A single
 	// name takes the legacy single-bundle load path unchanged. Two or more
@@ -845,6 +847,23 @@ type APIDefinition struct {
 	// ErrorOverrides contains the configurations for error response customization.
 	ErrorOverrides         ErrorOverridesMap `bson:"error_overrides" json:"error_overrides"`
 	ErrorOverridesDisabled bool              `bson:"error_overrides_disabled" json:"error_overrides_disabled" `
+}
+
+// MCPConfig contains request-security settings shared by Classic and OAS MCP
+// APIs.
+type MCPConfig struct {
+	// TrustedOrigins contains concrete HTTP(S) origins allowed to send MCP
+	// requests in addition to the API's own externally visible origin.
+	TrustedOrigins []string `bson:"trusted_origins,omitempty" json:"trusted_origins,omitempty"`
+}
+
+// Validate validates MCP request-security configuration.
+func (m *MCPConfig) Validate() error {
+	if m == nil {
+		return nil
+	}
+	_, err := internalhttputil.CanonicalOrigins(m.TrustedOrigins)
+	return err
 }
 
 type JWK struct {

--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -1447,6 +1447,20 @@
         "enabled"
       ]
     },
+    "X-Tyk-MCP": {
+      "type": "object",
+      "properties": {
+        "trustedOrigins": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
     "X-Tyk-Server": {
       "type": "object",
       "properties": {
@@ -1474,6 +1488,9 @@
         },
         "detailedTracing": {
           "$ref": "#/definitions/X-Tyk-DetailedTracing"
+        },
+        "mcp": {
+          "$ref": "#/definitions/X-Tyk-MCP"
         },
         "eventHandlers": {
           "type": "array",

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
+	internalhttputil "github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/oasutil"
 	"github.com/TykTechnologies/tyk/internal/reflect"
 
@@ -572,9 +573,10 @@ func (s *OAS) Validate(ctx context.Context, opts ...openapi3.ValidationOption) e
 	compliantModeErr := s.validateCompliantModeAuthentication()
 	prmErr := s.validatePRM()
 	mcpServerErr := s.validateMCPServerExtensionPlacement(false)
+	mcpOriginErr := s.validateMCPOrigins(false)
 	oauth2Err := s.ValidateOAuth2Schemes()
 
-	return errors.Join(validationErr, securityErr, compliantModeErr, prmErr, mcpServerErr, oauth2Err)
+	return errors.Join(validationErr, securityErr, compliantModeErr, prmErr, mcpServerErr, mcpOriginErr, oauth2Err)
 }
 
 // Normalize converts the OAS api to a normalized state.
@@ -771,8 +773,21 @@ func (s *OAS) ValidateForMCP(ctx context.Context, opts ...openapi3.ValidationOpt
 		prmErr = tykAuth.ProtectedResourceMetadata.Validate(true)
 	}
 	mcpServerErr := s.validateMCPServerExtensionPlacement(true)
+	mcpOriginErr := s.validateMCPOrigins(true)
 
-	return errors.Join(validationErr, securityErr, compliantModeErr, prmErr, mcpServerErr, oauth2Err)
+	return errors.Join(validationErr, securityErr, compliantModeErr, prmErr, mcpServerErr, mcpOriginErr, oauth2Err)
+}
+
+func (s *OAS) validateMCPOrigins(isMCP bool) error {
+	ext := s.GetTykExtension()
+	if ext == nil || ext.Server.MCP == nil {
+		return nil
+	}
+	if !isMCP {
+		return errors.New("server.mcp is valid only for MCP APIs")
+	}
+	_, err := internalhttputil.CanonicalOrigins(ext.Server.MCP.TrustedOrigins)
+	return err
 }
 
 // APIDef holds both OAS and Classic forms of an API definition.

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1387,6 +1387,20 @@
         "enabled"
       ]
     },
+    "X-Tyk-MCP": {
+      "type": "object",
+      "properties": {
+        "trustedOrigins": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
     "X-Tyk-Server": {
       "type": "object",
       "properties": {
@@ -1414,6 +1428,9 @@
         },
         "detailedTracing": {
           "$ref": "#/definitions/X-Tyk-DetailedTracing"
+        },
+        "mcp": {
+          "$ref": "#/definitions/X-Tyk-MCP"
         },
         "eventHandlers": {
           "type": "array",

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1446,6 +1446,21 @@
       ],
       "additionalProperties": false
     },
+    "X-Tyk-MCP": {
+      "type": "object",
+      "properties": {
+        "trustedOrigins": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "X-Tyk-Server": {
       "type": "object",
       "properties": {
@@ -1473,6 +1488,9 @@
         },
         "detailedTracing": {
           "$ref": "#/definitions/X-Tyk-DetailedTracing"
+        },
+        "mcp": {
+          "$ref": "#/definitions/X-Tyk-MCP"
         },
         "eventHandlers": {
           "type": "array",

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -34,6 +34,9 @@ type Server struct {
 	// Tyk classic API definition: `detailed_tracing`
 	DetailedTracing *DetailedTracing `bson:"detailedTracing,omitempty" json:"detailedTracing,omitempty"`
 
+	// MCP contains request-security settings for MCP APIs.
+	MCP *MCP `bson:"mcp,omitempty" json:"mcp,omitempty"`
+
 	// EventHandlers contains the configuration related to Tyk Events.
 	//
 	// Tyk classic API definition: `event_handlers`
@@ -113,6 +116,11 @@ func (s *Server) Fill(api apidef.APIDefinition) {
 		s.DetailedTracing = nil
 	}
 
+	s.MCP = nil
+	if api.MCP != nil {
+		s.MCP = &MCP{TrustedOrigins: append([]string(nil), api.MCP.TrustedOrigins...)}
+	}
+
 	if s.EventHandlers == nil {
 		s.EventHandlers = EventHandlers{}
 	}
@@ -176,6 +184,11 @@ func (s *Server) ExtractTo(api *apidef.APIDefinition) {
 
 	s.DetailedTracing.ExtractTo(api)
 
+	api.MCP = nil
+	if s.MCP != nil {
+		api.MCP = &apidef.MCPConfig{TrustedOrigins: append([]string(nil), s.MCP.TrustedOrigins...)}
+	}
+
 	if s.EventHandlers == nil {
 		s.EventHandlers = EventHandlers{}
 		defer func() {
@@ -187,6 +200,15 @@ func (s *Server) ExtractTo(api *apidef.APIDefinition) {
 
 	s.extractIPAccessControlTo(api)
 	s.extractBatchProcessingTo(api)
+}
+
+// MCP contains MCP request-security settings.
+type MCP struct {
+	// TrustedOrigins contains concrete HTTP(S) origins allowed to send MCP
+	// requests in addition to the API's own externally visible origin.
+	//
+	// Tyk classic API definition: `mcp.trusted_origins`.
+	TrustedOrigins []string `bson:"trustedOrigins,omitempty" json:"trustedOrigins,omitempty"`
 }
 
 // ListenPath is the base path on Tyk to which requests for this API

--- a/apidef/oas/server_test.go
+++ b/apidef/oas/server_test.go
@@ -10,6 +10,17 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	t.Run("MCP trusted origins round trip", func(t *testing.T) {
+		input := Server{MCP: &MCP{TrustedOrigins: []string{"https://client.example"}}}
+		var classic apidef.APIDefinition
+		input.ExtractTo(&classic)
+		assert.Equal(t, []string{"https://client.example"}, classic.MCP.TrustedOrigins)
+
+		var output Server
+		output.Fill(classic)
+		assert.Equal(t, input.MCP, output.MCP)
+	})
+
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 

--- a/apidef/oas/validate_for_mcp_test.go
+++ b/apidef/oas/validate_for_mcp_test.go
@@ -78,4 +78,21 @@ func TestValidateForMCP(t *testing.T) {
 		assert.NoError(t, o.ValidateForMCP(context.Background()))
 		assert.NoError(t, o.Validate(context.Background()))
 	})
+
+	t.Run("trusted MCP origins validate only in MCP context", func(t *testing.T) {
+		o := mkOAS(nil)
+		o.GetTykExtension().Server.MCP = &MCP{TrustedOrigins: []string{"HTTPS://CLIENT.EXAMPLE:443"}}
+		assert.NoError(t, o.ValidateForMCP(context.Background()))
+		err := o.Validate(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "server.mcp")
+	})
+
+	t.Run("invalid trusted MCP origin is rejected", func(t *testing.T) {
+		o := mkOAS(nil)
+		o.GetTykExtension().Server.MCP = &MCP{TrustedOrigins: []string{"https://*.example"}}
+		err := o.ValidateForMCP(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid origin")
+	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/TykTechnologies/storage/kv"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	internalhttputil "github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/otel"
 	logger "github.com/TykTechnologies/tyk/log"
 	"github.com/TykTechnologies/tyk/regexp"
@@ -690,12 +691,25 @@ type HttpServerOptionsConfig struct {
 	// A value of 1 means using the last IP, 2 means second to last, and so on.
 	XFFDepth int `json:"xff_depth"`
 
+	// TrustedProxyCIDRs lists the proxy networks whose Forwarded and
+	// X-Forwarded-* headers may be used to determine the request's public
+	// origin. Requests received directly, or from any other peer, ignore those
+	// headers.
+	TrustedProxyCIDRs []string `json:"trusted_proxy_cidrs"`
+
 	// MaxResponseBodySize sets an upper limit on the response body (payload) size in bytes. It defaults to 0, which means there is no restriction on the response body size.
 	//
 	// The Gateway will return `HTTP 500 Response Body Too Large` if the response payload exceeds MaxResponseBodySize+1 bytes.
 	//
 	// **Note:** The limit is applied only when the [Response Body Transform middleware](/api-management/traffic-transformation/response-body) is enabled.
 	MaxResponseBodySize int64 `json:"max_response_body_size"`
+}
+
+// ValidateTrustedProxyCIDRs validates the networks permitted to supply public
+// request-origin headers.
+func (h HttpServerOptionsConfig) ValidateTrustedProxyCIDRs() error {
+	_, err := internalhttputil.ParseTrustedProxyCIDRs(h.TrustedProxyCIDRs)
+	return err
 }
 
 type AuthOverrideConf struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -355,6 +355,17 @@ func TestCustomCertsDataDecoder(t *testing.T) {
 	assert.Equal(t, "testCerts", c.HttpServerOptions.Certificates[0].Name, "TYK_GW_HTTPSERVEROPTIONS_CERTIFICATES domain_name should be equals to testCerts")
 }
 
+func TestTrustedProxyCIDRsEnvironmentAndValidation(t *testing.T) {
+	var c Config
+	t.Setenv("TYK_GW_HTTPSERVEROPTIONS_TRUSTEDPROXYCIDRS", "10.0.0.0/8,2001:db8::/32")
+	require.NoError(t, envconfig.Process("TYK_GW", &c))
+	assert.Equal(t, []string{"10.0.0.0/8", "2001:db8::/32"}, c.HttpServerOptions.TrustedProxyCIDRs)
+	require.NoError(t, c.HttpServerOptions.ValidateTrustedProxyCIDRs())
+
+	c.HttpServerOptions.TrustedProxyCIDRs = []string{"not-a-cidr"}
+	assert.Error(t, c.HttpServerOptions.ValidateTrustedProxyCIDRs())
+}
+
 // TestSecretsDecoder tests env variable decoding for TYK_GW_SECRETS.
 // It confirms that key pairs should be provided as a comma separated
 // list of keys and values, additionally separated by `:` (colon).

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -232,6 +232,14 @@ func (s *APISpec) Validate(oasConfig config.OASConfig) error {
 			return err
 		}
 	}
+	if s.MCP != nil {
+		if !s.IsMCPManaged() {
+			return errors.New("mcp configuration is valid only for MCP APIs")
+		}
+		if err := s.MCP.Validate(); err != nil {
+			return err
+		}
+	}
 
 	// For tcp services we need to make sure we can bind to the port.
 	switch s.Protocol {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -401,6 +401,10 @@ func (gw *Gateway) processSpec(
 		logger.Info("Checking security policy: Open")
 	}
 
+	// Origin validation must run before body parsing, authentication, policy,
+	// and quota side effects for MCP traffic.
+	gw.mwAppendEnabled(&chainArray, &MCPOriginValidationMiddleware{BaseMiddleware: baseMid.Copy()})
+
 	// For MCP/JSON-RPC APIs, add RequestSizeLimitMiddleware early to prevent DoS attacks.
 	// JSONRPCMiddleware reads the entire request body, so size must be validated first.
 	if spec.IsMCP() {

--- a/gateway/mcp_cache_safety_test.go
+++ b/gateway/mcp_cache_safety_test.go
@@ -1,0 +1,124 @@
+package gateway
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/internal/httpctx"
+	"github.com/TykTechnologies/tyk/internal/mcp"
+	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+type cacheReadCountingStore struct {
+	*storage.DummyStorage
+	getCalls int
+}
+
+func (s *cacheReadCountingStore) GetKey(key string) (string, error) {
+	s.getCalls++
+	return s.DummyStorage.GetKey(key)
+}
+
+func TestRedisCacheMiddleware_BypassesCredentialSpecificMCPFiltering(t *testing.T) {
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.APIID = "mcp-api"
+		spec.MarkAsMCP()
+		spec.CacheOptions.EnableCache = true
+	})[0]
+	store := &cacheReadCountingStore{DummyStorage: storage.NewDummyStorage()}
+	middleware := &RedisCacheMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec}, store: store}
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList})
+	setSessionForTest(req, &user.SessionState{AccessRights: map[string]user.AccessDefinition{
+		spec.APIID: {
+			APIID: spec.APIID,
+			MCPAccessRights: user.MCPAccessRights{
+				Tools: user.AccessControlRules{Allowed: []string{"visible"}},
+			},
+		},
+	}})
+
+	err, status := middleware.ProcessRequest(httptest.NewRecorder(), req, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Zero(t, store.getCalls)
+	assert.Nil(t, ctxGetCacheOptions(req), "bypassed reads must not arm the cache writer")
+}
+
+func TestCredentialSpecificMCPFilteringApplies(t *testing.T) {
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.APIID = "mcp-api"
+		spec.MarkAsMCP()
+	})[0]
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	session := &user.SessionState{AccessRights: map[string]user.AccessDefinition{
+		spec.APIID: {
+			APIID: spec.APIID,
+			MCPAccessRights: user.MCPAccessRights{
+				Tools: user.AccessControlRules{Blocked: []string{"secret"}},
+			},
+		},
+	}}
+
+	httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList})
+	assert.True(t, credentialSpecificMCPFilteringApplies(spec, req, session))
+
+	httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodPromptsList})
+	assert.False(t, credentialSpecificMCPFilteringApplies(spec, req, session), "unrestricted primitive types remain cacheable")
+
+	session.AccessRights[spec.APIID] = user.AccessDefinition{
+		APIID: spec.APIID,
+		JSONRPCMethodsAccessRights: user.AccessControlRules{
+			Blocked: []string{mcp.MethodToolsCall},
+		},
+	}
+	httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodInitialize})
+	assert.True(t, credentialSpecificMCPFilteringApplies(spec, req, session))
+
+	assert.False(t, credentialSpecificMCPFilteringApplies(spec, req, nil))
+
+	nonMCP := BuildAPI(func(spec *APISpec) { spec.APIID = "http-api" })[0]
+	assert.False(t, credentialSpecificMCPFilteringApplies(nonMCP, req, session))
+}
+
+func TestResponseCacheMiddleware_SkipsEditedAndStreamingMCPResponses(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		contentType    string
+		responseEdited bool
+	}{
+		{name: "credential-specific JSON", contentType: "application/json", responseEdited: true},
+		{name: "SSE", contentType: "text/event-stream", responseEdited: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store := storage.NewDummyStorage()
+			spec := BuildAPI(func(spec *APISpec) {
+				spec.APIID = "mcp-api"
+				spec.MarkAsMCP()
+				spec.CacheOptions.EnableCache = true
+			})[0]
+			middleware := &ResponseCacheMiddleware{
+				BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec},
+				store:                  store,
+			}
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			ctxSetCacheOptions(req, &cacheOptions{key: "cache-key", timeout: 60, responseEdited: tt.responseEdited})
+			res := &http.Response{
+				StatusCode:    http.StatusOK,
+				Header:        http.Header{"Content-Type": []string{tt.contentType}},
+				Body:          io.NopCloser(bytes.NewBufferString("payload")),
+				ContentLength: 7,
+			}
+
+			require.NoError(t, middleware.HandleResponse(httptest.NewRecorder(), res, req, nil))
+			assert.Empty(t, store.Data)
+		})
+	}
+}

--- a/gateway/mcp_discovery_rules.go
+++ b/gateway/mcp_discovery_rules.go
@@ -1,16 +1,42 @@
 package gateway
 
 import (
+	"net/http"
 	stdregexp "regexp"
 	"strings"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/jsonrpc"
 	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/user"
 )
 
 const oasJSONRPCMethodOperationPrefix = "json-rpc-method:"
+
+func credentialSpecificMCPFilteringApplies(spec *APISpec, req *http.Request, ses *user.SessionState) bool {
+	if spec == nil || req == nil || ses == nil || !spec.IsMCP() {
+		return false
+	}
+
+	state := httpctx.GetJSONRPCRoutingState(req)
+	if state == nil {
+		return false
+	}
+	if cfg := listConfigForMCPMethod(state.Method); cfg != nil {
+		return !sessionMCPRules(spec, ses, cfg).IsEmpty()
+	}
+	if state.Method == mcp.MethodInitialize {
+		return !sessionJSONRPCMethodRules(spec, ses).IsEmpty()
+	}
+	return false
+}
+
+func markMCPResponseEdited(req *http.Request) {
+	if options := ctxGetCacheOptions(req); options != nil {
+		options.responseEdited = true
+	}
+}
 
 func effectiveMCPListRuleSets(spec *APISpec, ses *user.SessionState, cfg *mcp.ListFilterConfig) []user.AccessControlRules {
 	ruleSets := make([]user.AccessControlRules, 0, 2)

--- a/gateway/mcp_synthetic_runtime_test.go
+++ b/gateway/mcp_synthetic_runtime_test.go
@@ -157,11 +157,29 @@ func TestRESTAsMCPToolView_RewritesToolsListForCallerProxy(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	require.Contains(t, body, "result", "response body: %s", rec.Body.String())
 	result := body["result"].(map[string]any)
+	assert.Equal(t, "private", result["cacheScope"])
+	assert.EqualValues(t, 0, result["ttlMs"])
 	tools := result["tools"].([]any)
 	require.Len(t, tools, 1)
 	tool := tools[0].(map[string]any)
 	assert.Equal(t, "orders", tool["name"])
 	assert.Equal(t, "proxy one list", tool["description"])
+}
+
+func TestRewriteMCPToolsListResponse_PreservesUnchangedBytesAndHints(t *testing.T) {
+	view := oas.MCPToolView{Tools: []oas.DerivedTool{{
+		Name:        "orders",
+		Description: "list orders",
+		InputSchema: map[string]any{"type": "object"},
+	}}}
+	tools, err := json.Marshal(view.Tools)
+	require.NoError(t, err)
+	original := []byte("{\n  \"jsonrpc\": \"2.0\", \"id\": 1, \"result\": {\"tools\": " + string(tools) + ", \"cacheScope\": \"public\", \"ttlMs\": 5000}\n}")
+
+	rewritten, changed, err := rewriteMCPToolsListResponse(original, view)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Equal(t, original, rewritten)
 }
 
 func TestWriteSyntheticMCPToolsListResponse_FailsClosedWhenRewriteFails(t *testing.T) {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -242,12 +242,7 @@ func (gw *Gateway) isDisabledForMCP(mw TykMiddleware) bool {
 		return false
 	}
 
-	switch mw.(type) {
-	case *RedisCacheMiddleware:
-		return true
-	default:
-		return false
-	}
+	return false
 }
 
 func (gw *Gateway) mwAppendEnabled(chain *[]alice.Constructor, mw TykMiddleware) bool {

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -906,7 +906,7 @@ func TestRecordAccessLog_OriginalPath(t *testing.T) {
 func TestGateway_isDisabledForMCP(t *testing.T) {
 	gw := &Gateway{}
 
-	t.Run("RedisCacheMiddleware disabled for MCP APIs", func(t *testing.T) {
+	t.Run("RedisCacheMiddleware enabled for MCP APIs with request-level safety", func(t *testing.T) {
 		mcpSpec := BuildAPI(func(spec *APISpec) {
 			spec.APIID = "mcp-test"
 			spec.MarkAsMCP()
@@ -919,7 +919,7 @@ func TestGateway_isDisabledForMCP(t *testing.T) {
 		}
 
 		result := gw.isDisabledForMCP(cacheMW)
-		assert.True(t, result, "RedisCacheMiddleware should be disabled for MCP APIs")
+		assert.False(t, result, "MCP cache safety is evaluated per request")
 	})
 
 	t.Run("RedisCacheMiddleware enabled for non-MCP APIs", func(t *testing.T) {
@@ -955,7 +955,7 @@ func TestGateway_isDisabledForMCP(t *testing.T) {
 func TestGateway_mwAppendEnabled_MCP(t *testing.T) {
 	gw := &Gateway{}
 
-	t.Run("does not append cache middleware for MCP APIs", func(t *testing.T) {
+	t.Run("appends cache middleware for MCP APIs", func(t *testing.T) {
 		mcpSpec := BuildAPI(func(spec *APISpec) {
 			spec.APIID = "mcp-test"
 			spec.CacheOptions.EnableCache = true // Even if enabled in config
@@ -971,8 +971,8 @@ func TestGateway_mwAppendEnabled_MCP(t *testing.T) {
 		var chain []alice.Constructor
 		result := gw.mwAppendEnabled(&chain, cacheMW)
 
-		assert.False(t, result, "mwAppendEnabled should return false for restricted MCP middleware")
-		assert.Empty(t, chain, "Chain should be empty - cache middleware should not be added for MCP")
+		assert.True(t, result, "cache middleware should evaluate MCP safety per request")
+		assert.Len(t, chain, 1)
 	})
 
 	t.Run("appends cache middleware for non-MCP APIs", func(t *testing.T) {

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strings"
 	"sync"
@@ -115,6 +116,13 @@ type APISpec struct {
 	// compiledErrorOverrides holds the indexed error override rules for O(1) lookup.
 	// Built from apidef.ErrorOverrides during gateway startup.
 	compiledErrorOverrides atomic.Pointer[CompiledErrorOverrides]
+
+	// MCP origin-security configuration is immutable for a loaded spec. Parse it
+	// once and retain the canonical origins/proxy networks off the request path.
+	mcpOriginConfigOnce     sync.Once
+	mcpTrustedOrigins       map[string]struct{}
+	mcpTrustedProxyPrefixes []netip.Prefix
+	mcpOriginConfigErr      error
 }
 
 // MCPAdapterRuntime groups runtime-only state for a synthetic REST-as-MCP

--- a/gateway/model_apispec_test.go
+++ b/gateway/model_apispec_test.go
@@ -203,3 +203,22 @@ func TestAPISpecValidate_AllowsMCPServerExtensionOnPairedProxy(t *testing.T) {
 	require.True(t, spec.IsMCPManaged())
 	require.NoError(t, spec.Validate(config.OASConfig{}))
 }
+
+func TestAPISpecValidate_ClassicMCPTrustedOrigins(t *testing.T) {
+	valid := &APISpec{APIDefinition: &apidef.APIDefinition{
+		ApplicationProtocol: apidef.AppProtocolMCP,
+		MCP:                 &apidef.MCPConfig{TrustedOrigins: []string{"https://client.example"}},
+	}}
+	require.NoError(t, valid.Validate(config.OASConfig{}))
+
+	invalid := &APISpec{APIDefinition: &apidef.APIDefinition{
+		ApplicationProtocol: apidef.AppProtocolMCP,
+		MCP:                 &apidef.MCPConfig{TrustedOrigins: []string{"null"}},
+	}}
+	assert.Error(t, invalid.Validate(config.OASConfig{}))
+
+	nonMCP := &APISpec{APIDefinition: &apidef.APIDefinition{
+		MCP: &apidef.MCPConfig{TrustedOrigins: []string{"https://client.example"}},
+	}}
+	assert.Error(t, nonMCP.Validate(config.OASConfig{}))
+}

--- a/gateway/mw_jsonrpc.go
+++ b/gateway/mw_jsonrpc.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -393,33 +394,62 @@ func (m *JSONRPCMiddleware) syntheticMCPToolViewForCaller(r *http.Request) (oas.
 func (m *JSONRPCMiddleware) writeSyntheticMCPToolsListResponse(w http.ResponseWriter, r *http.Request, rec *bufferedResponseWriter, view oas.MCPToolView, filter bool, policyCtx *restAsMCPPolicyContext) {
 	body := rec.body.Bytes()
 	if filter && rec.statusCode < http.StatusBadRequest {
-		rewritten, err := rewriteMCPToolsListResponse(body, view)
+		rewritten, changed, err := rewriteMCPToolsListResponse(body, view)
 		if err != nil {
 			m.Logger().WithError(err).Warn("failed to rewrite REST-as-MCP tools/list response")
 			m.writeJSONRPCError(w, r, nil, mcp.JSONRPCInternalError, "Internal error", nil)
 			return
 		}
 		body = rewritten
+		if changed {
+			markMCPResponseEdited(r)
+		}
 	}
 	if rec.statusCode < http.StatusBadRequest {
 		if filtered, ok := filterRESTAsMCPListResponse(body, policyCtx); ok {
 			body = filtered
+			markMCPResponseEdited(r)
 		}
 	}
 	rec.writeTo(w, body)
 }
 
-func rewriteMCPToolsListResponse(body []byte, view oas.MCPToolView) ([]byte, error) {
+func rewriteMCPToolsListResponse(body []byte, view oas.MCPToolView) ([]byte, bool, error) {
 	var envelope map[string]any
 	if err := json.Unmarshal(body, &envelope); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	result, ok := envelope["result"].(map[string]any)
 	if !ok {
-		return body, nil
+		return body, false, nil
+	}
+	currentTools, err := json.Marshal(result["tools"])
+	if err != nil {
+		return nil, false, err
+	}
+	callerTools, err := json.Marshal(view.Tools)
+	if err != nil {
+		return nil, false, err
+	}
+	if jsonBytesEqual(currentTools, callerTools) {
+		return body, false, nil
 	}
 	result["tools"] = view.Tools
-	return json.Marshal(envelope)
+	result["cacheScope"] = "private"
+	result["ttlMs"] = 0
+	rewritten, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, false, err
+	}
+	return rewritten, true, nil
+}
+
+func jsonBytesEqual(left, right []byte) bool {
+	var leftValue, rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
 }
 
 // bufferedResponseWriter is intentionally local to synthetic REST-as-MCP

--- a/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
+++ b/gateway/mw_jsonrpc_rest_as_mcp_policy_test.go
@@ -138,6 +138,11 @@ func TestRESTAsMCPPolicy_FiltersToolsListResponseForCallerView(t *testing.T) {
 	tools := jsonRPCToolsList(t, rec.Body.Bytes())
 	assert.Equal(t, []string{"orders"}, tools)
 	assert.NotContains(t, rec.Body.String(), "make_order")
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+	result := envelope["result"].(map[string]any)
+	assert.Equal(t, "private", result["cacheScope"])
+	assert.EqualValues(t, 0, result["ttlMs"])
 }
 
 func TestRESTAsMCPPolicy_EndpointRateLimitBlocksToolCall(t *testing.T) {

--- a/gateway/mw_mcp_origin_validation.go
+++ b/gateway/mw_mcp_origin_validation.go
@@ -1,0 +1,76 @@
+package gateway
+
+import (
+	"net/http"
+
+	internalhttputil "github.com/TykTechnologies/tyk/internal/httputil"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+)
+
+// MCPOriginValidationMiddleware protects MCP endpoints from DNS rebinding and
+// cross-origin browser requests before request bodies, credentials, policies,
+// or quotas are processed.
+type MCPOriginValidationMiddleware struct {
+	*BaseMiddleware
+}
+
+func (m *MCPOriginValidationMiddleware) Name() string {
+	return "MCPOriginValidationMiddleware"
+}
+
+func (m *MCPOriginValidationMiddleware) EnabledForSpec() bool {
+	return m.Spec.IsMCPManaged()
+}
+
+// ProcessRequest allows requests without Origin, the API's own public origin,
+// and explicitly trusted origins. Invalid origins receive a plain HTTP 403.
+//
+//nolint:staticcheck // middleware interface requires the status return value
+func (m *MCPOriginValidationMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	originHeaders := r.Header.Values("Origin")
+	if len(originHeaders) == 0 {
+		return nil, http.StatusOK
+	}
+	if len(originHeaders) != 1 {
+		return rejectMCPOrigin(w)
+	}
+
+	origin, err := internalhttputil.CanonicalOrigin(originHeaders[0])
+	if err != nil {
+		return rejectMCPOrigin(w)
+	}
+	external, err := externalOriginForSpec(r, m.Spec)
+	if err != nil {
+		return rejectMCPOrigin(w)
+	}
+	if origin == external {
+		return nil, http.StatusOK
+	}
+
+	if m.Spec.MCP != nil {
+		trusted, canonicalErr := internalhttputil.CanonicalOrigins(m.Spec.MCP.TrustedOrigins)
+		if canonicalErr != nil {
+			return rejectMCPOrigin(w)
+		}
+		for _, allowed := range trusted {
+			if origin == allowed {
+				return nil, http.StatusOK
+			}
+		}
+	}
+
+	return rejectMCPOrigin(w)
+}
+
+func externalOriginForSpec(r *http.Request, spec *APISpec) (string, error) {
+	var trustedProxyCIDRs []string
+	if spec != nil {
+		trustedProxyCIDRs = spec.GlobalConfig.HttpServerOptions.TrustedProxyCIDRs
+	}
+	return internalhttputil.ExternalOrigin(r, trustedProxyCIDRs)
+}
+
+func rejectMCPOrigin(w http.ResponseWriter) (error, int) {
+	http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+	return nil, middleware.StatusRespond
+}

--- a/gateway/mw_mcp_origin_validation.go
+++ b/gateway/mw_mcp_origin_validation.go
@@ -47,15 +47,12 @@ func (m *MCPOriginValidationMiddleware) ProcessRequest(w http.ResponseWriter, r 
 		return nil, http.StatusOK
 	}
 
-	if m.Spec.MCP != nil {
-		trusted, canonicalErr := internalhttputil.CanonicalOrigins(m.Spec.MCP.TrustedOrigins)
-		if canonicalErr != nil {
+	if m.Spec != nil {
+		if configErr := m.Spec.prepareMCPOriginConfig(); configErr != nil {
 			return rejectMCPOrigin(w)
 		}
-		for _, allowed := range trusted {
-			if origin == allowed {
-				return nil, http.StatusOK
-			}
+		if _, allowed := m.Spec.mcpTrustedOrigins[origin]; allowed {
+			return nil, http.StatusOK
 		}
 	}
 
@@ -63,11 +60,36 @@ func (m *MCPOriginValidationMiddleware) ProcessRequest(w http.ResponseWriter, r 
 }
 
 func externalOriginForSpec(r *http.Request, spec *APISpec) (string, error) {
-	var trustedProxyCIDRs []string
-	if spec != nil {
-		trustedProxyCIDRs = spec.GlobalConfig.HttpServerOptions.TrustedProxyCIDRs
+	if spec == nil {
+		return internalhttputil.ExternalOriginWithTrustedProxies(r, nil)
 	}
-	return internalhttputil.ExternalOrigin(r, trustedProxyCIDRs)
+	if err := spec.prepareMCPOriginConfig(); err != nil {
+		return "", err
+	}
+	return internalhttputil.ExternalOriginWithTrustedProxies(r, spec.mcpTrustedProxyPrefixes)
+}
+
+func (spec *APISpec) prepareMCPOriginConfig() error {
+	spec.mcpOriginConfigOnce.Do(func() {
+		var configuredOrigins []string
+		if spec.MCP != nil {
+			configuredOrigins = spec.MCP.TrustedOrigins
+		}
+		origins, err := internalhttputil.CanonicalOrigins(configuredOrigins)
+		if err != nil {
+			spec.mcpOriginConfigErr = err
+			return
+		}
+		spec.mcpTrustedOrigins = make(map[string]struct{}, len(origins))
+		for _, origin := range origins {
+			spec.mcpTrustedOrigins[origin] = struct{}{}
+		}
+
+		spec.mcpTrustedProxyPrefixes, spec.mcpOriginConfigErr = internalhttputil.ParseTrustedProxyCIDRs(
+			spec.GlobalConfig.HttpServerOptions.TrustedProxyCIDRs,
+		)
+	})
+	return spec.mcpOriginConfigErr
 }
 
 func rejectMCPOrigin(w http.ResponseWriter) (error, int) {

--- a/gateway/mw_mcp_origin_validation_test.go
+++ b/gateway/mw_mcp_origin_validation_test.go
@@ -1,0 +1,78 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+)
+
+func TestMCPOriginValidationMiddleware(t *testing.T) {
+	t.Parallel()
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			ApplicationProtocol: apidef.AppProtocolMCP,
+			MCP: &apidef.MCPConfig{TrustedOrigins: []string{
+				"https://TRUSTED.example:443",
+			}},
+		},
+		GlobalConfig: config.Config{HttpServerOptions: config.HttpServerOptionsConfig{
+			TrustedProxyCIDRs: []string{"10.0.0.0/8"},
+		}},
+	}
+	mw := &MCPOriginValidationMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec}}
+
+	tests := []struct {
+		name       string
+		origin     string
+		forwarded  string
+		remoteAddr string
+		wantStatus int
+	}{
+		{name: "absent", wantStatus: http.StatusOK},
+		{name: "same direct", origin: "http://gateway.example", wantStatus: http.StatusOK},
+		{name: "canonical same direct", origin: "HTTP://GATEWAY.EXAMPLE:80", wantStatus: http.StatusOK},
+		{name: "explicit trusted", origin: "https://trusted.example", wantStatus: http.StatusOK},
+		{name: "same forwarded from trusted peer", origin: "https://public.example", forwarded: "for=192.0.2.1;proto=https;host=public.example", remoteAddr: "10.0.0.2:80", wantStatus: http.StatusOK},
+		{name: "spoofed forwarded from untrusted peer", origin: "https://public.example", forwarded: "for=192.0.2.1;proto=https;host=public.example", remoteAddr: "192.0.2.2:80", wantStatus: http.StatusForbidden},
+		{name: "untrusted", origin: "https://evil.example", wantStatus: http.StatusForbidden},
+		{name: "null", origin: "null", wantStatus: http.StatusForbidden},
+		{name: "wildcard", origin: "https://*.example", wantStatus: http.StatusForbidden},
+		{name: "malformed", origin: "://bad", wantStatus: http.StatusForbidden},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://gateway.example/mcp", nil)
+			if test.origin != "" {
+				req.Header.Set("Origin", test.origin)
+			}
+			if test.forwarded != "" {
+				req.Header.Set("Forwarded", test.forwarded)
+			}
+			if test.remoteAddr != "" {
+				req.RemoteAddr = test.remoteAddr
+			}
+			rec := httptest.NewRecorder()
+
+			err, status := mw.ProcessRequest(rec, req, nil)
+			require.NoError(t, err)
+			if test.wantStatus == http.StatusForbidden {
+				assert.Equal(t, middleware.StatusRespond, status)
+				assert.Equal(t, http.StatusForbidden, rec.Code)
+				assert.Equal(t, "Forbidden\n", rec.Body.String())
+				assert.Equal(t, "text/plain; charset=utf-8", rec.Header().Get("Content-Type"))
+				return
+			}
+			assert.Equal(t, http.StatusOK, status)
+			assert.Empty(t, rec.Body.String())
+		})
+	}
+}

--- a/gateway/mw_mcp_origin_validation_test.go
+++ b/gateway/mw_mcp_origin_validation_test.go
@@ -76,3 +76,39 @@ func TestMCPOriginValidationMiddleware(t *testing.T) {
 		})
 	}
 }
+
+func TestMCPOriginValidationPreparesImmutableConfigOnce(t *testing.T) {
+	t.Parallel()
+
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			ApplicationProtocol: apidef.AppProtocolMCP,
+			MCP:                 &apidef.MCPConfig{TrustedOrigins: []string{"HTTPS://CLIENT.EXAMPLE:443"}},
+		},
+		GlobalConfig: config.Config{HttpServerOptions: config.HttpServerOptionsConfig{
+			TrustedProxyCIDRs: []string{"10.0.0.0/8"},
+		}},
+	}
+	require.NoError(t, spec.prepareMCPOriginConfig())
+	assert.Contains(t, spec.mcpTrustedOrigins, "https://client.example")
+	require.Len(t, spec.mcpTrustedProxyPrefixes, 1)
+
+	// Loaded API specs are immutable. Corrupting the source slices after
+	// preparation proves subsequent requests use the parsed runtime cache.
+	spec.MCP.TrustedOrigins[0] = "null"
+	spec.GlobalConfig.HttpServerOptions.TrustedProxyCIDRs[0] = "not-a-cidr"
+	require.NoError(t, spec.prepareMCPOriginConfig())
+
+	req := httptest.NewRequest(http.MethodPost, "http://internal.example/mcp", nil)
+	req.RemoteAddr = "10.0.0.2:80"
+	req.Header.Set("Forwarded", "for=192.0.2.1;proto=https;host=public.example")
+	external, err := externalOriginForSpec(req, spec)
+	require.NoError(t, err)
+	assert.Equal(t, "https://public.example", external)
+
+	mw := &MCPOriginValidationMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec}}
+	req.Header.Set("Origin", "https://client.example")
+	err, status := mw.ProcessRequest(httptest.NewRecorder(), req, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+}

--- a/gateway/mw_protected_resource.go
+++ b/gateway/mw_protected_resource.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/header"
-	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/internal/middleware"
 )
@@ -197,12 +196,15 @@ func (gw *Gateway) upstreamPRMDoc(ctx context.Context, spec *APISpec) (*mcp.PRMD
 // scheme + host + the API's listen path. Used as the rewritten `resource`
 // field so RFC 9728 §3.3 origin validation passes.
 func gatewayResourceURL(r *http.Request, spec *APISpec) string {
-	scheme := httputil.RequestScheme(r)
+	origin, err := externalOriginForSpec(r, spec)
+	if err != nil {
+		return ""
+	}
 	listen := spec.Proxy.ListenPath
 	if !strings.HasSuffix(listen, "/") {
 		listen += "/"
 	}
-	return fmt.Sprintf("%s://%s%s", scheme, r.Host, listen)
+	return origin + listen
 }
 
 // prmWellKnownPath returns the full well-known path for the PRM endpoint,
@@ -235,7 +237,11 @@ func prmMetadataURL(r *http.Request, spec *APISpec) string {
 	} else {
 		return ""
 	}
-	return fmt.Sprintf("%s://%s%s", httputil.RequestScheme(r), r.Host, wellKnown)
+	origin, err := externalOriginForSpec(r, spec)
+	if err != nil {
+		return ""
+	}
+	return origin + wellKnown
 }
 
 // setPRMWWWAuthenticateHeader sets the WWW-Authenticate header with a Bearer challenge

--- a/gateway/mw_protected_resource_test.go
+++ b/gateway/mw_protected_resource_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/test"
 )
@@ -568,6 +569,9 @@ func TestPRMWWWAuthenticateHeader(t *testing.T) {
 					ListenPath: "/test-api/",
 				},
 			},
+			GlobalConfig: config.Config{HttpServerOptions: config.HttpServerOptionsConfig{
+				TrustedProxyCIDRs: []string{"192.0.2.0/24"},
+			}},
 		}
 		spec.OAS.SetTykExtension(&oas.XTykAPIGateway{
 			Server: oas.Server{

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -147,11 +147,16 @@ type cacheOptions struct {
 	key                    string
 	cacheOnlyResponseCodes []int
 	timeout                int64
+	responseEdited         bool
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	t1 := time.Now()
+	if credentialSpecificMCPFilteringApplies(m.Spec, r, ctxGetSession(r)) {
+		m.Logger().Debug("Bypassing response cache for credential-specific MCP filtering")
+		return nil, http.StatusOK
+	}
 
 	var stat RequestStatus
 	var cacheKeyRegex string

--- a/gateway/res_cache.go
+++ b/gateway/res_cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/TykTechnologies/tyk/storage"
@@ -70,6 +71,14 @@ func (m *ResponseCacheMiddleware) HandleResponse(w http.ResponseWriter, res *htt
 	options := ctxGetCacheOptions(r)
 	if options == nil {
 		m.logger().Debug("Request is not cacheable")
+		return nil
+	}
+	if options.responseEdited {
+		m.logger().Debug("Response was edited for the MCP caller and is not cacheable")
+		return nil
+	}
+	if strings.HasPrefix(res.Header.Get("Content-Type"), "text/event-stream") {
+		m.logger().Debug("Streaming response is not cacheable")
 		return nil
 	}
 

--- a/gateway/res_handler_mcp_list_filter.go
+++ b/gateway/res_handler_mcp_list_filter.go
@@ -91,6 +91,7 @@ func (h *MCPListFilterResponseHandler) HandleResponse(_ http.ResponseWriter, res
 	res.Body = io.NopCloser(bytes.NewReader(newBody))
 	res.ContentLength = int64(len(newBody))
 	res.Header.Set("Content-Length", strconv.Itoa(len(newBody)))
+	markMCPResponseEdited(req)
 
 	return nil
 }

--- a/gateway/res_handler_mcp_list_filter_test.go
+++ b/gateway/res_handler_mcp_list_filter_test.go
@@ -814,7 +814,7 @@ func TestMCPListFilterResponseHandler_HandleResponse_InitializeCapabilitiesFilte
 				"api-1": {
 					APIID: "api-1",
 					JSONRPCMethodsAccessRights: user.AccessControlRules{
-						Blocked: []string{mcp.MethodSamplingCreate},
+						Blocked: []string{mcp.MethodSamplingCreateMessage},
 					},
 				},
 			},

--- a/gateway/res_handler_mcp_list_filter_test.go
+++ b/gateway/res_handler_mcp_list_filter_test.go
@@ -1076,6 +1076,50 @@ func TestMCPListFilterResponseHandler_HandleResponse_ContentLengthUpdated(t *tes
 		"Content-Length header should match actual body size")
 }
 
+func TestMCPListFilterResponseHandler_CacheSafetyTracksActualEdits(t *testing.T) {
+	h := buildMCPListFilterHandler("api-1", true)
+	session := &user.SessionState{AccessRights: map[string]user.AccessDefinition{
+		"api-1": {
+			APIID: "api-1",
+			MCPAccessRights: user.MCPAccessRights{
+				Tools: user.AccessControlRules{Allowed: []string{"visible"}},
+			},
+		},
+	}}
+
+	t.Run("removed item makes result private and disables cache write", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList, ID: 1})
+		options := &cacheOptions{}
+		ctxSetCacheOptions(req, options)
+		res := makeHTTPResponse([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"visible"},{"name":"hidden"}],"nextCursor":"two","cacheScope":"public","ttlMs":5000}}`))
+
+		require.NoError(t, h.HandleResponse(httptest.NewRecorder(), res, req, session))
+		body := readResponseBody(t, res)
+		var envelope mcp.JSONRPCResponse
+		require.NoError(t, json.Unmarshal(body, &envelope))
+		var result map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(envelope.Result, &result))
+		assert.JSONEq(t, `"private"`, string(result["cacheScope"]))
+		assert.JSONEq(t, `0`, string(result["ttlMs"]))
+		assert.JSONEq(t, `"two"`, string(result["nextCursor"]))
+		assert.True(t, options.responseEdited)
+	})
+
+	t.Run("fully authorized result preserves bytes and cache hints", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{Method: mcp.MethodToolsList, ID: 1})
+		options := &cacheOptions{}
+		ctxSetCacheOptions(req, options)
+		original := []byte("{\n  \"jsonrpc\": \"2.0\", \"id\": 1, \"result\": {\"tools\": [{\"name\": \"visible\"}], \"cacheScope\": \"public\", \"ttlMs\": 5000}\n}")
+		res := makeHTTPResponse(original)
+
+		require.NoError(t, h.HandleResponse(httptest.NewRecorder(), res, req, session))
+		assert.Equal(t, original, readResponseBody(t, res))
+		assert.False(t, options.responseEdited)
+	})
+}
+
 func TestMCPListFilterResponseHandler_HandleResponse_WrongAPIID(t *testing.T) {
 	h := buildMCPListFilterHandler("api-1", true)
 	rw := httptest.NewRecorder()

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1664,6 +1664,9 @@ func (gw *Gateway) initSystem() error {
 	defer globalMu.Unlock()
 
 	gwConfig := gw.GetConfig()
+	if err := gwConfig.HttpServerOptions.ValidateTrustedProxyCIDRs(); err != nil {
+		return fmt.Errorf("invalid http_server_options.trusted_proxy_cidrs: %w", err)
+	}
 
 	// Initialize the appropriate log formatter
 	if !gw.isRunningTests() && os.Getenv("TYK_LOGFORMAT") == "" && !*cli.DebugMode {

--- a/gateway/sse_hook_mcp_list_filter_test.go
+++ b/gateway/sse_hook_mcp_list_filter_test.go
@@ -223,6 +223,12 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 
 		names := extractToolNames(t, strings.Join(modified.Data, "\n"))
 		assert.ElementsMatch(t, []string{"get_weather", "get_forecast"}, names)
+		var envelope mcp.JSONRPCResponse
+		require.NoError(t, json.Unmarshal([]byte(strings.Join(modified.Data, "\n")), &envelope))
+		var result map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(envelope.Result, &result))
+		assert.JSONEq(t, `"private"`, string(result["cacheScope"]))
+		assert.JSONEq(t, `0`, string(result["ttlMs"]))
 	})
 
 	t.Run("filters tools by denylist", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/miekg/dns v1.1.62
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/modelcontextprotocol/go-sdk v1.6.0
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1 // test
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/openzipkin/zipkin-go v0.4.3

--- a/go.sum
+++ b/go.sum
@@ -1071,8 +1071,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
-github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/httputil/origin.go
+++ b/internal/httputil/origin.go
@@ -95,17 +95,23 @@ func ParseTrustedProxyCIDRs(cidrs []string) ([]netip.Prefix, error) {
 // ExternalOrigin returns the canonical origin visible to the requester. Proxy
 // headers are considered only when the immediate network peer is trusted.
 func ExternalOrigin(r *http.Request, trustedProxyCIDRs []string) (string, error) {
+	prefixes, err := ParseTrustedProxyCIDRs(trustedProxyCIDRs)
+	if err != nil {
+		return "", err
+	}
+	return ExternalOriginWithTrustedProxies(r, prefixes)
+}
+
+// ExternalOriginWithTrustedProxies is ExternalOrigin's request-path form for
+// callers that parsed their immutable proxy configuration at load time.
+func ExternalOriginWithTrustedProxies(r *http.Request, trustedProxyPrefixes []netip.Prefix) (string, error) {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
 	}
 	host := r.Host
 
-	prefixes, err := ParseTrustedProxyCIDRs(trustedProxyCIDRs)
-	if err != nil {
-		return "", err
-	}
-	if peerIsTrusted(r.RemoteAddr, prefixes) {
+	if peerIsTrusted(r.RemoteAddr, trustedProxyPrefixes) {
 		forwardedProto, forwardedHost := rightmostForwarded(r.Header.Values("Forwarded"))
 		if forwardedProto != "" {
 			scheme = forwardedProto

--- a/internal/httputil/origin.go
+++ b/internal/httputil/origin.go
@@ -1,0 +1,201 @@
+package httputil
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// CanonicalOrigin validates and canonicalizes a concrete HTTP(S) origin.
+// Paths, credentials, queries, fragments, wildcards, and opaque origins are
+// deliberately rejected.
+func CanonicalOrigin(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" || strings.Contains(raw, "*") {
+		return "", fmt.Errorf("invalid origin %q", raw)
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid origin %q: %w", raw, err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("origin %q must use http or https", raw)
+	}
+	if u.Opaque != "" || u.User != nil || u.Host == "" || u.Path != "" || u.RawPath != "" ||
+		u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return "", fmt.Errorf("origin %q must contain only scheme, host, and optional port", raw)
+	}
+
+	hostname := strings.ToLower(u.Hostname())
+	if hostname == "" || strings.ContainsAny(hostname, " /?#@") {
+		return "", fmt.Errorf("origin %q has an invalid host", raw)
+	}
+	if addr, parseErr := netip.ParseAddr(hostname); parseErr == nil {
+		hostname = addr.String()
+	}
+
+	port := u.Port()
+	if port != "" {
+		portNumber, parseErr := strconv.ParseUint(port, 10, 16)
+		if parseErr != nil || portNumber == 0 {
+			return "", fmt.Errorf("origin %q has an invalid port", raw)
+		}
+		if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+			port = ""
+		}
+	}
+
+	host := hostname
+	if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	if port != "" {
+		host = net.JoinHostPort(hostname, port)
+	}
+	return scheme + "://" + host, nil
+}
+
+// CanonicalOrigins validates origins and returns their canonical forms.
+func CanonicalOrigins(origins []string) ([]string, error) {
+	canonical := make([]string, 0, len(origins))
+	seen := make(map[string]struct{}, len(origins))
+	for index, origin := range origins {
+		value, err := CanonicalOrigin(origin)
+		if err != nil {
+			return nil, fmt.Errorf("trusted origin %d: %w", index, err)
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		canonical = append(canonical, value)
+	}
+	return canonical, nil
+}
+
+// ParseTrustedProxyCIDRs validates trusted proxy networks.
+func ParseTrustedProxyCIDRs(cidrs []string) ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(cidrs))
+	for index, cidr := range cidrs {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+		if err != nil {
+			return nil, fmt.Errorf("trusted proxy CIDR %d %q: %w", index, cidr, err)
+		}
+		prefixes = append(prefixes, prefix.Masked())
+	}
+	return prefixes, nil
+}
+
+// ExternalOrigin returns the canonical origin visible to the requester. Proxy
+// headers are considered only when the immediate network peer is trusted.
+func ExternalOrigin(r *http.Request, trustedProxyCIDRs []string) (string, error) {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	host := r.Host
+
+	prefixes, err := ParseTrustedProxyCIDRs(trustedProxyCIDRs)
+	if err != nil {
+		return "", err
+	}
+	if peerIsTrusted(r.RemoteAddr, prefixes) {
+		forwardedProto, forwardedHost := rightmostForwarded(r.Header.Values("Forwarded"))
+		if forwardedProto != "" {
+			scheme = forwardedProto
+		} else if value := rightmostHeaderValue(r.Header.Values("X-Forwarded-Proto")); value != "" {
+			scheme = value
+		}
+		if forwardedHost != "" {
+			host = forwardedHost
+		} else if value := rightmostHeaderValue(r.Header.Values("X-Forwarded-Host")); value != "" {
+			host = value
+		}
+	}
+
+	return CanonicalOrigin(scheme + "://" + strings.TrimSpace(host))
+}
+
+func peerIsTrusted(remoteAddr string, prefixes []netip.Prefix) bool {
+	if len(prefixes) == 0 {
+		return false
+	}
+	host := remoteAddr
+	if splitHost, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = splitHost
+	}
+	addr, err := netip.ParseAddr(strings.Trim(host, "[]"))
+	if err != nil {
+		return false
+	}
+	for _, prefix := range prefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func rightmostHeaderValue(values []string) string {
+	parts := splitHeaderList(strings.Join(values, ","), ',')
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(parts[len(parts)-1])
+}
+
+func rightmostForwarded(values []string) (proto, host string) {
+	element := rightmostHeaderValue(values)
+	if element == "" {
+		return "", ""
+	}
+	for _, parameter := range splitHeaderList(element, ';') {
+		key, value, ok := strings.Cut(parameter, "=")
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, "\"") {
+			unquoted, err := strconv.Unquote(value)
+			if err != nil {
+				continue
+			}
+			value = unquoted
+		}
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "proto":
+			proto = value
+		case "host":
+			host = value
+		}
+	}
+	return proto, host
+}
+
+func splitHeaderList(value string, separator byte) []string {
+	var parts []string
+	start := 0
+	quoted := false
+	escaped := false
+	for index := 0; index < len(value); index++ {
+		switch {
+		case escaped:
+			escaped = false
+		case quoted && value[index] == '\\':
+			escaped = true
+		case value[index] == '"':
+			quoted = !quoted
+		case !quoted && value[index] == separator:
+			parts = append(parts, value[start:index])
+			start = index + 1
+		}
+	}
+	parts = append(parts, value[start:])
+	return parts
+}

--- a/internal/httputil/origin_test.go
+++ b/internal/httputil/origin_test.go
@@ -1,0 +1,77 @@
+package httputil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{name: "lowercase and default HTTPS port", in: "HTTPS://EXAMPLE.COM:443", want: "https://example.com", ok: true},
+		{name: "non-default port", in: "http://Example.COM:8080", want: "http://example.com:8080", ok: true},
+		{name: "IPv6", in: "https://[2001:0db8::1]:443", want: "https://[2001:db8::1]", ok: true},
+		{name: "null", in: "null"},
+		{name: "wildcard", in: "https://*.example.com"},
+		{name: "path", in: "https://example.com/"},
+		{name: "credentials", in: "https://user@example.com"},
+		{name: "query", in: "https://example.com?x=1"},
+		{name: "fragment", in: "https://example.com#x"},
+		{name: "non HTTP", in: "file://example.com"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := CanonicalOrigin(test.in)
+			if !test.ok {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestExternalOrigin_TrustsOnlyImmediatePeerAndRightmostValues(t *testing.T) {
+	t.Parallel()
+
+	newRequest := func() *http.Request {
+		req := httptest.NewRequest("POST", "http://internal:8080/mcp", nil)
+		req.RemoteAddr = "10.0.0.9:1234"
+		req.Header.Add("Forwarded", "for=attacker;proto=http;host=evil.example, for=10.0.0.8;proto=https;host=API.EXAMPLE:443")
+		req.Header.Set("X-Forwarded-Proto", "http, http")
+		req.Header.Set("X-Forwarded-Host", "evil.example, also-evil.example")
+		return req
+	}
+
+	origin, err := ExternalOrigin(newRequest(), []string{"10.0.0.0/24"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example", origin)
+
+	origin, err = ExternalOrigin(newRequest(), []string{"192.0.2.0/24"})
+	require.NoError(t, err)
+	assert.Equal(t, "http://internal:8080", origin)
+}
+
+func TestExternalOrigin_UsesRightmostXForwardedValues(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest("POST", "http://internal/mcp", nil)
+	req.RemoteAddr = "[2001:db8::2]:1234"
+	req.Header.Set("X-Forwarded-Proto", "http, https")
+	req.Header.Set("X-Forwarded-Host", "evil.example, [2001:db8::1]:443")
+
+	origin, err := ExternalOrigin(req, []string{"2001:db8::/64"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://[2001:db8::1]", origin)
+}

--- a/internal/mcp/adapter/sdk_v17_test.go
+++ b/internal/mcp/adapter/sdk_v17_test.go
@@ -1,0 +1,149 @@
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	sdkjsonrpc "github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+)
+
+const sdkModernProtocolVersion = "2026-07-28"
+
+func TestSDKV17ProtocolContracts(t *testing.T) {
+	assert.Equal(t, "io.modelcontextprotocol/protocolVersion", mcpsdk.MetaKeyProtocolVersion)
+	assert.Equal(t, "io.modelcontextprotocol/clientCapabilities", mcpsdk.MetaKeyClientCapabilities)
+	assert.Equal(t, "io.modelcontextprotocol/clientInfo", mcpsdk.MetaKeyClientInfo)
+	assert.Equal(t, "io.modelcontextprotocol/serverInfo", mcpsdk.MetaKeyServerInfo)
+	assert.EqualValues(t, -32020, mcpsdk.CodeHeaderMismatch)
+	assert.EqualValues(t, sdkjsonrpc.CodeInvalidParams, mcpsdk.CodeResourceNotFound)
+
+	err := mcpsdk.ResourceNotFoundError("file:///missing.txt")
+	var rpcErr *sdkjsonrpc.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, sdkjsonrpc.CodeInvalidParams, rpcErr.Code)
+}
+
+func TestSDKV17ModernDiscoveryCanaryWithoutProductionStatelessRouting(t *testing.T) {
+	adapter := newSDKV17TestAdapter(t)
+
+	t.Run("stateless transport advertises modern discovery metadata and cache fields", func(t *testing.T) {
+		handler := adapter.StreamableHTTPHandler(&mcpsdk.StreamableHTTPOptions{Stateless: true, JSONResponse: true})
+		response := serveSDKV17Discovery(t, handler, sdkModernProtocolVersion, sdkModernProtocolVersion)
+		assert.Equal(t, http.StatusOK, response.Code, response.Body.String())
+		assert.Empty(t, response.Header().Get("Mcp-Session-Id"))
+
+		result := sdkV17Result(t, response)
+		assert.Equal(t, "complete", result["resultType"])
+		assert.Equal(t, "public", result["cacheScope"])
+		assert.EqualValues(t, 0, result["ttlMs"])
+		supported := stringSlice(t, result["supportedVersions"])
+		assert.Contains(t, supported, sdkModernProtocolVersion)
+		meta := result["_meta"].(map[string]any)
+		serverInfo := meta[mcpsdk.MetaKeyServerInfo].(map[string]any)
+		assert.Equal(t, "Orders [MCP adapter]", serverInfo["name"])
+	})
+
+	t.Run("mismatched modern declaration uses header mismatch code", func(t *testing.T) {
+		handler := adapter.StreamableHTTPHandler(&mcpsdk.StreamableHTTPOptions{Stateless: true, JSONResponse: true})
+		response := serveSDKV17Discovery(t, handler, "2025-11-25", sdkModernProtocolVersion)
+		assert.Equal(t, http.StatusBadRequest, response.Code, response.Body.String())
+		var envelope map[string]any
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &envelope))
+		errObject := envelope["error"].(map[string]any)
+		assert.EqualValues(t, mcpsdk.CodeHeaderMismatch, errObject["code"])
+	})
+
+	t.Run("adapter-owned production handler remains stateful", func(t *testing.T) {
+		first := adapter.StreamableHTTPHandler(nil)
+		second := adapter.StreamableHTTPHandler(nil)
+		assert.Equal(t, first, second, "nil options must reuse the cached stateful handler")
+
+		response := serveSDKV17Discovery(t, first, sdkModernProtocolVersion, sdkModernProtocolVersion)
+		assert.Equal(t, http.StatusOK, response.Code, response.Body.String())
+		supported := stringSlice(t, sdkV17Result(t, response)["supportedVersions"])
+		assert.False(t, slices.Contains(supported, sdkModernProtocolVersion),
+			"TT-18014 must not enable modern stateless production routing")
+		assert.NotEmpty(t, supported)
+	})
+}
+
+func TestSDKV17LegacySessionCompatibilityCanary(t *testing.T) {
+	adapter := newSDKV17TestAdapter(t)
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "v1.7-canary", Version: "1"}, nil)
+	session, err := client.Connect(context.Background(), &mcpsdk.StreamableClientTransport{
+		Endpoint:   "http://mcp.test/mcp",
+		HTTPClient: &http.Client{Transport: loopbackRoundTripper{handler: adapter.StreamableHTTPHandler(nil)}},
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, session.Close()) })
+
+	initialize := session.InitializeResult()
+	require.NotNil(t, initialize)
+	assert.NotEqual(t, sdkModernProtocolVersion, initialize.ProtocolVersion)
+	list, err := session.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, list.Tools, 2)
+	assert.Equal(t, "public", list.GetCacheScope())
+	assert.Zero(t, list.GetTTLMs())
+}
+
+func newSDKV17TestAdapter(t *testing.T) *SDKAdapter {
+	t.Helper()
+	adapter, err := NewSDKAdapter(SDKServerConfig{
+		Name:  "Orders [MCP adapter]",
+		Tools: sampleTools(),
+		CallTool: func(context.Context, *oas.DerivedTool, map[string]any) (*Recorder, error) {
+			return NewRecorder(), nil
+		},
+	})
+	require.NoError(t, err)
+	return adapter
+}
+
+func serveSDKV17Discovery(t *testing.T, handler http.Handler, headerVersion, bodyVersion string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := `{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{` +
+		`"io.modelcontextprotocol/protocolVersion":"` + bodyVersion + `",` +
+		`"io.modelcontextprotocol/clientCapabilities":{},` +
+		`"io.modelcontextprotocol/clientInfo":{"name":"canary","version":"1"}}}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Protocol-Version", headerVersion)
+	req.Header.Set("Mcp-Method", "server/discover")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func sdkV17Result(t *testing.T, response *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &envelope))
+	result, ok := envelope["result"].(map[string]any)
+	require.True(t, ok, "response has no result: %s", response.Body.String())
+	return result
+}
+
+func stringSlice(t *testing.T, value any) []string {
+	t.Helper()
+	values, ok := value.([]any)
+	require.True(t, ok)
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		item, ok := value.(string)
+		require.True(t, ok)
+		result = append(result, item)
+	}
+	return result
+}

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -33,7 +33,7 @@ const (
 	MethodPromptsList = "prompts/list"
 
 	// Client capability methods
-	MethodSamplingCreate = "sampling/create"
+	MethodSamplingCreateMessage = "sampling/createMessage"
 )
 
 // JSON-RPC parameter keys used across MCP methods

--- a/internal/mcp/list_filter.go
+++ b/internal/mcp/list_filter.go
@@ -210,7 +210,7 @@ var InitializeCapabilityMethods = map[string][]string{
 	"tools":     {MethodToolsList, MethodToolsCall},
 	"resources": {MethodResourcesList, MethodResourcesTemplatesList, MethodResourcesRead},
 	"prompts":   {MethodPromptsList, MethodPromptsGet},
-	"sampling":  {MethodSamplingCreate},
+	"sampling":  {MethodSamplingCreateMessage},
 }
 
 // FilterInitializeCapabilitiesBody removes initialize response capabilities

--- a/internal/mcp/list_filter.go
+++ b/internal/mcp/list_filter.go
@@ -117,9 +117,9 @@ func ReencodeEnvelope(envelope *JSONRPCResponse, result map[string]json.RawMessa
 }
 
 // FilterJSONRPCBody parses a JSON-RPC response body, filters the list items
-// according to the given config and rules, and returns the re-encoded body.
-// Returns (nil, false) when any parsing or marshalling step fails, signalling
-// that the caller should pass through the original body unmodified.
+// according to the given config and rules, and returns the re-encoded body only
+// when at least one item was removed. Returns (nil, false) for parse failures or
+// unchanged content, signalling that the caller must retain the original bytes.
 func FilterJSONRPCBody(body []byte, cfg *ListFilterConfig, rules user.AccessControlRules) ([]byte, bool) {
 	return FilterJSONRPCBodyWithRuleSets(body, cfg, []user.AccessControlRules{rules})
 }
@@ -147,7 +147,7 @@ func FilterJSONRPCBodyWithRuleSets(body []byte, cfg *ListFilterConfig, ruleSets 
 
 // FilterParsedJSONRPC filters items in an already-parsed JSON-RPC result and
 // re-encodes the envelope. Returns (nil, false) when the array key is missing,
-// items cannot be parsed, or re-encoding fails.
+// items cannot be parsed, no items were removed, or re-encoding fails.
 func FilterParsedJSONRPC(envelope *JSONRPCResponse, result map[string]json.RawMessage, cfg *ListFilterConfig, rules user.AccessControlRules) ([]byte, bool) {
 	return FilterParsedJSONRPCWithRuleSets(envelope, result, cfg, []user.AccessControlRules{rules})
 }
@@ -166,6 +166,11 @@ func FilterParsedJSONRPCWithRuleSets(envelope *JSONRPCResponse, result map[strin
 	}
 
 	filtered := FilterItemsWithRuleSets(items, cfg.NameField, ruleSets)
+	if len(filtered) == len(items) {
+		return nil, false
+	}
+
+	SetPrivateCacheHints(result)
 
 	newBody, err := ReencodeEnvelope(envelope, result, cfg.ArrayKey, filtered)
 	if err != nil {
@@ -173,6 +178,15 @@ func FilterParsedJSONRPCWithRuleSets(envelope *JSONRPCResponse, result map[strin
 	}
 
 	return newBody, true
+}
+
+// SetPrivateCacheHints prevents an authorization-specific MCP result from
+// being reused for a different caller. It operates on the raw result map so
+// unknown fields and pagination cursors are preserved when the envelope is
+// re-encoded.
+func SetPrivateCacheHints(result map[string]json.RawMessage) {
+	result["cacheScope"] = json.RawMessage(`"private"`)
+	result["ttlMs"] = json.RawMessage(`0`)
 }
 
 // InferListConfigFromResult determines the list type by inspecting which
@@ -247,6 +261,7 @@ func FilterInitializeCapabilitiesParsed(envelope *JSONRPCResponse, result map[st
 	if !changed {
 		return nil, false
 	}
+	SetPrivateCacheHints(result)
 
 	capabilitiesBytes, err := json.Marshal(capabilities)
 	if err != nil {

--- a/internal/mcp/list_filter_test.go
+++ b/internal/mcp/list_filter_test.go
@@ -270,6 +270,28 @@ func TestFilterItemsWithRuleSets(t *testing.T) {
 }
 
 func TestFilterJSONRPCBody(t *testing.T) {
+	t.Run("unchanged list preserves original bytes and cache hints", func(t *testing.T) {
+		body := []byte("{\n  \"jsonrpc\": \"2.0\", \"id\": 1, \"result\": {\"tools\": [{\"name\": \"allowed\"}], \"cacheScope\": \"public\", \"ttlMs\": 3000}\n}")
+		result, changed := FilterJSONRPCBody(body, ListFilterConfigs["tools"], user.AccessControlRules{Allowed: []string{"allowed"}})
+		assert.False(t, changed)
+		assert.Nil(t, result, "caller must retain the original bytes when nothing was removed")
+	})
+
+	t.Run("edited paginated list receives private zero-TTL hints", func(t *testing.T) {
+		body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed"},{"name":"secret"}],"nextCursor":"page-2","cacheScope":"public","ttlMs":3000,"extension":{"kept":true}}}`)
+		result, changed := FilterJSONRPCBody(body, ListFilterConfigs["tools"], user.AccessControlRules{Allowed: []string{"allowed"}})
+		require.True(t, changed)
+
+		var envelope JSONRPCResponse
+		require.NoError(t, json.Unmarshal(result, &envelope))
+		var responseResult map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(envelope.Result, &responseResult))
+		assert.JSONEq(t, `"private"`, string(responseResult["cacheScope"]))
+		assert.JSONEq(t, `0`, string(responseResult["ttlMs"]))
+		assert.JSONEq(t, `"page-2"`, string(responseResult["nextCursor"]))
+		assert.JSONEq(t, `{"kept":true}`, string(responseResult["extension"]))
+	})
+
 	t.Run("batch JSON-RPC array passes through (returns false)", func(t *testing.T) {
 		// JSON-RPC batch = top-level array. Not supported for filtering.
 		batch := `[{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a"}]}},{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"b"}]}}]`
@@ -339,6 +361,15 @@ func TestFilterInitializeCapabilitiesBody(t *testing.T) {
 	assert.NotContains(t, capabilities, "tools")
 	assert.Contains(t, capabilities, "resources")
 	assert.Contains(t, capabilities, "prompts")
+	assert.JSONEq(t, `"private"`, string(responseResult["cacheScope"]))
+	assert.JSONEq(t, `0`, string(responseResult["ttlMs"]))
+
+	t.Run("unchanged capabilities preserve original response", func(t *testing.T) {
+		unchangedBody := []byte("{\n\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"capabilities\":{\"tools\":{}},\"cacheScope\":\"public\",\"ttlMs\":42}}")
+		unchanged, changed := FilterInitializeCapabilitiesBody(unchangedBody, []user.AccessControlRules{{Allowed: []string{".*"}}})
+		assert.False(t, changed)
+		assert.Nil(t, unchanged)
+	})
 }
 
 func TestInferListConfigFromResult(t *testing.T) {

--- a/internal/mcp/list_filter_test.go
+++ b/internal/mcp/list_filter_test.go
@@ -344,7 +344,7 @@ func TestFilterInitializeCapabilitiesBody(t *testing.T) {
 	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{"listChanged":true},"resources":{"subscribe":true},"prompts":{},"sampling":{}},"serverInfo":{"name":"test","version":"1.0.0"}}}`)
 
 	result, ok := FilterInitializeCapabilitiesBody(body, []user.AccessControlRules{
-		{Blocked: []string{MethodSamplingCreate, MethodToolsList}},
+		{Blocked: []string{MethodSamplingCreateMessage, MethodToolsList}},
 	})
 	require.True(t, ok)
 
@@ -370,6 +370,36 @@ func TestFilterInitializeCapabilitiesBody(t *testing.T) {
 		assert.False(t, changed)
 		assert.Nil(t, unchanged)
 	})
+}
+
+func TestSamplingCapabilityUsesCreateMessageMethod(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"sampling":{}}}}`)
+	tests := []struct {
+		name        string
+		blocked     string
+		wantChanged bool
+	}{
+		{name: "correct createMessage method removes sampling", blocked: MethodSamplingCreateMessage, wantChanged: true},
+		{name: "obsolete create method does not control sampling", blocked: "sampling/create", wantChanged: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered, changed := FilterInitializeCapabilitiesBody(body, []user.AccessControlRules{{Blocked: []string{tt.blocked}}})
+			assert.Equal(t, tt.wantChanged, changed)
+			if !tt.wantChanged {
+				assert.Nil(t, filtered)
+				return
+			}
+			var envelope JSONRPCResponse
+			require.NoError(t, json.Unmarshal(filtered, &envelope))
+			var result map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(envelope.Result, &result))
+			var capabilities map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(result["capabilities"], &capabilities))
+			assert.NotContains(t, capabilities, "sampling")
+		})
+	}
 }
 
 func TestInferListConfigFromResult(t *testing.T) {


### PR DESCRIPTION
## Description

Adds MCP trusted-origin contracts for OAS and Classic definitions, trusted-proxy CIDR configuration, canonical external-origin handling, and an early Origin-validation middleware. Dashboard covers management round trips and absent/same/trusted/untrusted/null Origin behavior.

## Related Issue

- [TT-18030](https://tyktech.atlassian.net/browse/TT-18030)
- [Gateway PR #8597](https://github.com/TykTechnologies/tyk/pull/8597)
- [Dashboard PR #6122](https://github.com/TykTechnologies/tyk-analytics/pull/6122)
- [Gateway branch](https://github.com/TykTechnologies/tyk/tree/TT-18030-mcp-origin-validation)
- [Dashboard branch](https://github.com/TykTechnologies/tyk-analytics/tree/TT-18030-mcp-origin-validation)

## Motivation and Context

Browser-origin validation must happen before body, authentication, policy, quota, or upstream side effects and must share proxy-aware origin canonicalization with PRM/OAuth URLs.

## How This Has Been Tested

- `GOCACHE=/private/tmp/tt18006-go-cache go test ./gateway -run 'TestMCP' -count=1` — pass on the complete Gateway stack, including origin/config/middleware tests.
- `GOCACHE=/private/tmp/tt18006-dashboard-gocache go test ./dashboard -run 'TestMCP(TrustedOriginsManagementContract|ProtocolContextAnalyticsJSONCompatibility)' -count=1` — pass.
- `python3 -m compileall -q tests/api/mcp_client.py tests/api/tests/mcp` — pass on the complete Dashboard stack.
- The documented `.venv/bin/pytest -c pytest_local.ini tests/mcp/ ...` Docker gate was not run because the live release environment is unavailable.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] Public OAS, Classic, Gateway config, and environment contracts are documented in TT-18030.
- [x] Dashboard go.mod pins the matching Gateway draft and go mod tidy completed.
- [ ] Full release test matrix completed.


[TT-18030]: https://tyktech.atlassian.net/browse/TT-18030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ