### PR TITLE
[TT-17921] Improve header handling for GraphQL-based APIs

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1089,32 +1089,28 @@ func isCORSPreflight(r *http.Request) bool {
 	return r.Method == http.MethodOptions
 }
 
-type variableReplaceRoundTripper struct {
-	next   http.RoundTripper
-	outReq *http.Request
-	gw     *Gateway
-}
-
-func (d *variableReplaceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	for key := range req.Header {
-		val := d.gw.ReplaceTykVariables(d.outReq, req.Header.Get(key), false)
-		req.Header.Set(key, val)
-	}
-
-	return d.next.RoundTrip(req)
-}
-
 func (p *ReverseProxy) handleGraphQL(roundTripper *TykRoundTripper, outreq *http.Request, w http.ResponseWriter) (res *http.Response, hijacked bool, err error) {
 	isWebSocketUpgrade := ctxGetGraphQLIsWebSocketUpgrade(outreq)
 	needsEngine := needsGraphQLExecutionEngine(p.TykAPISpec)
 
 	requestHeadersRewrite := make(map[string]apidef.RequestHeadersRewriteConfig)
 	for key, value := range p.TykAPISpec.GraphQL.Proxy.RequestHeadersRewrite {
+		// Resolved here, once, because these are the only header values the graph engine
+		// adds that no header modifier sees: the transport applies them itself, after the
+		// engine has already finalised the fetch headers.
+		//
+		// Nothing else on this path resolves variables any more. Upstream headers of the
+		// engine, global and per data source alike, are resolved by the header modifier
+		// while the fetch input is built, which is what the subscription connection key is
+		// computed from (TT-17921). A round tripper that walked the outgoing headers
+		// instead used to sit here, and it ran too late for that key, collapsed multi
+		// value headers and expanded variables inside header values the caller had sent.
+		value.Value = p.Gw.ReplaceTykVariables(outreq, value.Value, false)
 		// Use the canonical format of the MIME header key.
 		requestHeadersRewrite[textproto.CanonicalMIMEHeaderKey(key)] = value
 	}
 	res, hijacked, err = p.TykAPISpec.GraphEngine.HandleReverseProxy(graphengine.ReverseProxyParams{
-		RoundTripper:       &variableReplaceRoundTripper{next: roundTripper, outReq: outreq, gw: p.Gw},
+		RoundTripper:       roundTripper,
 		ResponseWriter:     w,
 		OutRequest:         outreq,
 		WebSocketUpgrader:  &p.wsUpgrader,

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -1230,6 +1230,51 @@ func TestGraphQL_ProxyOnlyHeaders(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("the consumer's credential reaches the upstream once", func(t *testing.T) {
+		// Two writers put it there and neither knows about the other: with strip_auth_data
+		// off the engine adds the consumer's auth header to the fetch input through
+		// propagateAuthHeaders, and setProxyOnlyHeaders then forwards the consumer's
+		// headers again. The upstream used to receive the credential twice.
+		spec := defaultSpec
+		spec.GraphQL.Proxy.RequestHeadersRewrite = nil
+		spec.UseKeylessAccess = false
+		spec.UseStandardAuth = true
+		spec.StripAuthData = false
+		spec.AuthConfigs = map[string]apidef.AuthConfig{
+			apidef.AuthTokenType: {AuthHeaderName: "X-API-KEY"},
+		}
+		g.Gw.LoadAPI(spec)
+
+		_, authKey := g.CreateSession(func(s *user.SessionState) {
+			s.AccessRights = map[string]user.AccessDefinition{
+				spec.APIID: {APIName: spec.Name, APIID: spec.APIID, Versions: []string{"Default"}},
+			}
+			s.OrgID = spec.OrgID
+		})
+
+		g.AddDynamicHandler("/dynamic", func(writer http.ResponseWriter, r *http.Request) {
+			values := r.Header.Values("X-Api-Key")
+			if len(values) != 1 {
+				t.Errorf("upstream received X-Api-Key %d times: %v", len(values), values)
+				return
+			}
+			if values[0] != authKey {
+				t.Errorf("upstream received the wrong credential: %q", values[0])
+			}
+		})
+		_, err := g.Run(t, test.TestCase{
+			Path: "/",
+			Headers: map[string]string{
+				"X-API-KEY": authKey,
+			},
+			Method: http.MethodPost,
+			Data: graphql.Request{
+				Query: gqlContinentQuery,
+			},
+		})
+		assert.NoError(t, err)
+	})
+
 	t.Run("a variable inside a header the caller sent is not expanded", func(t *testing.T) {
 		// Only values that come from the API definition are resolved. A round tripper that
 		// walked every outgoing header used to sit on this path and expanded whatever the

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -1116,7 +1116,13 @@ func TestGraphQL_UDGHeaders(t *testing.T) {
 					strings.Contains(string(b), `{"name":"Context","value":"request-context"}`) &&
 					strings.Contains(string(b), `{"name":"Global-Static","value":"foobar"}`) &&
 					strings.Contains(string(b), `{"name":"Global-Context","value":"follow-up-request-global-context"}`) &&
-					strings.Contains(string(b), `{"name":"Does-Exist-Already","value":"ds-does-exist-already"}`)
+					strings.Contains(string(b), `{"name":"Does-Exist-Already","value":"ds-does-exist-already"}`) &&
+					// A header with more than one value has to keep all of them. The round
+					// tripper that used to resolve variables on the way to the upstream read
+					// with Get and wrote with Set, so it collapsed this to gzip alone.
+					strings.Contains(string(b), `{"name":"Accept-Encoding","value":"gzip"}`) &&
+					strings.Contains(string(b), `{"name":"Accept-Encoding","value":"deflate"}`) &&
+					strings.Contains(string(b), `{"name":"Accept-Encoding","value":"br"}`)
 			},
 		},
 	}...)
@@ -1187,6 +1193,62 @@ func TestGraphQL_ProxyOnlyHeaders(t *testing.T) {
 			Path: "/",
 			Headers: map[string]string{
 				"Test-Header": "test-value",
+			},
+			Method: http.MethodPost,
+			Data: graphql.Request{
+				Query: gqlContinentQuery,
+			},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("test context variable request headers rewrite", func(t *testing.T) {
+		// request_headers_rewrite is applied by the engine transport, after the header
+		// modifier has already finalised the fetch headers, so it is resolved where the
+		// rules are built instead. See handleGraphQL.
+		spec := defaultSpec
+		spec.GraphQL.Proxy.RequestHeadersRewrite = map[string]apidef.RequestHeadersRewriteConfig{
+			"X-Rewritten": {Value: "$tyk_context.headers_Test_Header"},
+		}
+		spec.EnableContextVars = true
+		g.Gw.LoadAPI(spec)
+		g.AddDynamicHandler("/dynamic", func(writer http.ResponseWriter, r *http.Request) {
+			if !headerCheck("X-Rewritten", "test-value", r.Header) {
+				t.Errorf("rewritten header not resolved, got %q", r.Header.Get("X-Rewritten"))
+			}
+		})
+		_, err := g.Run(t, test.TestCase{
+			Path: "/",
+			Headers: map[string]string{
+				"Test-Header": "test-value",
+			},
+			Method: http.MethodPost,
+			Data: graphql.Request{
+				Query: gqlContinentQuery,
+			},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("a variable inside a header the caller sent is not expanded", func(t *testing.T) {
+		// Only values that come from the API definition are resolved. A round tripper that
+		// walked every outgoing header used to sit on this path and expanded whatever the
+		// caller had put in one, which let a caller read the context of their own session
+		// back out of the upstream request. See handleGraphQL.
+		spec := defaultSpec
+		spec.GraphQL.Proxy.RequestHeadersRewrite = nil
+		spec.EnableContextVars = true
+		g.Gw.LoadAPI(spec)
+		g.AddDynamicHandler("/dynamic", func(writer http.ResponseWriter, r *http.Request) {
+			if !headerCheck("X-Injection-Probe", "$tyk_context.headers_Test_Header", r.Header) {
+				t.Errorf("caller supplied variable was expanded, got %q", r.Header.Get("X-Injection-Probe"))
+			}
+		})
+		_, err := g.Run(t, test.TestCase{
+			Path: "/",
+			Headers: map[string]string{
+				"Test-Header":       "test-value",
+				"X-Injection-Probe": "$tyk_context.headers_Test_Header",
 			},
 			Method: http.MethodPost,
 			Data: graphql.Request{

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/TykTechnologies/goautosocket v0.0.0-20190430121222-97bfa5e7e481
 	github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6
 	github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260624141309-dae0d8d8d038
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260818151404-c416c52a2dd3
 	github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2
@@ -97,10 +97,11 @@ require (
 	github.com/Azure/go-amqp v1.4.0
 	github.com/IBM/sarama v1.46.3
 	github.com/Jeffail/gabs/v2 v2.7.0
-	github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d
+	github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20260818151404-c416c52a2dd3
 	github.com/TykTechnologies/opentelemetry v0.0.26
 	github.com/TykTechnologies/structviewer v1.2.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
+	github.com/coder/websocket v1.8.13
 	github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd
 	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/getkin/kin-openapi v0.133.0
@@ -270,7 +271,6 @@ require (
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect
-	github.com/coder/websocket v1.8.13 // indirect
 	github.com/colinmarc/hdfs v1.1.3 // indirect
 	github.com/containerd/continuity v0.4.2 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,10 +177,10 @@ github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6 h1:wwt23wdyi
 github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6/go.mod h1:v6v7Mlj08+EmEcXOfpuTxGt2qYU9yhqqtv4QF9Wf50E=
 github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e h1:wbd35YYCywZbgc4Fk/G2pQHnvwYzjedrw8pNzUsVowg=
 github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e/go.mod h1:WtiSLIlItUVsHyHQB1NG+de/L4/PTtmZWc9CnzTRBLs=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260817122723-1ff2d4d7c6a7 h1:vKx1VrJCd9aNAWVTIKykiBFf2kBfNe8d++LO6lC6XKk=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260817122723-1ff2d4d7c6a7/go.mod h1:bvVafmGebtdjIFG2bXkLd+O1jOjjU/3To+mQHcLr4KI=
-github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20260817122723-1ff2d4d7c6a7 h1:vDzhsksab6kua027xH9oYHXlMWu4/4sF0UkK3Vv7NaI=
-github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20260817122723-1ff2d4d7c6a7/go.mod h1:XM1owY0ZCJ1Rai64Q1UKXZYNDkWikZDojgefZw8raPk=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260818151404-c416c52a2dd3 h1:muQy5S8Y0bZk3wNLQnHjDJzUBB5I3f5FzftIkpCIP5s=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260818151404-c416c52a2dd3/go.mod h1:bvVafmGebtdjIFG2bXkLd+O1jOjjU/3To+mQHcLr4KI=
+github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20260818151404-c416c52a2dd3 h1:R7ZoRYvA/rEJj648PWCRK2q6wHtEO/oDp22kRCDtdF0=
+github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20260818151404-c416c52a2dd3/go.mod h1:XM1owY0ZCJ1Rai64Q1UKXZYNDkWikZDojgefZw8raPk=
 github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36 h1:7nNsyocI/RKBqo73RR9G/SiFMZ8w2sN+HMsQXYp9wPI=
 github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36/go.mod h1:qiglVaUPPOWET4bQsBmsAaLiCml20a01REQSi7TSUa0=
 github.com/TykTechnologies/kin-openapi v0.512.1-0.20260817104659-7198d52254ff h1:lpF67zYIQzUMacE5UraBYrzaajVEkHO3h/TzCNWSCwY=

--- a/go.sum
+++ b/go.sum
@@ -177,10 +177,10 @@ github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6 h1:wwt23wdyi
 github.com/TykTechnologies/gorpc v0.0.0-20250214161245-e9f3f088e8c6/go.mod h1:v6v7Mlj08+EmEcXOfpuTxGt2qYU9yhqqtv4QF9Wf50E=
 github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e h1:wbd35YYCywZbgc4Fk/G2pQHnvwYzjedrw8pNzUsVowg=
 github.com/TykTechnologies/goverify v0.0.0-20260203113354-7a104729566e/go.mod h1:WtiSLIlItUVsHyHQB1NG+de/L4/PTtmZWc9CnzTRBLs=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260624141309-dae0d8d8d038 h1:akyeFvwB5ZnVq9jbGPx1pP33ETxp0ziDlt5r40HRCDY=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260624141309-dae0d8d8d038/go.mod h1:bvVafmGebtdjIFG2bXkLd+O1jOjjU/3To+mQHcLr4KI=
-github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d h1:bK9T78hExbTuDK4UaBuGi9aL28hK68Uw3OyNZswdPcA=
-github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d/go.mod h1:XM1owY0ZCJ1Rai64Q1UKXZYNDkWikZDojgefZw8raPk=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260817122723-1ff2d4d7c6a7 h1:vKx1VrJCd9aNAWVTIKykiBFf2kBfNe8d++LO6lC6XKk=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20260817122723-1ff2d4d7c6a7/go.mod h1:bvVafmGebtdjIFG2bXkLd+O1jOjjU/3To+mQHcLr4KI=
+github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20260817122723-1ff2d4d7c6a7 h1:vDzhsksab6kua027xH9oYHXlMWu4/4sF0UkK3Vv7NaI=
+github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20260817122723-1ff2d4d7c6a7/go.mod h1:XM1owY0ZCJ1Rai64Q1UKXZYNDkWikZDojgefZw8raPk=
 github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36 h1:7nNsyocI/RKBqo73RR9G/SiFMZ8w2sN+HMsQXYp9wPI=
 github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36/go.mod h1:qiglVaUPPOWET4bQsBmsAaLiCml20a01REQSi7TSUa0=
 github.com/TykTechnologies/kin-openapi v0.512.1-0.20260817104659-7198d52254ff h1:lpF67zYIQzUMacE5UraBYrzaajVEkHO3h/TzCNWSCwY=

--- a/internal/graphengine/context.go
+++ b/internal/graphengine/context.go
@@ -3,6 +3,7 @@ package graphengine
 import (
 	"context"
 	"net/http"
+	"sync"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )
@@ -47,10 +48,46 @@ func getGraphQLEngineTransportContextValue(ctx context.Context) *graphQLEngineTr
 	return value
 }
 
+// subscriptionRequestContext returns the context that a websocket subscription handler
+// runs on. It carries the transport values of the request that opened the connection, so
+// upstream fetches keep using that caller's round tripper, but it is rooted at the long
+// lived engine context so that releasing the API ends the subscription.
+//
+// The request context cannot be used as the parent: net/http cancels it as soon as
+// ServeHTTP returns, and the gateway returns as soon as the connection is hijacked, so a
+// subscription rooted there is cancelled before it delivers anything.
+func subscriptionRequestContext(engineCtx context.Context, outreq *http.Request) context.Context {
+	if engineCtx == nil {
+		engineCtx = context.Background()
+	}
+	if outreq == nil {
+		return engineCtx
+	}
+	return copyGraphQLEngineTransportContextValue(engineCtx, outreq.Context())
+}
+
 type GraphQLProxyOnlyContextValues struct {
 	forwardedRequest       *http.Request
-	upstreamResponse       *http.Response
 	ignoreForwardedHeaders map[string]bool
+
+	// upstreamResponse is written by the transport and read by the engine. Those can be
+	// different goroutines: a subscription fetch runs on the resolver's trigger goroutine
+	// and can outlive the handover that reads the response, so both sides go through the
+	// accessors below.
+	mu               sync.Mutex
+	upstreamResponse *http.Response
+}
+
+func (g *GraphQLProxyOnlyContextValues) setUpstreamResponse(response *http.Response) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.upstreamResponse = response
+}
+
+func (g *GraphQLProxyOnlyContextValues) getUpstreamResponse() *http.Response {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.upstreamResponse
 }
 
 func SetProxyOnlyContextValue(ctx context.Context, req *http.Request) context.Context {

--- a/internal/graphengine/context.go
+++ b/internal/graphengine/context.go
@@ -16,7 +16,36 @@ const (
 
 type contextKey struct{}
 
+type transportContextKey struct{}
+
 var graphqlProxyContextInfo = contextKey{}
+var graphqlTransportContextInfo = transportContextKey{}
+
+type graphQLEngineTransportContextValues struct {
+	roundTripper  http.RoundTripper
+	headersConfig ReverseProxyHeadersConfig
+}
+
+func SetGraphQLEngineTransportContextValue(ctx context.Context, roundTripper http.RoundTripper, headersConfig ReverseProxyHeadersConfig) context.Context {
+	value := &graphQLEngineTransportContextValues{
+		roundTripper:  roundTripper,
+		headersConfig: headersConfig,
+	}
+	return context.WithValue(ctx, graphqlTransportContextInfo, value)
+}
+
+func copyGraphQLEngineTransportContextValue(target, source context.Context) context.Context {
+	value, _ := source.Value(graphqlTransportContextInfo).(*graphQLEngineTransportContextValues)
+	if value == nil {
+		return target
+	}
+	return context.WithValue(target, graphqlTransportContextInfo, value)
+}
+
+func getGraphQLEngineTransportContextValue(ctx context.Context) *graphQLEngineTransportContextValues {
+	value, _ := ctx.Value(graphqlTransportContextInfo).(*graphQLEngineTransportContextValues)
+	return value
+}
 
 type GraphQLProxyOnlyContextValues struct {
 	forwardedRequest       *http.Request

--- a/internal/graphengine/context.go
+++ b/internal/graphengine/context.go
@@ -36,15 +36,18 @@ func SetGraphQLEngineTransportContextValue(ctx context.Context, roundTripper htt
 }
 
 func copyGraphQLEngineTransportContextValue(target, source context.Context) context.Context {
-	value, _ := source.Value(graphqlTransportContextInfo).(*graphQLEngineTransportContextValues)
-	if value == nil {
+	value, ok := source.Value(graphqlTransportContextInfo).(*graphQLEngineTransportContextValues)
+	if !ok || value == nil {
 		return target
 	}
 	return context.WithValue(target, graphqlTransportContextInfo, value)
 }
 
 func getGraphQLEngineTransportContextValue(ctx context.Context) *graphQLEngineTransportContextValues {
-	value, _ := ctx.Value(graphqlTransportContextInfo).(*graphQLEngineTransportContextValues)
+	value, ok := ctx.Value(graphqlTransportContextInfo).(*graphQLEngineTransportContextValues)
+	if !ok {
+		return nil
+	}
 	return value
 }
 

--- a/internal/graphengine/context_test.go
+++ b/internal/graphengine/context_test.go
@@ -1,0 +1,102 @@
+package graphengine
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestGraphQLEngineTransportContextValue(t *testing.T) {
+	headersConfig := ReverseProxyHeadersConfig{
+		ProxyOnly: ProxyOnlyHeadersConfig{
+			UseImmutableHeaders: true,
+			RequestHeadersRewrite: map[string]apidef.RequestHeadersRewriteConfig{
+				"X-Custom": {Value: "rewritten", Remove: false},
+			},
+		},
+	}
+
+	t.Run("should return nil when no value is set", func(t *testing.T) {
+		assert.Nil(t, getGraphQLEngineTransportContextValue(context.Background()))
+	})
+
+	t.Run("should return the round tripper and the headers config that were set", func(t *testing.T) {
+		roundTripper := taggedRoundTripper("caller")
+
+		ctx := SetGraphQLEngineTransportContextValue(context.Background(), roundTripper, headersConfig)
+
+		values := getGraphQLEngineTransportContextValue(ctx)
+		require.NotNil(t, values)
+		assert.Equal(t, roundTripper, values.roundTripper)
+		assert.Equal(t, headersConfig, values.headersConfig)
+	})
+
+	t.Run("should keep a nil round tripper as nil", func(t *testing.T) {
+		ctx := SetGraphQLEngineTransportContextValue(context.Background(), nil, ReverseProxyHeadersConfig{})
+
+		values := getGraphQLEngineTransportContextValue(ctx)
+		require.NotNil(t, values)
+		assert.Nil(t, values.roundTripper)
+	})
+
+	t.Run("should not read a foreign value stored under a different key", func(t *testing.T) {
+		ctx := SetProxyOnlyContextValue(context.Background(), &http.Request{})
+
+		assert.Nil(t, getGraphQLEngineTransportContextValue(ctx))
+	})
+}
+
+func TestCopyGraphQLEngineTransportContextValue(t *testing.T) {
+	t.Run("should copy the value of the source context into the target context", func(t *testing.T) {
+		roundTripper := taggedRoundTripper("caller")
+		source := SetGraphQLEngineTransportContextValue(context.Background(), roundTripper, ReverseProxyHeadersConfig{
+			ProxyOnly: ProxyOnlyHeadersConfig{UseImmutableHeaders: true},
+		})
+
+		target := copyGraphQLEngineTransportContextValue(context.Background(), source)
+
+		values := getGraphQLEngineTransportContextValue(target)
+		require.NotNil(t, values)
+		// The value is shared by reference, it is never rebuilt for the target context.
+		assert.Same(t, getGraphQLEngineTransportContextValue(source), values)
+		assert.Equal(t, roundTripper, values.roundTripper)
+		assert.True(t, values.headersConfig.ProxyOnly.UseImmutableHeaders)
+	})
+
+	t.Run("should return the target context unchanged when the source has no value", func(t *testing.T) {
+		target := context.Background()
+
+		assert.Equal(t, target, copyGraphQLEngineTransportContextValue(target, context.Background()))
+		assert.Nil(t, getGraphQLEngineTransportContextValue(copyGraphQLEngineTransportContextValue(target, context.Background())))
+	})
+
+	t.Run("should keep the values that the target context already carries", func(t *testing.T) {
+		forwardedRequest, err := http.NewRequest(http.MethodPost, "http://example.com/graphql", nil)
+		require.NoError(t, err)
+		target := SetProxyOnlyContextValue(context.Background(), forwardedRequest)
+		source := SetGraphQLEngineTransportContextValue(context.Background(), taggedRoundTripper("caller"), ReverseProxyHeadersConfig{})
+
+		target = copyGraphQLEngineTransportContextValue(target, source)
+
+		require.NotNil(t, getGraphQLEngineTransportContextValue(target))
+		proxyOnlyValues := GetProxyOnlyContextValue(target)
+		require.NotNil(t, proxyOnlyValues)
+		assert.Same(t, forwardedRequest, proxyOnlyValues.forwardedRequest)
+	})
+
+	t.Run("should overwrite a value that the target context already carries", func(t *testing.T) {
+		target := SetGraphQLEngineTransportContextValue(context.Background(), taggedRoundTripper("stale"), ReverseProxyHeadersConfig{})
+		source := SetGraphQLEngineTransportContextValue(context.Background(), taggedRoundTripper("current"), ReverseProxyHeadersConfig{})
+
+		target = copyGraphQLEngineTransportContextValue(target, source)
+
+		values := getGraphQLEngineTransportContextValue(target)
+		require.NotNil(t, values)
+		assert.Equal(t, taggedRoundTripper("current"), values.roundTripper)
+	})
+}

--- a/internal/graphengine/context_test.go
+++ b/internal/graphengine/context_test.go
@@ -156,8 +156,8 @@ func TestSubscriptionRequestContext(t *testing.T) {
 		request, cancelRequest := newRequestWithTransportValues(t, taggedRoundTripper("caller"))
 		defer cancelRequest()
 
-		assert.NotNil(t, subscriptionRequestContext(nil, request))
-		assert.NotNil(t, subscriptionRequestContext(nil, nil))
+		assert.NotNil(t, subscriptionRequestContext(nil, request)) //nolint:staticcheck // SA1012: the nil context is what this test covers
+		assert.NotNil(t, subscriptionRequestContext(nil, nil))     //nolint:staticcheck // SA1012: the nil context is what this test covers
 		assert.Nil(t, getGraphQLEngineTransportContextValue(subscriptionRequestContext(context.Background(), nil)))
 	})
 }

--- a/internal/graphengine/context_test.go
+++ b/internal/graphengine/context_test.go
@@ -3,6 +3,7 @@ package graphengine
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -98,5 +99,103 @@ func TestCopyGraphQLEngineTransportContextValue(t *testing.T) {
 		values := getGraphQLEngineTransportContextValue(target)
 		require.NotNil(t, values)
 		assert.Equal(t, taggedRoundTripper("current"), values.roundTripper)
+	})
+}
+
+func TestSubscriptionRequestContext(t *testing.T) {
+	newRequestWithTransportValues := func(t *testing.T, roundTripper http.RoundTripper) (*http.Request, context.CancelFunc) {
+		t.Helper()
+		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+		require.NoError(t, err)
+		requestCtx, cancelRequest := context.WithCancel(request.Context())
+		requestCtx = SetGraphQLEngineTransportContextValue(requestCtx, roundTripper, ReverseProxyHeadersConfig{
+			ProxyOnly: ProxyOnlyHeadersConfig{UseImmutableHeaders: true},
+		})
+		return request.WithContext(requestCtx), cancelRequest
+	}
+
+	t.Run("should carry the transport values of the request", func(t *testing.T) {
+		roundTripper := taggedRoundTripper("caller")
+		request, cancelRequest := newRequestWithTransportValues(t, roundTripper)
+		defer cancelRequest()
+
+		subscriptionCtx := subscriptionRequestContext(context.Background(), request)
+
+		values := getGraphQLEngineTransportContextValue(subscriptionCtx)
+		require.NotNil(t, values)
+		assert.Equal(t, roundTripper, values.roundTripper)
+		assert.True(t, values.headersConfig.ProxyOnly.UseImmutableHeaders)
+	})
+
+	// This is the regression guard for the websocket handover: net/http cancels the request
+	// context as soon as ServeHTTP returns, which happens as soon as the connection is
+	// hijacked, so a subscription must not inherit that cancellation.
+	t.Run("should not inherit the cancellation of the request", func(t *testing.T) {
+		request, cancelRequest := newRequestWithTransportValues(t, taggedRoundTripper("caller"))
+
+		subscriptionCtx := subscriptionRequestContext(context.Background(), request)
+		cancelRequest()
+
+		require.Error(t, request.Context().Err(), "the request context should be cancelled")
+		assert.NoError(t, subscriptionCtx.Err(), "the subscription context should still be alive")
+	})
+
+	t.Run("should be cancelled together with the engine", func(t *testing.T) {
+		request, cancelRequest := newRequestWithTransportValues(t, taggedRoundTripper("caller"))
+		defer cancelRequest()
+		engineCtx, cancelEngine := context.WithCancel(context.Background())
+
+		subscriptionCtx := subscriptionRequestContext(engineCtx, request)
+		require.NoError(t, subscriptionCtx.Err())
+		cancelEngine()
+
+		assert.ErrorIs(t, subscriptionCtx.Err(), context.Canceled)
+	})
+
+	t.Run("should tolerate a nil engine context and a nil request", func(t *testing.T) {
+		request, cancelRequest := newRequestWithTransportValues(t, taggedRoundTripper("caller"))
+		defer cancelRequest()
+
+		assert.NotNil(t, subscriptionRequestContext(nil, request))
+		assert.NotNil(t, subscriptionRequestContext(nil, nil))
+		assert.Nil(t, getGraphQLEngineTransportContextValue(subscriptionRequestContext(context.Background(), nil)))
+	})
+}
+
+func TestGraphQLProxyOnlyContextValues_UpstreamResponse(t *testing.T) {
+	t.Run("should return nil before the transport stored a response", func(t *testing.T) {
+		values := &GraphQLProxyOnlyContextValues{}
+
+		assert.Nil(t, values.getUpstreamResponse())
+	})
+
+	t.Run("should return the response the transport stored", func(t *testing.T) {
+		values := &GraphQLProxyOnlyContextValues{}
+		response := &http.Response{StatusCode: http.StatusTeapot}
+
+		values.setUpstreamResponse(response)
+
+		assert.Same(t, response, values.getUpstreamResponse())
+	})
+
+	// The transport writes from the fetch goroutine while the engine reads from the request
+	// goroutine, which for a subscription can be a different one. Run under -race.
+	t.Run("should be safe for concurrent use", func(t *testing.T) {
+		values := &GraphQLProxyOnlyContextValues{}
+		var waitGroup sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			waitGroup.Add(2)
+			go func() {
+				defer waitGroup.Done()
+				values.setUpstreamResponse(&http.Response{StatusCode: http.StatusOK})
+			}()
+			go func() {
+				defer waitGroup.Done()
+				_ = values.getUpstreamResponse()
+			}()
+		}
+		waitGroup.Wait()
+
+		assert.NotNil(t, values.getUpstreamResponse())
 	})
 }

--- a/internal/graphengine/credential_isolation_test.go
+++ b/internal/graphengine/credential_isolation_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -117,9 +118,15 @@ func newRecordingSSEUpstream(t *testing.T, recorder *authorizationRecorder) *htt
 	return server
 }
 
-// newRecordingWSUpstream serves a single subscription event over a WebSocket connection.
+// newRecordingWSUpstream serves subscription events over a WebSocket connection.
 // subprotocol selects the protocol to negotiate and dataMessageType the message type that
 // carries the payload: graphql-ws uses "data", graphql-transport-ws uses "next".
+//
+// It answers every subscription that arrives on the connection, not just the first. Most
+// tests open one connection per caller and so only ever use the first, but a test that
+// asserts callers are not multiplexed onto one upstream connection needs the multiplexed
+// ones to be served as well: otherwise they never complete and the test hangs instead of
+// reporting the shared connection.
 func newRecordingWSUpstream(t *testing.T, recorder *authorizationRecorder, subprotocol, dataMessageType string) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -141,26 +148,50 @@ func newRecordingWSUpstream(t *testing.T, recorder *authorizationRecorder, subpr
 		if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(`{"type":"connection_ack"}`)); err != nil {
 			return
 		}
-		// start / subscribe
-		_, message, err := connection.Read(ctx)
-		if err != nil {
-			return
+		// start / subscribe, once per subscription multiplexed onto this connection
+		for {
+			_, message, err := connection.Read(ctx)
+			if err != nil {
+				return
+			}
+			var start struct {
+				ID   string `json:"id"`
+				Type string `json:"type"`
+			}
+			if err = json.Unmarshal(message, &start); err != nil {
+				return
+			}
+			// Anything else is a stop, a complete or a keep alive, which carries no
+			// subscription to answer.
+			if start.Type != "start" && start.Type != "subscribe" {
+				continue
+			}
+			data := fmt.Sprintf(`{"type":%q,"id":%q,"payload":{"data":{"count":1}}}`, dataMessageType, start.ID)
+			if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(data)); err != nil {
+				return
+			}
+			complete := fmt.Sprintf(`{"type":"complete","id":%q}`, start.ID)
+			if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(complete)); err != nil {
+				return
+			}
 		}
-		var start struct {
-			ID string `json:"id"`
-		}
-		if err = json.Unmarshal(message, &start); err != nil {
-			return
-		}
-		data := fmt.Sprintf(`{"type":%q,"id":%q,"payload":{"data":{"count":1}}}`, dataMessageType, start.ID)
-		if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(data)); err != nil {
-			return
-		}
-		complete := fmt.Sprintf(`{"type":"complete","id":%q}`, start.ID)
-		_ = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(complete))
 	}))
 	t.Cleanup(server.Close)
 	return server
+}
+
+// isolationContextHeaderVariable matches the $tyk_context.headers_<Name> form, where the
+// dashes of the header name are written as underscores.
+var isolationContextHeaderVariable = regexp.MustCompile(`\$tyk_context\.headers_([A-Za-z0-9_]+)`)
+
+// isolationVariableReplacer stands in for Gateway.ReplaceTykVariables. It resolves against
+// the request being served, so a value that belongs to another caller stays visible as that
+// caller's value rather than silently becoming correct.
+func isolationVariableReplacer(request *http.Request, value string, _ bool) string {
+	return isolationContextHeaderVariable.ReplaceAllStringFunc(value, func(match string) string {
+		name := strings.ReplaceAll(strings.TrimPrefix(match, "$tyk_context.headers_"), "_", "-")
+		return request.Header.Get(name)
+	})
 }
 
 // newIsolationEngineV2 builds a real EngineV2 that answers every request with operation.
@@ -181,6 +212,7 @@ func newIsolationEngineV2(t *testing.T, apiDefinition *apidef.APIDefinition, ope
 				return &graphql.Request{Query: operation}
 			},
 			NewReusableBodyReadCloser: testReusableReadCloser,
+			TykVariableReplacer:       isolationVariableReplacer,
 		},
 	})
 	require.NoError(t, err)
@@ -207,9 +239,7 @@ func newIsolationEngineV3(t *testing.T, apiDefinition *apidef.APIDefinition, ope
 				return &graphqlv2.Request{Query: operation}
 			},
 			NewReusableBodyReadCloser: testReusableReadCloser,
-			TykVariableReplacer: func(_ *http.Request, value string, _ bool) string {
-				return value
-			},
+			TykVariableReplacer:       isolationVariableReplacer,
 		},
 	})
 	require.NoError(t, err)
@@ -966,6 +996,132 @@ func TestEngineV2_WebSocketUpgradeIsolatesCallerAuthorization(t *testing.T) {
 	}
 
 	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+// --- Dynamic upstream headers ----------------------------------------------------
+//
+// A UDG global header of $tyk_context.headers_Authorization is how an API definition asks
+// for the caller's credential to be forwarded upstream, and it is the shape where an
+// unresolved value does the most damage. The header modifier is what resolves it, and it has
+// to, because the library applies the modifier before it derives the key that decides whether
+// two callers share one upstream subscription connection: connectionKey in the v1
+// subscription client, UniqueRequestID in the v2 resolver. A value still holding the literal
+// $tyk_context token is the same for every caller, so every caller hashes alike.
+
+const dynamicUpstreamHeader = "X-Upstream-Authorization"
+
+// newDynamicHeaderUDGApiDefinition builds a UDG API whose only upstream credential is a
+// dynamic global header. StripAuthData keeps propagateAuthHeaders out of it, so a concrete
+// per caller value cannot reach the upstream by any other route.
+func newDynamicHeaderUDGApiDefinition(version apidef.GraphQLConfigVersion, upstreamURL string) *apidef.APIDefinition {
+	apiDefinition := newUDGApiDefinition(version, upstreamURL)
+	apiDefinition.StripAuthData = true
+	apiDefinition.GraphQL.Engine.GlobalHeaders = []apidef.UDGGlobalHeader{{
+		Key:   dynamicUpstreamHeader,
+		Value: "$tyk_context.headers_Authorization",
+	}}
+	return apiDefinition
+}
+
+// newDynamicHeaderUDGSubscriptionApiDefinition is the same thing for a subscription served by
+// a GraphQL data source.
+func newDynamicHeaderUDGSubscriptionApiDefinition(t *testing.T, version apidef.GraphQLConfigVersion, subscriptionType apidef.SubscriptionType, upstreamURL string) *apidef.APIDefinition {
+	t.Helper()
+	apiDefinition := newUDGSubscriptionApiDefinition(t, version, subscriptionType, upstreamURL)
+	apiDefinition.StripAuthData = true
+	apiDefinition.GraphQL.Engine.GlobalHeaders = []apidef.UDGGlobalHeader{{
+		Key:   dynamicUpstreamHeader,
+		Value: "$tyk_context.headers_Authorization",
+	}}
+	return apiDefinition
+}
+
+func TestEngineV2_DynamicUpstreamHeaderIsolatesCallerCredential(t *testing.T) {
+	engine := newIsolationEngineV2(t,
+		newDynamicHeaderUDGApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, upstream, "", token)
+	}
+
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.headerValues(dynamicUpstreamHeader))
+}
+
+func TestEngineV3_DynamicUpstreamHeaderIsolatesCallerCredential(t *testing.T) {
+	engine := newIsolationEngineV3(t,
+		newDynamicHeaderUDGApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, upstream, "", token)
+	}
+
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, 2)
+	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.headerValues(dynamicUpstreamHeader))
+}
+
+// The leak in one test. Every caller brings a different credential, and the count of upstream
+// connections is the assertion: an unresolved header value makes all twenty connection keys
+// identical, and the library dials and registers under one lock, so the nineteen callers
+// behind the first one deterministically multiplex onto its connection. Twenty distinct
+// credentials upstream therefore means twenty connections, none of them shared.
+func TestEngineV2_DynamicUpstreamHeaderDoesNotShareSubscriptionConnection(t *testing.T) {
+	upstream := newAuthorizationRecorder(dynamicUpstreamHeader)
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLWS, messageTypeData)
+	engine := newIsolationEngineV2(t,
+		newDynamicHeaderUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion2, apidef.GQLSubscriptionWS, server.URL),
+		"subscription { count }")
+
+	credentials := concurrentCredentials()
+	callConcurrently(t, engine, http.DefaultTransport, credentials)
+
+	assert.ElementsMatch(t, credentials, upstream.values(),
+		"every caller has to open its own upstream connection with its own credential")
+}
+
+func TestEngineV3_DynamicUpstreamHeaderDoesNotShareSubscriptionConnection(t *testing.T) {
+	upstream := newAuthorizationRecorder(dynamicUpstreamHeader)
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLWS, messageTypeData)
+	engine := newIsolationEngineV3(t,
+		newDynamicHeaderUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion3Preview, apidef.GQLSubscriptionWS, server.URL),
+		"subscription { count }")
+
+	credentials := concurrentCredentials()
+	callConcurrently(t, engine, http.DefaultTransport, credentials)
+
+	waitForUpstreamCalls(t, upstream, len(credentials))
+	assert.ElementsMatch(t, credentials, upstream.values(),
+		"every caller has to open its own upstream connection with its own credential")
+}
+
+// The plain fetch path under the same load, to catch a replacer that reads the wrong request
+// when several are in flight. Cold, so nothing is cached when the burst starts.
+func TestEngineV2_ConcurrentDynamicHeaderCallersDoNotShareCredentials(t *testing.T) {
+	engine := newIsolationEngineV2(t,
+		newDynamicHeaderUDGApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	credentials := concurrentCredentials()
+	callConcurrently(t, engine, upstream, credentials)
+
+	assert.ElementsMatch(t, credentials, upstream.headerValues(dynamicUpstreamHeader))
+}
+
+func TestEngineV3_ConcurrentDynamicHeaderCallersDoNotShareCredentials(t *testing.T) {
+	engine := newIsolationEngineV3(t,
+		newDynamicHeaderUDGApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	credentials := concurrentCredentials()
+	callConcurrently(t, engine, upstream, credentials)
+
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, len(credentials))
+	assert.ElementsMatch(t, credentials, upstream.headerValues(dynamicUpstreamHeader))
 }
 
 // Engine v3 has no WebSocket upgrade test. 3-preview accepts the upgrade and starts the

--- a/internal/graphengine/credential_isolation_test.go
+++ b/internal/graphengine/credential_isolation_test.go
@@ -1,0 +1,959 @@
+package graphengine
+
+// Shared fixtures for the upstream credential isolation tests. The defect these guard
+// against is a cached execution plan that carries the first caller's upstream auth
+// header, so every test here drives at least two callers with different credentials
+// through one engine and asserts what each upstream connection actually received.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	nhooyrwebsocket "github.com/coder/websocket"
+	gorillawebsocket "github.com/gorilla/websocket"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+	graphqlv2 "github.com/TykTechnologies/graphql-go-tools/v2/pkg/graphql"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+const (
+	// The two upstream WebSocket protocols that a data source can be configured with.
+	// They differ in the message type that carries a payload.
+	protocolGraphQLWS          = "graphql-ws"
+	protocolGraphQLTransportWS = "graphql-transport-ws"
+	messageTypeData            = "data" // graphql-ws
+	messageTypeNext            = "next" // graphql-transport-ws
+
+	isolationTestSchema = "type Query { hello: String } type Subscription { count: Int }"
+)
+
+// authorizationRecorder records the credential that each upstream connection carried,
+// in the order the upstream saw them.
+type authorizationRecorder struct {
+	// headerName is the request header that values() reports. Empty means Authorization.
+	headerName string
+
+	mu       sync.Mutex
+	received []http.Header
+}
+
+func newAuthorizationRecorder(headerName string) *authorizationRecorder {
+	return &authorizationRecorder{headerName: headerName}
+}
+
+func (r *authorizationRecorder) header() string {
+	if r.headerName == "" {
+		return "Authorization"
+	}
+	return r.headerName
+}
+
+func (r *authorizationRecorder) recordRequest(request *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.received = append(r.received, request.Header.Clone())
+}
+
+// values returns the credential of every recorded upstream connection, in order.
+func (r *authorizationRecorder) values() []string {
+	return r.headerValues(r.header())
+}
+
+// headerValues returns the value of name for every recorded upstream connection, in order.
+func (r *authorizationRecorder) headerValues(name string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	values := make([]string, 0, len(r.received))
+	for _, recorded := range r.received {
+		values = append(values, recorded.Get(name))
+	}
+	return values
+}
+
+// authorizationRecordingRoundTripper records the credential of every upstream fetch and
+// answers with a valid GraphQL response. Proxy-only mode reads the header and the status
+// code of this response back out of the proxy-only context, so both are populated.
+type authorizationRecordingRoundTripper struct {
+	*authorizationRecorder
+}
+
+func newAuthorizationRecordingRoundTripper() *authorizationRecordingRoundTripper {
+	return &authorizationRecordingRoundTripper{authorizationRecorder: newAuthorizationRecorder("")}
+}
+
+func (r *authorizationRecordingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	r.recordRequest(request)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(`{"data":{"hello":"world"}}`)),
+		Request:    request,
+	}, nil
+}
+
+// newRecordingSSEUpstream serves a single subscription event over server sent events.
+func newRecordingSSEUpstream(t *testing.T, recorder *authorizationRecorder) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		recorder.recordRequest(request)
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(writer, "event: next\ndata: {\"data\":{\"count\":1}}\n\nevent: complete\n\n")
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// newRecordingWSUpstream serves a single subscription event over a WebSocket connection.
+// subprotocol selects the protocol to negotiate and dataMessageType the message type that
+// carries the payload: graphql-ws uses "data", graphql-transport-ws uses "next".
+func newRecordingWSUpstream(t *testing.T, recorder *authorizationRecorder, subprotocol, dataMessageType string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		recorder.recordRequest(request)
+
+		connection, err := nhooyrwebsocket.Accept(writer, request, &nhooyrwebsocket.AcceptOptions{
+			Subprotocols: []string{subprotocol},
+		})
+		if err != nil {
+			return
+		}
+		defer connection.CloseNow()
+		ctx := request.Context()
+		// connection_init
+		_, _, err = connection.Read(ctx)
+		if err != nil {
+			return
+		}
+		if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(`{"type":"connection_ack"}`)); err != nil {
+			return
+		}
+		// start / subscribe
+		_, message, err := connection.Read(ctx)
+		if err != nil {
+			return
+		}
+		var start struct {
+			ID string `json:"id"`
+		}
+		if err = json.Unmarshal(message, &start); err != nil {
+			return
+		}
+		data := fmt.Sprintf(`{"type":%q,"id":%q,"payload":{"data":{"count":1}}}`, dataMessageType, start.ID)
+		if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(data)); err != nil {
+			return
+		}
+		complete := fmt.Sprintf(`{"type":"complete","id":%q}`, start.ID)
+		_ = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(complete))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// newIsolationEngineV2 builds a real EngineV2 that answers every request with operation.
+// The gateway hands one client per API to both the http and the streaming client, so the
+// tests do the same.
+func newIsolationEngineV2(t *testing.T, apiDefinition *apidef.APIDefinition, operation string) *EngineV2 {
+	t.Helper()
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	client := &http.Client{}
+	engine, err := NewEngineV2(EngineV2Options{
+		Logger:          logger,
+		ApiDefinition:   apiDefinition,
+		HttpClient:      client,
+		StreamingClient: client,
+		Injections: EngineV2Injections{
+			ContextRetrieveRequest: func(*http.Request) *graphql.Request {
+				return &graphql.Request{Query: operation}
+			},
+			NewReusableBodyReadCloser: testReusableReadCloser,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(engine.Cancel)
+	return engine
+}
+
+// newIsolationEngineV3 builds a real EngineV3 that answers every request with operation.
+func newIsolationEngineV3(t *testing.T, apiDefinition *apidef.APIDefinition, operation string) *EngineV3 {
+	t.Helper()
+	schema, err := graphqlv2.NewSchemaFromString(apiDefinition.GraphQL.Schema)
+	require.NoError(t, err)
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	client := &http.Client{}
+	engine, err := NewEngineV3(EngineV3Options{
+		Logger:          logger,
+		Schema:          schema,
+		ApiDefinition:   apiDefinition,
+		HttpClient:      client,
+		StreamingClient: client,
+		Injections: EngineV3Injections{
+			ContextRetrieveRequest: func(*http.Request) *graphqlv2.Request {
+				return &graphqlv2.Request{Query: operation}
+			},
+			NewReusableBodyReadCloser: testReusableReadCloser,
+			TykVariableReplacer: func(_ *http.Request, value string, _ bool) string {
+				return value
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(engine.Cancel)
+	return engine
+}
+
+// callerRequest builds a gateway request that carries credential in headerName. An empty
+// credential produces a request without the header, which is the unauthenticated caller.
+// extraHeaders are set verbatim, which lets a test tell one caller from another by a header
+// that only proxy-only header forwarding copies upstream.
+func callerRequest(t *testing.T, headerName, credential string, extraHeaders map[string]string) *http.Request {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+	require.NoError(t, err)
+	if credential != "" {
+		if headerName == "" {
+			headerName = "Authorization"
+		}
+		request.Header.Set(headerName, credential)
+	}
+	for key, value := range extraHeaders {
+		request.Header.Set(key, value)
+	}
+	return request
+}
+
+// callAs drives one request through the engine and releases the response body.
+func callAs(t *testing.T, engine Engine, roundTripper http.RoundTripper, headerName, credential string) {
+	t.Helper()
+	callAsWithHeaders(t, engine, roundTripper, headerName, credential, nil)
+}
+
+func callAsWithHeaders(t *testing.T, engine Engine, roundTripper http.RoundTripper, headerName, credential string, extraHeaders map[string]string) {
+	t.Helper()
+	response, _, err := engine.HandleReverseProxy(ReverseProxyParams{
+		RoundTripper: roundTripper,
+		OutRequest:   callerRequest(t, headerName, credential, extraHeaders),
+		NeedsEngine:  true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	_ = response.Body.Close()
+}
+
+// newUDGApiDefinition builds an execution engine (UDG) API with a single REST data source
+// for queries.
+func newUDGApiDefinition(version apidef.GraphQLConfigVersion, upstreamURL string) *apidef.APIDefinition {
+	apiDefinition := newTestApiDefinitionV2(apidef.GraphQLExecutionModeExecutionEngine, upstreamURL)
+	apiDefinition.GraphQL.Version = version
+	apiDefinition.UseStandardAuth = true
+	apiDefinition.StripAuthData = false
+	return apiDefinition
+}
+
+// newUDGSubscriptionApiDefinition builds an execution engine (UDG) API with a single GraphQL
+// data source that serves the count subscription over subscriptionType.
+func newUDGSubscriptionApiDefinition(t *testing.T, version apidef.GraphQLConfigVersion, subscriptionType apidef.SubscriptionType, upstreamURL string) *apidef.APIDefinition {
+	t.Helper()
+	dataSourceConfig, err := json.Marshal(apidef.GraphQLEngineDataSourceConfigGraphQL{
+		URL:              upstreamURL,
+		Method:           http.MethodPost,
+		SubscriptionType: subscriptionType,
+		SSEUsePost:       subscriptionType == apidef.GQLSubscriptionSSE,
+	})
+	require.NoError(t, err)
+	return &apidef.APIDefinition{
+		UseStandardAuth: true,
+		GraphQL: apidef.GraphQLConfig{
+			Enabled:       true,
+			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
+			Version:       version,
+			Schema:        isolationTestSchema,
+			Engine: apidef.GraphQLEngineConfig{DataSources: []apidef.GraphQLEngineDataSource{{
+				Kind:       apidef.GraphQLEngineDataSourceKindGraphQL,
+				Name:       "subscription",
+				RootFields: []apidef.GraphQLTypeFields{{Type: "Subscription", Fields: []string{"count"}}},
+				Config:     dataSourceConfig,
+			}}},
+		},
+	}
+}
+
+// newProxyOnlyApiDefinition builds a proxy-only API. Proxy-only reaches the engine for
+// config version 2 and 3-preview, see needsGraphQLExecutionEngine in gateway/mw_graphql.go.
+func newProxyOnlyApiDefinition(version apidef.GraphQLConfigVersion, targetURL string, subscriptionType apidef.SubscriptionType) *apidef.APIDefinition {
+	apiDefinition := &apidef.APIDefinition{
+		UseStandardAuth: true,
+		GraphQL: apidef.GraphQLConfig{
+			Enabled:       true,
+			ExecutionMode: apidef.GraphQLExecutionModeProxyOnly,
+			Version:       version,
+			Schema:        isolationTestSchema,
+			Proxy: apidef.GraphQLProxyConfig{
+				SubscriptionType: subscriptionType,
+				// Engine v3 proxy-only has no SSEUsePost equivalent, so SSE is a GET there.
+				SSEUsePost: subscriptionType == apidef.GQLSubscriptionSSE && version == apidef.GraphQLConfigVersion2,
+			},
+		},
+	}
+	apiDefinition.Proxy.TargetURL = targetURL
+	return apiDefinition
+}
+
+// waitForUpstreamCalls waits for count upstream connections. The engine v3 resolver
+// completes fetches asynchronously, so unlike the v2 tests those have to poll.
+func waitForUpstreamCalls(t *testing.T, recorder *authorizationRecorder, count int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(recorder.values()) == count
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// --- Proxy-only mode -------------------------------------------------------------
+//
+// Proxy-only reaches the engine on config version 2 and 3-preview, see
+// needsGraphQLExecutionEngine in gateway/mw_graphql.go. It is also the only mode that
+// takes GraphQLEngineTransport.handleProxyOnly and therefore the per-request
+// headersConfig, so the HTTP cases assert a plain caller header was forwarded too:
+// only setProxyOnlyHeaders copies that upstream.
+
+func TestEngineV2_ProxyOnlyHTTPIsolatesCallerAuthorization(t *testing.T) {
+	engine := newIsolationEngineV2(t,
+		newProxyOnlyApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql", apidef.GQLSubscriptionUndefined),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, caller := range []string{"a", "b"} {
+		callAsWithHeaders(t, engine, upstream, "", "Bearer "+caller, map[string]string{"X-Caller": caller})
+	}
+
+	assert.Equal(t, []string{"Bearer a", "Bearer b"}, upstream.values())
+	// Proves the proxy-only branch of the transport ran: nothing else forwards X-Caller.
+	assert.Equal(t, []string{"a", "b"}, upstream.headerValues("X-Caller"))
+}
+
+func TestEngineV2_ProxyOnlySSESubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingSSEUpstream(t, upstream)
+	engine := newIsolationEngineV2(t,
+		newProxyOnlyApiDefinition(apidef.GraphQLConfigVersion2, server.URL, apidef.GQLSubscriptionSSE),
+		"subscription { count }")
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, http.DefaultTransport, "", token)
+	}
+
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestEngineV2_ProxyOnlyWebSocketSubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLWS, messageTypeData)
+	engine := newIsolationEngineV2(t,
+		newProxyOnlyApiDefinition(apidef.GraphQLConfigVersion2, server.URL, apidef.GQLSubscriptionWS),
+		"subscription { count }")
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, http.DefaultTransport, "", token)
+	}
+
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestEngineV3_ProxyOnlyHTTPIsolatesCallerAuthorization(t *testing.T) {
+	engine := newIsolationEngineV3(t,
+		newProxyOnlyApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql", apidef.GQLSubscriptionUndefined),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, caller := range []string{"a", "b"} {
+		callAsWithHeaders(t, engine, upstream, "", "Bearer "+caller, map[string]string{"X-Caller": caller})
+	}
+
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, 2)
+	assert.ElementsMatch(t, []string{"Bearer a", "Bearer b"}, upstream.values())
+	assert.ElementsMatch(t, []string{"a", "b"}, upstream.headerValues("X-Caller"))
+}
+
+func TestEngineV3_ProxyOnlySSESubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingSSEUpstream(t, upstream)
+	engine := newIsolationEngineV3(t,
+		newProxyOnlyApiDefinition(apidef.GraphQLConfigVersion3Preview, server.URL, apidef.GQLSubscriptionSSE),
+		"subscription { count }")
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, http.DefaultTransport, "", token)
+	}
+
+	waitForUpstreamCalls(t, upstream, 2)
+	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestEngineV3_ProxyOnlyWebSocketSubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLWS, messageTypeData)
+	engine := newIsolationEngineV3(t,
+		newProxyOnlyApiDefinition(apidef.GraphQLConfigVersion3Preview, server.URL, apidef.GQLSubscriptionWS),
+		"subscription { count }")
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, http.DefaultTransport, "", token)
+	}
+
+	waitForUpstreamCalls(t, upstream, 2)
+	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+// --- graphql-transport-ws --------------------------------------------------------
+//
+// The second upstream WebSocket protocol has its own handler in the library. The
+// graphql-ws tests above cover the legacy one.
+
+func TestEngineV2_TransportWSSubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLTransportWS, messageTypeNext)
+	engine := newIsolationEngineV2(t,
+		newUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion2, apidef.GQLSubscriptionTransportWS, server.URL),
+		"subscription { count }")
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, http.DefaultTransport, "", token)
+	}
+
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestEngineV3_TransportWSSubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLTransportWS, messageTypeNext)
+	engine := newIsolationEngineV3(t,
+		newUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion3Preview, apidef.GQLSubscriptionTransportWS, server.URL),
+		"subscription { count }")
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, http.DefaultTransport, "", token)
+	}
+
+	waitForUpstreamCalls(t, upstream, 2)
+	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+// --- Negative controls -----------------------------------------------------------
+
+// An unauthenticated caller after an authenticated one is the reported defect shape: a
+// stale, only-if-absent header modifier hands the second caller the first caller's
+// credential instead of leaving the header unset.
+func TestEngineV2_UnauthenticatedCallerDoesNotInheritCredential(t *testing.T) {
+	t.Run("execution engine", func(t *testing.T) {
+		engine := newIsolationEngineV2(t,
+			newUDGApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql"),
+			"query { hello }")
+
+		upstream := newAuthorizationRecordingRoundTripper()
+		callAs(t, engine, upstream, "", "Bearer AAA")
+		callAs(t, engine, upstream, "", "")
+
+		assert.Equal(t, []string{"Bearer AAA", ""}, upstream.values())
+	})
+
+	t.Run("proxy only", func(t *testing.T) {
+		engine := newIsolationEngineV2(t,
+			newProxyOnlyApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql", apidef.GQLSubscriptionUndefined),
+			"query { hello }")
+
+		upstream := newAuthorizationRecordingRoundTripper()
+		callAs(t, engine, upstream, "", "Bearer AAA")
+		callAs(t, engine, upstream, "", "")
+
+		assert.Equal(t, []string{"Bearer AAA", ""}, upstream.values())
+	})
+}
+
+func TestEngineV3_UnauthenticatedCallerDoesNotInheritCredential(t *testing.T) {
+	t.Run("execution engine", func(t *testing.T) {
+		engine := newIsolationEngineV3(t,
+			newUDGApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql"),
+			"query { hello }")
+
+		upstream := newAuthorizationRecordingRoundTripper()
+		callAs(t, engine, upstream, "", "Bearer AAA")
+		callAs(t, engine, upstream, "", "")
+
+		waitForUpstreamCalls(t, upstream.authorizationRecorder, 2)
+		assert.ElementsMatch(t, []string{"Bearer AAA", ""}, upstream.values())
+	})
+
+	t.Run("proxy only", func(t *testing.T) {
+		engine := newIsolationEngineV3(t,
+			newProxyOnlyApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql", apidef.GQLSubscriptionUndefined),
+			"query { hello }")
+
+		upstream := newAuthorizationRecordingRoundTripper()
+		callAs(t, engine, upstream, "", "Bearer AAA")
+		callAs(t, engine, upstream, "", "")
+
+		waitForUpstreamCalls(t, upstream.authorizationRecorder, 2)
+		assert.ElementsMatch(t, []string{"Bearer AAA", ""}, upstream.values())
+	})
+}
+
+// StripAuthData has to keep the credential away from the upstream. This is execution
+// engine only on purpose: in proxy-only mode setProxyOnlyHeaders forwards every caller
+// header regardless, and the gateway strips the auth data before the engine sees it.
+func TestEngineV2_StripAuthDataKeepsCredentialFromUpstream(t *testing.T) {
+	apiDefinition := newUDGApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql")
+	apiDefinition.StripAuthData = true
+	engine := newIsolationEngineV2(t, apiDefinition, "query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, upstream, "", token)
+	}
+
+	assert.Equal(t, []string{"", ""}, upstream.values())
+}
+
+func TestEngineV3_StripAuthDataKeepsCredentialFromUpstream(t *testing.T) {
+	apiDefinition := newUDGApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql")
+	apiDefinition.StripAuthData = true
+	engine := newIsolationEngineV3(t, apiDefinition, "query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, upstream, "", token)
+	}
+
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, 2)
+	assert.Equal(t, []string{"", ""}, upstream.values())
+}
+
+// A custom auth header name has to be isolated per caller too, and must not fall back to
+// Authorization.
+func TestEngineV2_CustomAuthHeaderNameIsolatesCallerCredential(t *testing.T) {
+	apiDefinition := newUDGApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql")
+	apiDefinition.AuthConfigs = map[string]apidef.AuthConfig{
+		apidef.AuthTokenType: {AuthHeaderName: "X-Api-Key"},
+	}
+	engine := newIsolationEngineV2(t, apiDefinition, "query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, key := range []string{"key-aaa", "key-bbb"} {
+		callAs(t, engine, upstream, "X-Api-Key", key)
+	}
+
+	assert.Equal(t, []string{"key-aaa", "key-bbb"}, upstream.headerValues("X-Api-Key"))
+	assert.Equal(t, []string{"", ""}, upstream.headerValues("Authorization"))
+}
+
+func TestEngineV3_CustomAuthHeaderNameIsolatesCallerCredential(t *testing.T) {
+	apiDefinition := newUDGApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql")
+	apiDefinition.AuthConfigs = map[string]apidef.AuthConfig{
+		apidef.AuthTokenType: {AuthHeaderName: "X-Api-Key"},
+	}
+	engine := newIsolationEngineV3(t, apiDefinition, "query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, key := range []string{"key-aaa", "key-bbb"} {
+		callAs(t, engine, upstream, "X-Api-Key", key)
+	}
+
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, 2)
+	assert.ElementsMatch(t, []string{"key-aaa", "key-bbb"}, upstream.headerValues("X-Api-Key"))
+	assert.Equal(t, []string{"", ""}, upstream.headerValues("Authorization"))
+}
+
+// --- Concurrency -----------------------------------------------------------------
+//
+// The defect is a shared state defect, so the sequential tests above are the weaker
+// case. Every caller gets a unique credential and the multiset has to come back intact:
+// ElementsMatch catches a lost credential and a duplicated one alike.
+//
+// Both tests send one warm-up request before fanning out, which is also the production
+// state of an API that has served a request: the execution plan is cached, which is the
+// condition the credential defect needs.
+//
+// The warm-up is also what keeps these green under -race against the currently pinned
+// graphql-go-tools, which memoises lazily and without synchronisation in two places that a
+// cold concurrent burst hits. Both predate the version bump, byte for byte, and both are
+// fixed by scratchpad/gql-repro/fixes/graphql-go-tools/0006 and 0007:
+//   - v1 pkg/graphql/schema.go Schema.Hash writes s.hash on first use, and every request
+//     validates against the one *Schema of the API spec.
+//   - v2 pkg/engine/resolve/resolve.go ResolveGraphQLResponse writes response.Info on the
+//     cached plan on first use.
+//
+// Once those land and the pin moves, the warm-up is no longer required for -race, only for
+// the warm plan cache.
+
+const concurrentIsolationCallers = 20
+
+func concurrentCredentials() []string {
+	credentials := make([]string, 0, concurrentIsolationCallers)
+	for i := 0; i < concurrentIsolationCallers; i++ {
+		credentials = append(credentials, fmt.Sprintf("Bearer caller-%02d", i))
+	}
+	return credentials
+}
+
+// callConcurrently drives one request per credential at the same time.
+func callConcurrently(t *testing.T, engine Engine, roundTripper http.RoundTripper, credentials []string) {
+	t.Helper()
+	var waitGroup sync.WaitGroup
+	for _, credential := range credentials {
+		waitGroup.Add(1)
+		go func(credential string) {
+			defer waitGroup.Done()
+			callAs(t, engine, roundTripper, "", credential)
+		}(credential)
+	}
+	waitGroup.Wait()
+}
+
+func TestEngineV2_ConcurrentCallersDoNotShareCredentials(t *testing.T) {
+	engine := newIsolationEngineV2(t,
+		newUDGApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	callAs(t, engine, upstream, "", "Bearer warm-up")
+
+	credentials := concurrentCredentials()
+	callConcurrently(t, engine, upstream, credentials)
+
+	assert.ElementsMatch(t, append([]string{"Bearer warm-up"}, credentials...), upstream.values())
+}
+
+func TestEngineV3_ConcurrentCallersDoNotShareCredentials(t *testing.T) {
+	engine := newIsolationEngineV3(t,
+		newUDGApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	callAs(t, engine, upstream, "", "Bearer warm-up")
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, 1)
+
+	credentials := concurrentCredentials()
+	callConcurrently(t, engine, upstream, credentials)
+
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, len(credentials)+1)
+	assert.ElementsMatch(t, append([]string{"Bearer warm-up"}, credentials...), upstream.values())
+}
+
+// --- Supergraph ------------------------------------------------------------------
+//
+// Supergraph is the only mode that turns on the data loader and single flight, see
+// gqlengineadapter/adapter_supergraph.go. The entity fetch to the second subgraph runs
+// through the data loader, which is a separate code path from a plain root fetch.
+
+const (
+	isolationMergedSDL = `type Query {
+	allUsers: [User]
+}
+
+type User {
+	id: ID!
+	username: String!
+	account: [BankAccount!]
+}
+
+type BankAccount {
+	number: String
+	balance: Float
+}`
+
+	isolationAccountsSDL = `extend type Query {
+	allUsers: [User]
+}
+
+type User @key(fields: "id") {
+	id: ID!
+	username: String!
+}`
+
+	isolationBankAccountsSDL = `extend type User @key(fields: "id") {
+	id: ID! @extends
+	account: [BankAccount!]
+}
+
+type BankAccount {
+	number: String
+	balance: Float
+}`
+
+	isolationSupergraphOperation = "query { allUsers { id username account { number } } }"
+)
+
+// newRecordingGraphQLUpstream answers every request with responseBody and records the
+// credential it carried.
+func newRecordingGraphQLUpstream(t *testing.T, recorder *authorizationRecorder, responseBody string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		recorder.recordRequest(request)
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(writer, responseBody)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newSupergraphApiDefinition(accountsURL, bankAccountsURL string) *apidef.APIDefinition {
+	return &apidef.APIDefinition{
+		UseStandardAuth: true,
+		GraphQL: apidef.GraphQLConfig{
+			Enabled:       true,
+			ExecutionMode: apidef.GraphQLExecutionModeSupergraph,
+			Version:       apidef.GraphQLConfigVersion2,
+			Schema:        isolationMergedSDL,
+			Supergraph: apidef.GraphQLSupergraphConfig{
+				MergedSDL: isolationMergedSDL,
+				Subgraphs: []apidef.GraphQLSubgraphEntity{
+					{APIID: "accounts", URL: accountsURL, SDL: isolationAccountsSDL},
+					{APIID: "bank-accounts", URL: bankAccountsURL, SDL: isolationBankAccountsSDL},
+				},
+			},
+		},
+	}
+}
+
+func TestEngineV2_SupergraphIsolatesCallerAuthorization(t *testing.T) {
+	accountsRecorder := newAuthorizationRecorder("")
+	accounts := newRecordingGraphQLUpstream(t, accountsRecorder,
+		`{"data":{"allUsers":[{"id":"1","username":"u1","__typename":"User"}]}}`)
+	// The entity fetch that resolves User.account on the second subgraph.
+	entitiesRecorder := newAuthorizationRecorder("")
+	bankAccounts := newRecordingGraphQLUpstream(t, entitiesRecorder,
+		`{"data":{"_entities":[{"account":[{"number":"123"}]}]}}`)
+
+	engine := newIsolationEngineV2(t,
+		newSupergraphApiDefinition(accounts.URL, bankAccounts.URL),
+		isolationSupergraphOperation)
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		callAs(t, engine, http.DefaultTransport, "", token)
+	}
+
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, accountsRecorder.values(), "root fetch")
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, entitiesRecorder.values(), "entity fetch")
+}
+
+func TestEngineV2_SupergraphUnauthenticatedCallerDoesNotInheritCredential(t *testing.T) {
+	accountsRecorder := newAuthorizationRecorder("")
+	accounts := newRecordingGraphQLUpstream(t, accountsRecorder,
+		`{"data":{"allUsers":[{"id":"1","username":"u1","__typename":"User"}]}}`)
+	entitiesRecorder := newAuthorizationRecorder("")
+	bankAccounts := newRecordingGraphQLUpstream(t, entitiesRecorder,
+		`{"data":{"_entities":[{"account":[{"number":"123"}]}]}}`)
+
+	engine := newIsolationEngineV2(t,
+		newSupergraphApiDefinition(accounts.URL, bankAccounts.URL),
+		isolationSupergraphOperation)
+
+	callAs(t, engine, http.DefaultTransport, "", "Bearer AAA")
+	callAs(t, engine, http.DefaultTransport, "", "")
+
+	assert.Equal(t, []string{"Bearer AAA", ""}, accountsRecorder.values(), "root fetch")
+	assert.Equal(t, []string{"Bearer AAA", ""}, entitiesRecorder.values(), "entity fetch")
+}
+
+// Config version 3-preview rejects supergraph in the adapter, so there is no engine v3
+// twin of the tests above. See EngineConfigV3 in apidef/adapter/graphql_config_adapter.go.
+func TestNewEngineV3_RejectsSupergraph(t *testing.T) {
+	apiDefinition := newSupergraphApiDefinition("http://accounts.example", "http://bank-accounts.example")
+	apiDefinition.GraphQL.Version = apidef.GraphQLConfigVersion3Preview
+	schema, err := graphqlv2.NewSchemaFromString(apiDefinition.GraphQL.Schema)
+	require.NoError(t, err)
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	engine, err := NewEngineV3(EngineV3Options{
+		Logger:        logger,
+		Schema:        schema,
+		ApiDefinition: apiDefinition,
+		HttpClient:    &http.Client{},
+		Injections: EngineV3Injections{
+			NewReusableBodyReadCloser: testReusableReadCloser,
+		},
+	})
+	assert.Error(t, err)
+	assert.Nil(t, engine)
+}
+
+// Credential isolation alone does not prove transport isolation: if every caller shares
+// one round tripper, a shared http.Client.Transport looks identical to a request scoped
+// one. Here each caller brings its own round tripper and has to be the only one that sees
+// its own credential, which is what a mutated shared transport cannot deliver.
+func TestEngineV2_ConcurrentCallersDoNotShareTransports(t *testing.T) {
+	engine := newIsolationEngineV2(t,
+		newUDGApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	warmUp := newAuthorizationRecordingRoundTripper()
+	callAs(t, engine, warmUp, "", "Bearer warm-up")
+
+	credentials := concurrentCredentials()
+	upstreams := make([]*authorizationRecordingRoundTripper, len(credentials))
+	var waitGroup sync.WaitGroup
+	for i, credential := range credentials {
+		upstreams[i] = newAuthorizationRecordingRoundTripper()
+		waitGroup.Add(1)
+		go func(i int, credential string) {
+			defer waitGroup.Done()
+			callAs(t, engine, upstreams[i], "", credential)
+		}(i, credential)
+	}
+	waitGroup.Wait()
+
+	for i, credential := range credentials {
+		assert.Equal(t, []string{credential}, upstreams[i].values(),
+			"the fetch of caller %d has to go through the round tripper of caller %d", i, i)
+	}
+}
+
+func TestEngineV3_ConcurrentCallersDoNotShareTransports(t *testing.T) {
+	engine := newIsolationEngineV3(t,
+		newUDGApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	warmUp := newAuthorizationRecordingRoundTripper()
+	callAs(t, engine, warmUp, "", "Bearer warm-up")
+	waitForUpstreamCalls(t, warmUp.authorizationRecorder, 1)
+
+	credentials := concurrentCredentials()
+	upstreams := make([]*authorizationRecordingRoundTripper, len(credentials))
+	var waitGroup sync.WaitGroup
+	for i, credential := range credentials {
+		upstreams[i] = newAuthorizationRecordingRoundTripper()
+		waitGroup.Add(1)
+		go func(i int, credential string) {
+			defer waitGroup.Done()
+			callAs(t, engine, upstreams[i], "", credential)
+		}(i, credential)
+	}
+	waitGroup.Wait()
+
+	for i, credential := range credentials {
+		waitForUpstreamCalls(t, upstreams[i].authorizationRecorder, 1)
+		assert.Equal(t, []string{credential}, upstreams[i].values(),
+			"the fetch of caller %d has to go through the round tripper of caller %d", i, i)
+	}
+}
+
+// --- Client WebSocket upgrade path -----------------------------------------------
+//
+// A real subscription arrives as a WebSocket upgrade, which routes through
+// handoverWebSocketConnectionToGraphQLExecutionEngine rather than the HTTP handover. That
+// is the path where the context handed to the subscription handler matters: net/http
+// cancels the request context as soon as ServeHTTP returns, and the gateway returns as
+// soon as the connection is hijacked, so a subscription rooted at the request context
+// never delivers anything. See subscriptionRequestContext.
+
+// newWSUpgradeGateway serves the engine over a real HTTP server, so a client can perform a
+// WebSocket upgrade against it the way the gateway does.
+func newWSUpgradeGateway(t *testing.T, engine Engine) string {
+	t.Helper()
+	upgrader := &gorillawebsocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _, err := engine.HandleReverseProxy(ReverseProxyParams{
+			RoundTripper:       http.DefaultTransport,
+			ResponseWriter:     writer,
+			OutRequest:         request,
+			WebSocketUpgrader:  upgrader,
+			NeedsEngine:        true,
+			IsWebSocketUpgrade: true,
+		})
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	return "ws" + strings.TrimPrefix(server.URL, "http")
+}
+
+// subscribeOverWebSocket opens a graphql-ws subscription against the gateway and returns
+// the first payload message. It fails the test if the connection dies before one arrives.
+func subscribeOverWebSocket(t *testing.T, gatewayURL, headerName, credential, operation string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	requestHeader := http.Header{}
+	if credential != "" {
+		if headerName == "" {
+			headerName = "Authorization"
+		}
+		requestHeader.Set(headerName, credential)
+	}
+	connection, _, err := nhooyrwebsocket.Dial(ctx, gatewayURL, &nhooyrwebsocket.DialOptions{
+		Subprotocols: []string{protocolGraphQLWS},
+		HTTPHeader:   requestHeader,
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = connection.CloseNow()
+	}()
+
+	require.NoError(t, connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(`{"type":"connection_init"}`)))
+	_, acknowledgement, err := connection.Read(ctx)
+	require.NoError(t, err)
+	require.Contains(t, string(acknowledgement), "connection_ack")
+
+	start := fmt.Sprintf(`{"id":"1","type":"start","payload":{"query":%q}}`, operation)
+	require.NoError(t, connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(start)))
+
+	for {
+		_, message, err := connection.Read(ctx)
+		require.NoError(t, err, "the subscription closed before it delivered a payload")
+		// Skip keep alives, which carry no payload.
+		if strings.Contains(string(message), `"payload"`) {
+			return string(message)
+		}
+	}
+}
+
+func TestEngineV2_WebSocketUpgradeDeliversSubscriptionData(t *testing.T) {
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLWS, messageTypeData)
+	engine := newIsolationEngineV2(t,
+		newUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion2, apidef.GQLSubscriptionWS, server.URL),
+		"subscription { count }")
+
+	message := subscribeOverWebSocket(t, newWSUpgradeGateway(t, engine), "", "Bearer AAA", "subscription { count }")
+
+	assert.Contains(t, message, `"count":1`)
+	assert.Equal(t, []string{"Bearer AAA"}, upstream.values())
+}
+
+func TestEngineV2_WebSocketUpgradeIsolatesCallerAuthorization(t *testing.T) {
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLWS, messageTypeData)
+	engine := newIsolationEngineV2(t,
+		newUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion2, apidef.GQLSubscriptionWS, server.URL),
+		"subscription { count }")
+	gateway := newWSUpgradeGateway(t, engine)
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		message := subscribeOverWebSocket(t, gateway, "", token, "subscription { count }")
+		assert.Contains(t, message, `"count":1`)
+	}
+
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+// Engine v3 has no WebSocket upgrade test. 3-preview accepts the upgrade and starts the
+// upstream subscription with the right credential, but never writes a payload back to the
+// client. That is independent of the subscription context: it behaves identically with
+// context.Background(), with the request context and with the engine context. The v3
+// upstream credential isolation is covered through the HTTP handover instead, see
+// TestEngineV3_WebSocketSubscriptionIsolatesCallerAuthorization.

--- a/internal/graphengine/credential_isolation_test.go
+++ b/internal/graphengine/credential_isolation_test.go
@@ -9,8 +9,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -128,7 +130,8 @@ func newRecordingSSEUpstream(t *testing.T, recorder *authorizationRecorder) *htt
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		recorder.recordRequest(request)
 		writer.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(writer, "event: next\ndata: {\"data\":{\"count\":1}}\n\nevent: complete\n\n")
+		_, err := io.WriteString(writer, "event: next\ndata: {\"data\":{\"count\":1}}\n\nevent: complete\n\n")
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
 	return server
@@ -147,53 +150,77 @@ func newRecordingWSUpstream(t *testing.T, recorder *authorizationRecorder, subpr
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		recorder.recordRequest(request)
-
-		connection, err := nhooyrwebsocket.Accept(writer, request, &nhooyrwebsocket.AcceptOptions{
-			Subprotocols: []string{subprotocol},
-		})
-		if err != nil {
-			return
-		}
-		defer connection.CloseNow()
-		ctx := request.Context()
-		// connection_init
-		_, _, err = connection.Read(ctx)
-		if err != nil {
-			return
-		}
-		if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(`{"type":"connection_ack"}`)); err != nil {
-			return
-		}
-		// start / subscribe, once per subscription multiplexed onto this connection
-		for {
-			_, message, err := connection.Read(ctx)
-			if err != nil {
-				return
-			}
-			var start struct {
-				ID   string `json:"id"`
-				Type string `json:"type"`
-			}
-			if err = json.Unmarshal(message, &start); err != nil {
-				return
-			}
-			// Anything else is a stop, a complete or a keep alive, which carries no
-			// subscription to answer.
-			if start.Type != "start" && start.Type != "subscribe" {
-				continue
-			}
-			data := fmt.Sprintf(`{"type":%q,"id":%q,"payload":{"data":{"count":1}}}`, dataMessageType, start.ID)
-			if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(data)); err != nil {
-				return
-			}
-			complete := fmt.Sprintf(`{"type":"complete","id":%q}`, start.ID)
-			if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(complete)); err != nil {
-				return
-			}
-		}
+		serveRecordingWSConnection(writer, request, subprotocol, dataMessageType)
 	}))
 	t.Cleanup(server.Close)
 	return server
+}
+
+// serveRecordingWSConnection accepts the WebSocket connection, acknowledges the handshake
+// and then answers every subscription that arrives on it.
+//
+// It runs on a hijacked connection, which httptest.Server.Close does not wait for, so it
+// must never touch *testing.T: the goroutine can outlive the test. Every failure path
+// therefore just returns and lets the test observe the missing payload.
+func serveRecordingWSConnection(writer http.ResponseWriter, request *http.Request, subprotocol, dataMessageType string) {
+	connection, err := nhooyrwebsocket.Accept(writer, request, &nhooyrwebsocket.AcceptOptions{
+		Subprotocols: []string{subprotocol},
+	})
+	if err != nil {
+		return
+	}
+	defer connection.CloseNow() //nolint:errcheck // hijacked handler, cannot touch t; net.ErrClosed is the normal path
+
+	ctx := request.Context()
+	// connection_init
+	if _, _, err = connection.Read(ctx); err != nil {
+		return
+	}
+	if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(`{"type":"connection_ack"}`)); err != nil {
+		return
+	}
+	// start / subscribe, once per subscription multiplexed onto this connection
+	for {
+		_, message, err := connection.Read(ctx)
+		if err != nil {
+			return
+		}
+		if err = answerWSSubscription(ctx, connection, message, dataMessageType); err != nil {
+			return
+		}
+	}
+}
+
+// answerWSSubscription answers one start message with a single payload followed by a
+// complete. Anything else is a stop, a complete or a keep alive, which carries no
+// subscription to answer, so it is ignored.
+func answerWSSubscription(ctx context.Context, connection *nhooyrwebsocket.Conn, message []byte, dataMessageType string) error {
+	var start struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(message, &start); err != nil {
+		return err
+	}
+	if start.Type != "start" && start.Type != "subscribe" {
+		return nil
+	}
+	data := fmt.Sprintf(`{"type":%q,"id":%q,"payload":{"data":{"count":1}}}`, dataMessageType, start.ID)
+	if err := connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(data)); err != nil {
+		return err
+	}
+	complete := fmt.Sprintf(`{"type":"complete","id":%q}`, start.ID)
+	return connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(complete))
+}
+
+// closeWSConnection closes connection and fails the test on anything other than the
+// expected already-closed error: coder/websocket reports net.ErrClosed when the peer
+// closed first, which is how these subscriptions normally end.
+func closeWSConnection(t *testing.T, connection *nhooyrwebsocket.Conn) {
+	t.Helper()
+	if err := connection.CloseNow(); err != nil && !errors.Is(err, net.ErrClosed) {
+		assert.NoError(t, err)
+	}
 }
 
 // isolationContextHeaderVariable matches the $tyk_context.headers_<Name> form, where the
@@ -822,7 +849,8 @@ func newRecordingGraphQLUpstream(t *testing.T, recorder *authorizationRecorder, 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		recorder.recordRequest(request)
 		writer.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(writer, responseBody)
+		_, err := io.WriteString(writer, responseBody)
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
 	return server
@@ -1018,9 +1046,7 @@ func subscribeOverWebSocket(t *testing.T, gatewayURL, headerName, credential, op
 		HTTPHeader:   requestHeader,
 	})
 	require.NoError(t, err)
-	defer func() {
-		_ = connection.CloseNow()
-	}()
+	defer closeWSConnection(t, connection)
 
 	require.NoError(t, connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(`{"type":"connection_init"}`)))
 	_, acknowledgement, err := connection.Read(ctx)

--- a/internal/graphengine/credential_isolation_test.go
+++ b/internal/graphengine/credential_isolation_test.go
@@ -75,12 +75,28 @@ func (r *authorizationRecorder) values() []string {
 }
 
 // headerValues returns the value of name for every recorded upstream connection, in order.
+// Only the first value of each, so it cannot see a header the upstream received twice - use
+// headerValueLists for that.
 func (r *authorizationRecorder) headerValues(name string) []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	values := make([]string, 0, len(r.received))
 	for _, recorded := range r.received {
 		values = append(values, recorded.Get(name))
+	}
+	return values
+}
+
+// headerValueLists returns every value of name that each recorded upstream connection carried.
+// A credential forwarded twice shows up here and nowhere else: two writers put the caller's
+// auth header on a proxy-only request, the engine through propagateAuthHeaders and the
+// transport through setProxyOnlyHeaders.
+func (r *authorizationRecorder) headerValueLists(name string) [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	values := make([][]string, 0, len(r.received))
+	for _, recorded := range r.received {
+		values = append(values, recorded.Values(name))
 	}
 	return values
 }
@@ -344,6 +360,17 @@ func newProxyOnlyApiDefinition(version apidef.GraphQLConfigVersion, targetURL st
 	return apiDefinition
 }
 
+// assertHeaderArrivedOnce fails if any recorded upstream connection carried name more than
+// once. Proxy-only has two writers for the caller's auth header and neither knows about the
+// other, so a duplicate is the default failure mode rather than an exotic one.
+func assertHeaderArrivedOnce(t *testing.T, recorder *authorizationRecorder, name string) {
+	t.Helper()
+	for i, values := range recorder.headerValueLists(name) {
+		assert.LessOrEqual(t, len(values), 1,
+			"upstream connection %d received %s %d times: %v", i, name, len(values), values)
+	}
+}
+
 // waitForUpstreamCalls waits for count upstream connections. The engine v3 resolver
 // completes fetches asynchronously, so unlike the v2 tests those have to poll.
 func waitForUpstreamCalls(t *testing.T, recorder *authorizationRecorder, count int) {
@@ -374,6 +401,7 @@ func TestEngineV2_ProxyOnlyHTTPIsolatesCallerAuthorization(t *testing.T) {
 	assert.Equal(t, []string{"Bearer a", "Bearer b"}, upstream.values())
 	// Proves the proxy-only branch of the transport ran: nothing else forwards X-Caller.
 	assert.Equal(t, []string{"a", "b"}, upstream.headerValues("X-Caller"))
+	assertHeaderArrivedOnce(t, upstream.authorizationRecorder, "Authorization")
 }
 
 func TestEngineV2_ProxyOnlySSESubscriptionIsolatesCallerAuthorization(t *testing.T) {
@@ -388,6 +416,7 @@ func TestEngineV2_ProxyOnlySSESubscriptionIsolatesCallerAuthorization(t *testing
 	}
 
 	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+	assertHeaderArrivedOnce(t, upstream, "Authorization")
 }
 
 func TestEngineV2_ProxyOnlyWebSocketSubscriptionIsolatesCallerAuthorization(t *testing.T) {
@@ -402,6 +431,7 @@ func TestEngineV2_ProxyOnlyWebSocketSubscriptionIsolatesCallerAuthorization(t *t
 	}
 
 	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+	assertHeaderArrivedOnce(t, upstream, "Authorization")
 }
 
 func TestEngineV3_ProxyOnlyHTTPIsolatesCallerAuthorization(t *testing.T) {
@@ -417,6 +447,7 @@ func TestEngineV3_ProxyOnlyHTTPIsolatesCallerAuthorization(t *testing.T) {
 	waitForUpstreamCalls(t, upstream.authorizationRecorder, 2)
 	assert.ElementsMatch(t, []string{"Bearer a", "Bearer b"}, upstream.values())
 	assert.ElementsMatch(t, []string{"a", "b"}, upstream.headerValues("X-Caller"))
+	assertHeaderArrivedOnce(t, upstream.authorizationRecorder, "Authorization")
 }
 
 func TestEngineV3_ProxyOnlySSESubscriptionIsolatesCallerAuthorization(t *testing.T) {
@@ -432,6 +463,7 @@ func TestEngineV3_ProxyOnlySSESubscriptionIsolatesCallerAuthorization(t *testing
 
 	waitForUpstreamCalls(t, upstream, 2)
 	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+	assertHeaderArrivedOnce(t, upstream, "Authorization")
 }
 
 func TestEngineV3_ProxyOnlyWebSocketSubscriptionIsolatesCallerAuthorization(t *testing.T) {
@@ -447,6 +479,45 @@ func TestEngineV3_ProxyOnlyWebSocketSubscriptionIsolatesCallerAuthorization(t *t
 
 	waitForUpstreamCalls(t, upstream, 2)
 	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+	assertHeaderArrivedOnce(t, upstream, "Authorization")
+}
+
+// The reported shape: proxy-only, strip_auth_data off, a custom auth header name that the
+// consumer sends. The engine adds it to the fetch input through propagateAuthHeaders and the
+// transport forwards it again, so the upstream used to see the credential twice.
+func newProxyOnlyCustomAuthApiDefinition(version apidef.GraphQLConfigVersion, targetURL string) *apidef.APIDefinition {
+	apiDefinition := newProxyOnlyApiDefinition(version, targetURL, apidef.GQLSubscriptionUndefined)
+	apiDefinition.AuthConfigs = map[string]apidef.AuthConfig{
+		apidef.AuthTokenType: {AuthHeaderName: "X-Api-Key"},
+	}
+	return apiDefinition
+}
+
+func TestEngineV2_ProxyOnlyForwardsTheCallerCredentialOnce(t *testing.T) {
+	engine := newIsolationEngineV2(t,
+		newProxyOnlyCustomAuthApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, key := range []string{"key-aaa", "key-bbb"} {
+		callAs(t, engine, upstream, "X-Api-Key", key)
+	}
+
+	assert.Equal(t, [][]string{{"key-aaa"}, {"key-bbb"}}, upstream.headerValueLists("X-Api-Key"))
+}
+
+func TestEngineV3_ProxyOnlyForwardsTheCallerCredentialOnce(t *testing.T) {
+	engine := newIsolationEngineV3(t,
+		newProxyOnlyCustomAuthApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	for _, key := range []string{"key-aaa", "key-bbb"} {
+		callAs(t, engine, upstream, "X-Api-Key", key)
+	}
+
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, 2)
+	assert.ElementsMatch(t, [][]string{{"key-aaa"}, {"key-bbb"}}, upstream.headerValueLists("X-Api-Key"))
 }
 
 // --- graphql-transport-ws --------------------------------------------------------

--- a/internal/graphengine/credential_isolation_test.go
+++ b/internal/graphengine/credential_isolation_test.go
@@ -583,21 +583,13 @@ func TestEngineV3_CustomAuthHeaderNameIsolatesCallerCredential(t *testing.T) {
 // case. Every caller gets a unique credential and the multiset has to come back intact:
 // ElementsMatch catches a lost credential and a duplicated one alike.
 //
-// Both tests send one warm-up request before fanning out, which is also the production
-// state of an API that has served a request: the execution plan is cached, which is the
-// condition the credential defect needs.
-//
-// The warm-up is also what keeps these green under -race against the currently pinned
-// graphql-go-tools, which memoises lazily and without synchronisation in two places that a
-// cold concurrent burst hits. Both predate the version bump, byte for byte, and both are
-// fixed by scratchpad/gql-repro/fixes/graphql-go-tools/0006 and 0007:
-//   - v1 pkg/graphql/schema.go Schema.Hash writes s.hash on first use, and every request
-//     validates against the one *Schema of the API spec.
-//   - v2 pkg/engine/resolve/resolve.go ResolveGraphQLResponse writes response.Info on the
-//     cached plan on first use.
-//
-// Once those land and the pin moves, the warm-up is no longer required for -race, only for
-// the warm plan cache.
+// The tests come in two shapes. The warm ones send a request before fanning out, so the
+// execution plan is cached when the burst starts, which is the state the credential defect
+// needs and the state of any API that has served a request. The cold ones start with
+// nothing cached, which is what exercises the lazily initialised state inside
+// graphql-go-tools: the schema hash and the info of a cached plan were both filled in on
+// first use, so a cold burst raced on them. Both are fixed as of the pinned
+// graphql-go-tools 1ff2d4d7.
 
 const concurrentIsolationCallers = 20
 
@@ -621,6 +613,31 @@ func callConcurrently(t *testing.T, engine Engine, roundTripper http.RoundTrippe
 		}(credential)
 	}
 	waitGroup.Wait()
+}
+
+func TestEngineV2_ConcurrentColdCallersDoNotShareCredentials(t *testing.T) {
+	engine := newIsolationEngineV2(t,
+		newUDGApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	credentials := concurrentCredentials()
+	callConcurrently(t, engine, upstream, credentials)
+
+	assert.ElementsMatch(t, credentials, upstream.values())
+}
+
+func TestEngineV3_ConcurrentColdCallersDoNotShareCredentials(t *testing.T) {
+	engine := newIsolationEngineV3(t,
+		newUDGApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql"),
+		"query { hello }")
+
+	upstream := newAuthorizationRecordingRoundTripper()
+	credentials := concurrentCredentials()
+	callConcurrently(t, engine, upstream, credentials)
+
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, len(credentials))
+	assert.ElementsMatch(t, credentials, upstream.values())
 }
 
 func TestEngineV2_ConcurrentCallersDoNotShareCredentials(t *testing.T) {

--- a/internal/graphengine/engine_v1.go
+++ b/internal/graphengine/engine_v1.go
@@ -1,7 +1,6 @@
 package graphengine
 
 import (
-	"context"
 	"errors"
 	"net/http"
 
@@ -52,6 +51,7 @@ type EngineV1Options struct {
 func NewEngineV1(options EngineV1Options) (*EngineV1, error) {
 	logger := createAbstractLogrusLogger(options.Logger)
 	gqlTools := graphqlGoToolsV1{}
+	configureGraphQLEngineHTTPClient(options.HttpClient, DetermineGraphQLEngineTransportType(options.ApiDefinition), options.Injections.NewReusableBodyReadCloser)
 
 	var parsedSchema = options.Schema
 	if parsedSchema == nil {
@@ -186,7 +186,7 @@ func (e *EngineV1) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 	}
 
 	var result *graphql.ExecutionResult
-	result, err = e.ExecutionEngine.Execute(context.Background(), gqlRequest, graphql.ExecutionOptions{ExtraArguments: gqlRequest.Variables})
+	result, err = e.ExecutionEngine.Execute(outreq.Context(), gqlRequest, graphql.ExecutionOptions{ExtraArguments: gqlRequest.Variables})
 	if err != nil {
 		return
 	}
@@ -217,6 +217,7 @@ func (e *EngineV1) handoverWebSocketConnectionToGraphQLExecutionEngine(params *R
 		errChan,
 		conn,
 		executorPool,
+		gqlwebsocket.WithContext(params.OutRequest.Context()),
 		gqlwebsocket.WithLogger(e.logger),
 		gqlwebsocket.WithProtocolFromRequestHeaders(params.OutRequest),
 	)

--- a/internal/graphengine/engine_v1.go
+++ b/internal/graphengine/engine_v1.go
@@ -212,12 +212,17 @@ func (e *EngineV1) handoverWebSocketConnectionToGraphQLExecutionEngine(params *R
 	}
 	executorPool = subscription.NewExecutorV1Pool(e.ExecutionEngine.NewExecutionHandler())
 
+	// No WithContext here, unlike the v2 and v3 handovers. The legacy version 1 data
+	// sources build their upstream request with http.NewRequest and drop the execution
+	// context, so there is nothing request scoped to carry over, and handing the handler
+	// the request context would only cancel the subscription: net/http cancels that
+	// context as soon as ServeHTTP returns, which happens as soon as the connection is
+	// hijacked.
 	go gqlwebsocket.Handle(
 		done,
 		errChan,
 		conn,
 		executorPool,
-		gqlwebsocket.WithContext(params.OutRequest.Context()),
 		gqlwebsocket.WithLogger(e.logger),
 		gqlwebsocket.WithProtocolFromRequestHeaders(params.OutRequest),
 	)

--- a/internal/graphengine/engine_v1_test.go
+++ b/internal/graphengine/engine_v1_test.go
@@ -380,16 +380,14 @@ func TestNewEngineV1_ConfiguresHTTPClient(t *testing.T) {
 	})
 }
 
-func TestEngineV1_HandleReverseProxyUsesTheClientTransport(t *testing.T) {
+func TestEngineV1_HandleReverseProxyUsesTheGatewayRoundTripper(t *testing.T) {
 	// The legacy version 1 data sources (HttpJsonDataSource, GraphQLDataSource) build
 	// their upstream request with http.NewRequest and therefore drop the execution
-	// context, so the round tripper of the request cannot reach the engine transport.
-	// EngineV1 upstream fetches consequently run on the transport of the per API client
-	// that NewEngineV1 wrapped, and never on the round tripper of another caller.
-	//
-	// If graphql-go-tools starts to build those requests with http.NewRequestWithContext,
-	// this test fails and both callers see their own round tripper instead. That is the
-	// better behaviour - update the expectation here when it happens.
+	// context, so the round tripper of the request cannot reach the engine transport the
+	// way it does for EngineV2 and EngineV3. It arrives as the transport level fallback
+	// instead, which is what keeps a tyk:// internal data source working: only the
+	// gateway round tripper can route one, and the plain transport of the API client
+	// cannot. See fallbackRoundTripper and TestGraphQL_InternalDataSource.
 	recorder := &transportTagRecorder{}
 	logger := logrus.New()
 	logger.SetOutput(io.Discard)
@@ -421,11 +419,21 @@ func TestEngineV1_HandleReverseProxyUsesTheClientTransport(t *testing.T) {
 		_ = response.Body.Close()
 	}
 
-	assert.Equal(t, []string{"client", "client"}, recorder.values())
+	// Each caller's fetch goes through the round tripper of that caller's request, because
+	// the fallback is refreshed on every PreHandle.
+	assert.Equal(t, []string{"caller-a", "caller-b"}, recorder.values())
 	// The shared client keeps the transport that the constructor installed.
 	_, ok := client.Transport.(*GraphQLEngineTransport)
 	assert.True(t, ok)
 }
+
+// No concurrent EngineV1 counterpart to the tests above. The version 1 planner in
+// graphql-go-tools is not safe for concurrent execution - a burst through one EngineV1
+// races inside Planner.Plan and the legacy data source planners, with no Tyk code on the
+// stack. Untouched by the pinned library bump (pkg/execution and pkg/astvisitor are
+// identical across the pins), so it is a pre-existing property of the deprecated config
+// version 1, not something this package can guard. The thread safety that is ours, the
+// shared fallback round tripper, is covered in transport_test.go instead.
 
 // transportTagRecorder hands out round trippers that record which one an upstream
 // fetch went through. The version 1 handover does not propagate auth headers, so the

--- a/internal/graphengine/engine_v1_test.go
+++ b/internal/graphengine/engine_v1_test.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/jensneuse/abstractlogger"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -323,6 +326,139 @@ func TestEngineV1_HandleReverseProxy(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
+}
+
+func TestNewEngineV1_ConfiguresHTTPClient(t *testing.T) {
+	newEngine := func(t *testing.T, client *http.Client, executionMode apidef.GraphQLExecutionMode) *EngineV1 {
+		t.Helper()
+		logger := logrus.New()
+		logger.SetOutput(io.Discard)
+		engine, err := NewEngineV1(EngineV1Options{
+			Logger:        logger,
+			ApiDefinition: generateApiDefinitionEngineV1("http://upstream.example/api", executionMode),
+			HttpClient:    client,
+			Injections: EngineV1Injections{
+				ContextRetrieveRequest: func(*http.Request) *graphql.Request {
+					return &graphql.Request{Query: "query { hello }"}
+				},
+				NewReusableBodyReadCloser: testReusableReadCloser,
+			},
+		})
+		require.NoError(t, err)
+		return engine
+	}
+
+	t.Run("should install a stable engine transport that keeps the transport of the client", func(t *testing.T) {
+		client := &http.Client{Transport: taggedRoundTripper("client")}
+
+		newEngine(t, client, apidef.GraphQLExecutionModeExecutionEngine)
+
+		transport, ok := client.Transport.(*GraphQLEngineTransport)
+		require.True(t, ok, "the client transport should be wrapped")
+		assert.Equal(t, taggedRoundTripper("client"), transport.originalTransport)
+		assert.Equal(t, GraphQLEngineTransportTypeMultiUpstream, transport.transportType)
+	})
+
+	t.Run("should derive the transport type from the execution mode", func(t *testing.T) {
+		client := &http.Client{Transport: taggedRoundTripper("client")}
+
+		newEngine(t, client, apidef.GraphQLExecutionModeProxyOnly)
+
+		transport, ok := client.Transport.(*GraphQLEngineTransport)
+		require.True(t, ok, "the client transport should be wrapped")
+		assert.Equal(t, GraphQLEngineTransportTypeProxyOnly, transport.transportType)
+	})
+
+	t.Run("should not wrap the transport of a reused client twice", func(t *testing.T) {
+		client := &http.Client{Transport: taggedRoundTripper("client")}
+
+		newEngine(t, client, apidef.GraphQLExecutionModeExecutionEngine)
+		configuredTransport := client.Transport
+		newEngine(t, client, apidef.GraphQLExecutionModeExecutionEngine)
+
+		assert.Same(t, configuredTransport, client.Transport)
+	})
+}
+
+func TestEngineV1_HandleReverseProxyUsesTheClientTransport(t *testing.T) {
+	// The legacy version 1 data sources (HttpJsonDataSource, GraphQLDataSource) build
+	// their upstream request with http.NewRequest and therefore drop the execution
+	// context, so the round tripper of the request cannot reach the engine transport.
+	// EngineV1 upstream fetches consequently run on the transport of the per API client
+	// that NewEngineV1 wrapped, and never on the round tripper of another caller.
+	//
+	// If graphql-go-tools starts to build those requests with http.NewRequestWithContext,
+	// this test fails and both callers see their own round tripper instead. That is the
+	// better behaviour - update the expectation here when it happens.
+	recorder := &transportTagRecorder{}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	client := &http.Client{Transport: recorder.roundTripper("client")}
+	engine, err := NewEngineV1(EngineV1Options{
+		Logger:        logger,
+		ApiDefinition: generateApiDefinitionEngineV1("http://upstream.example/api", apidef.GraphQLExecutionModeExecutionEngine),
+		HttpClient:    client,
+		Injections: EngineV1Injections{
+			ContextRetrieveRequest: func(*http.Request) *graphql.Request {
+				return &graphql.Request{Query: "query { hello }"}
+			},
+			NewReusableBodyReadCloser: testReusableReadCloser,
+		},
+	})
+	require.NoError(t, err)
+
+	for _, tag := range []string{"caller-a", "caller-b"} {
+		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+		require.NoError(t, err)
+		response, hijacked, err := engine.HandleReverseProxy(ReverseProxyParams{
+			RoundTripper: recorder.roundTripper(tag),
+			OutRequest:   request,
+			NeedsEngine:  true,
+		})
+		require.NoError(t, err)
+		assert.False(t, hijacked)
+		require.NotNil(t, response)
+		_ = response.Body.Close()
+	}
+
+	assert.Equal(t, []string{"client", "client"}, recorder.values())
+	// The shared client keeps the transport that the constructor installed.
+	_, ok := client.Transport.(*GraphQLEngineTransport)
+	assert.True(t, ok)
+}
+
+// transportTagRecorder hands out round trippers that record which one an upstream
+// fetch went through. The version 1 handover does not propagate auth headers, so the
+// identity of the round tripper is what tells two callers apart.
+type transportTagRecorder struct {
+	mu   sync.Mutex
+	tags []string
+}
+
+func (r *transportTagRecorder) roundTripper(tag string) http.RoundTripper {
+	return roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		r.mu.Lock()
+		r.tags = append(r.tags, tag)
+		r.mu.Unlock()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(bytes.NewBufferString(`{"hello":"world"}`)),
+			Request:    request,
+		}, nil
+	})
+}
+
+func (r *transportTagRecorder) values() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.tags...)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
 }
 
 type testEngineV1Options struct {

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -54,6 +54,7 @@ type EngineV2 struct {
 	complexityChecker         ComplexityChecker
 	granularAccessChecker     GranularAccessChecker
 	reverseProxyPreHandler    ReverseProxyPreHandler
+	specCtx                   context.Context
 	contextCancel             context.CancelFunc
 	beforeFetchHook           resolve.BeforeFetchHook
 	afterFetchHook            resolve.AfterFetchHook
@@ -150,6 +151,7 @@ func NewEngineV2(options EngineV2Options) (*EngineV2, error) {
 		complexityChecker:         complexityChecker,
 		granularAccessChecker:     granularAccessChecker,
 		reverseProxyPreHandler:    reverseProxyPreHandler,
+		specCtx:                   specCtx,
 		contextCancel:             cancel,
 		beforeFetchHook:           options.Injections.BeforeFetchHook,
 		afterFetchHook:            options.Injections.AfterFetchHook,
@@ -318,9 +320,9 @@ func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 		// This is a valid query for proxy-only mode: query { __typename }
 		// In this case, upstreamResponse is nil.
 		// See TT-6419 for further info.
-		if proxyOnlyCtx.upstreamResponse != nil {
-			header = proxyOnlyCtx.upstreamResponse.Header
-			httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
+		if upstreamResponse := proxyOnlyCtx.getUpstreamResponse(); upstreamResponse != nil {
+			header = upstreamResponse.Header
+			httpStatus = upstreamResponse.StatusCode
 			// change the value of the header's content encoding to use the content encoding defined by the accept encoding
 			contentEncoding := selectContentEncodingToBeUsed(proxyOnlyCtx.forwardedRequest.Header.Get(httpclient.AcceptEncodingHeader))
 			header.Set(httpclient.ContentEncodingHeader, contentEncoding)
@@ -394,7 +396,7 @@ func (e *EngineV2) handoverWebSocketConnectionToGraphQLExecutionEngine(params *R
 		errChan,
 		conn,
 		executorPool,
-		gqlwebsocket.WithContext(params.OutRequest.Context()),
+		gqlwebsocket.WithContext(subscriptionRequestContext(e.specCtx, params.OutRequest)),
 		gqlwebsocket.WithLogger(e.logger),
 		gqlwebsocket.WithProtocolFromRequestHeaders(params.OutRequest),
 	)

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -296,7 +296,7 @@ func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 	}
 
 	upstreamHeaders := additionalUpstreamHeaders(e.logger, outreq, e.ApiDefinition)
-	execOptions = append(execOptions, graphql.WithHeaderModifier(e.gqlTools.headerModifier(upstreamHeaders)))
+	execOptions = append(execOptions, graphql.WithHeaderModifier(e.gqlTools.headerModifier(outreq, upstreamHeaders, e.tykVariableReplacer)))
 
 	if e.OpenTelemetry.Executor != nil {
 		if err = e.OpenTelemetry.Executor.Execute(reqCtx, gqlRequest, &resultWriter, execOptions...); err != nil {
@@ -388,7 +388,7 @@ func (e *EngineV2) handoverWebSocketConnectionToGraphQLExecutionEngine(params *R
 	executorPool = subscription.NewExecutorV2Pool(
 		e.ExecutionEngine,
 		initialRequestContext,
-		subscription.WithExecutorV2HeaderModifier(e.gqlTools.headerModifier(upstreamHeaders)),
+		subscription.WithExecutorV2HeaderModifier(e.gqlTools.headerModifier(params.OutRequest, upstreamHeaders, e.tykVariableReplacer)),
 	)
 
 	go gqlwebsocket.Handle(

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -77,6 +77,9 @@ type EngineV2Options struct {
 func NewEngineV2(options EngineV2Options) (*EngineV2, error) {
 	logger := createAbstractLogrusLogger(options.Logger)
 	gqlTools := graphqlGoToolsV1{}
+	transportType := DetermineGraphQLEngineTransportType(options.ApiDefinition)
+	configureGraphQLEngineHTTPClient(options.HttpClient, transportType, options.Injections.NewReusableBodyReadCloser)
+	configureGraphQLEngineHTTPClient(options.StreamingClient, transportType, options.Injections.NewReusableBodyReadCloser)
 
 	var parsedSchema = options.Schema
 	if parsedSchema == nil {
@@ -279,6 +282,7 @@ func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 	isProxyOnly := isProxyOnly(e.ApiDefinition)
 	span := otel.SpanFromContext(outreq.Context())
 	reqCtx := otel.ContextWithSpan(context.Background(), span)
+	reqCtx = copyGraphQLEngineTransportContextValue(reqCtx, outreq.Context())
 	if isProxyOnly {
 		reqCtx = SetProxyOnlyContextValue(reqCtx, outreq)
 	}
@@ -390,6 +394,7 @@ func (e *EngineV2) handoverWebSocketConnectionToGraphQLExecutionEngine(params *R
 		errChan,
 		conn,
 		executorPool,
+		gqlwebsocket.WithContext(params.OutRequest.Context()),
 		gqlwebsocket.WithLogger(e.logger),
 		gqlwebsocket.WithProtocolFromRequestHeaders(params.OutRequest),
 	)

--- a/internal/graphengine/engine_v2_test.go
+++ b/internal/graphengine/engine_v2_test.go
@@ -3,12 +3,16 @@ package graphengine
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
+	nhooyrwebsocket "github.com/coder/websocket"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,6 +23,73 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/internal/otel"
 )
+
+type authorizationRecordingRoundTripper struct {
+	mu       sync.Mutex
+	received []string
+}
+
+func (r *authorizationRecordingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	r.mu.Lock()
+	r.received = append(r.received, request.Header.Get("Authorization"))
+	r.mu.Unlock()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewBufferString(`{"hello":"world"}`)),
+		Request:    request,
+	}, nil
+}
+
+func (r *authorizationRecordingRoundTripper) values() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.received...)
+}
+
+func newAuthorizationRecordingWSUpstream(t *testing.T) (*httptest.Server, *authorizationRecordingRoundTripper) {
+	t.Helper()
+	recorder := &authorizationRecordingRoundTripper{}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		recorder.mu.Lock()
+		recorder.received = append(recorder.received, request.Header.Get("Authorization"))
+		recorder.mu.Unlock()
+
+		connection, err := nhooyrwebsocket.Accept(writer, request, &nhooyrwebsocket.AcceptOptions{
+			Subprotocols: []string{"graphql-ws"},
+		})
+		if err != nil {
+			return
+		}
+		defer connection.CloseNow()
+		ctx := request.Context()
+		_, _, err = connection.Read(ctx)
+		if err != nil {
+			return
+		}
+		if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(`{"type":"connection_ack"}`)); err != nil {
+			return
+		}
+		_, message, err := connection.Read(ctx)
+		if err != nil {
+			return
+		}
+		var start struct {
+			ID string `json:"id"`
+		}
+		if err = json.Unmarshal(message, &start); err != nil {
+			return
+		}
+		data := fmt.Sprintf(`{"type":"data","id":%q,"payload":{"data":{"count":1}}}`, start.ID)
+		if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(data)); err != nil {
+			return
+		}
+		complete := fmt.Sprintf(`{"type":"complete","id":%q}`, start.ID)
+		_ = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(complete))
+	}))
+	t.Cleanup(server.Close)
+	return server, recorder
+}
 
 type engineV2Mocks struct {
 	controller             *gomock.Controller
@@ -375,6 +446,227 @@ func TestEngineV2_HandleReverseProxy(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, hijacked)
 		assert.Nil(t, result)
+	})
+}
+
+func TestEngineV2_HandleReverseProxyIsolatesCallerAuthorization(t *testing.T) {
+	apiDefinition := newTestApiDefinitionV2(apidef.GraphQLExecutionModeExecutionEngine, "http://upstream.example/graphql")
+	apiDefinition.UseStandardAuth = true
+	apiDefinition.StripAuthData = false
+	client := &http.Client{}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	engine, err := NewEngineV2(EngineV2Options{
+		Logger:          logger,
+		ApiDefinition:   apiDefinition,
+		HttpClient:      client,
+		StreamingClient: client,
+		Injections: EngineV2Injections{
+			ContextRetrieveRequest: func(*http.Request) *graphql.Request {
+				return &graphql.Request{Query: "query { hello }"}
+			},
+			NewReusableBodyReadCloser: testReusableReadCloser,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(engine.Cancel)
+
+	upstream := &authorizationRecordingRoundTripper{}
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+		require.NoError(t, err)
+		request.Header.Set("Authorization", token)
+		response, hijacked, err := engine.HandleReverseProxy(ReverseProxyParams{
+			RoundTripper: upstream,
+			OutRequest:   request,
+			NeedsEngine:  true,
+		})
+		require.NoError(t, err)
+		assert.False(t, hijacked)
+		require.NotNil(t, response)
+		_ = response.Body.Close()
+	}
+
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestEngineV2_SSESubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	upstream := &authorizationRecordingRoundTripper{}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		upstream.mu.Lock()
+		upstream.received = append(upstream.received, request.Header.Get("Authorization"))
+		upstream.mu.Unlock()
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(writer, "event: next\ndata: {\"data\":{\"count\":1}}\n\nevent: complete\n\n")
+	}))
+	t.Cleanup(server.Close)
+
+	dataSourceConfig, err := json.Marshal(apidef.GraphQLEngineDataSourceConfigGraphQL{
+		URL:              server.URL,
+		Method:           http.MethodPost,
+		SubscriptionType: apidef.GQLSubscriptionSSE,
+		SSEUsePost:       true,
+	})
+	require.NoError(t, err)
+	apiDefinition := &apidef.APIDefinition{
+		UseStandardAuth: true,
+		GraphQL: apidef.GraphQLConfig{
+			Enabled:       true,
+			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
+			Version:       apidef.GraphQLConfigVersion2,
+			Schema:        "type Query { hello: String } type Subscription { count: Int }",
+			Engine: apidef.GraphQLEngineConfig{DataSources: []apidef.GraphQLEngineDataSource{{
+				Kind:       apidef.GraphQLEngineDataSourceKindGraphQL,
+				Name:       "subscription",
+				RootFields: []apidef.GraphQLTypeFields{{Type: "Subscription", Fields: []string{"count"}}},
+				Config:     dataSourceConfig,
+			}}},
+		},
+	}
+	client := &http.Client{}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	engine, err := NewEngineV2(EngineV2Options{
+		Logger:          logger,
+		ApiDefinition:   apiDefinition,
+		HttpClient:      client,
+		StreamingClient: client,
+		Injections: EngineV2Injections{
+			ContextRetrieveRequest: func(*http.Request) *graphql.Request {
+				return &graphql.Request{Query: "subscription { count }"}
+			},
+			NewReusableBodyReadCloser: testReusableReadCloser,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(engine.Cancel)
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+		require.NoError(t, err)
+		request.Header.Set("Authorization", token)
+		response, _, err := engine.HandleReverseProxy(ReverseProxyParams{
+			RoundTripper: http.DefaultTransport,
+			OutRequest:   request,
+			NeedsEngine:  true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		_ = response.Body.Close()
+	}
+
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestEngineV2_WebSocketSubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	server, upstream := newAuthorizationRecordingWSUpstream(t)
+	dataSourceConfig, err := json.Marshal(apidef.GraphQLEngineDataSourceConfigGraphQL{
+		URL:              server.URL,
+		SubscriptionType: apidef.GQLSubscriptionWS,
+	})
+	require.NoError(t, err)
+	apiDefinition := &apidef.APIDefinition{
+		UseStandardAuth: true,
+		GraphQL: apidef.GraphQLConfig{
+			Enabled:       true,
+			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
+			Version:       apidef.GraphQLConfigVersion2,
+			Schema:        "type Query { hello: String } type Subscription { count: Int }",
+			Engine: apidef.GraphQLEngineConfig{DataSources: []apidef.GraphQLEngineDataSource{{
+				Kind:       apidef.GraphQLEngineDataSourceKindGraphQL,
+				Name:       "subscription",
+				RootFields: []apidef.GraphQLTypeFields{{Type: "Subscription", Fields: []string{"count"}}},
+				Config:     dataSourceConfig,
+			}}},
+		},
+	}
+	client := &http.Client{}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	engine, err := NewEngineV2(EngineV2Options{
+		Logger:          logger,
+		ApiDefinition:   apiDefinition,
+		HttpClient:      client,
+		StreamingClient: client,
+		Injections: EngineV2Injections{
+			ContextRetrieveRequest: func(*http.Request) *graphql.Request {
+				return &graphql.Request{Query: "subscription { count }"}
+			},
+			NewReusableBodyReadCloser: testReusableReadCloser,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(engine.Cancel)
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+		require.NoError(t, err)
+		request.Header.Set("Authorization", token)
+		response, _, err := engine.HandleReverseProxy(ReverseProxyParams{
+			RoundTripper: http.DefaultTransport,
+			OutRequest:   request,
+			NeedsEngine:  true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		_ = response.Body.Close()
+	}
+
+	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestNewEngineV2_ConfiguresHTTPClients(t *testing.T) {
+	newEngine := func(t *testing.T, httpClient, streamingClient *http.Client) *EngineV2 {
+		t.Helper()
+		logger := logrus.New()
+		logger.SetOutput(io.Discard)
+		engine, err := NewEngineV2(EngineV2Options{
+			Logger:          logger,
+			ApiDefinition:   newTestApiDefinitionV2(apidef.GraphQLExecutionModeExecutionEngine, "http://upstream.example/graphql"),
+			HttpClient:      httpClient,
+			StreamingClient: streamingClient,
+			Injections: EngineV2Injections{
+				ContextRetrieveRequest: func(*http.Request) *graphql.Request {
+					return &graphql.Request{Query: "query { hello }"}
+				},
+				NewReusableBodyReadCloser: testReusableReadCloser,
+			},
+		})
+		require.NoError(t, err)
+		t.Cleanup(engine.Cancel)
+		return engine
+	}
+
+	t.Run("should configure both the http client and the streaming client", func(t *testing.T) {
+		httpClient := &http.Client{Transport: taggedRoundTripper("http")}
+		streamingClient := &http.Client{Transport: taggedRoundTripper("streaming")}
+
+		newEngine(t, httpClient, streamingClient)
+
+		httpTransport, ok := httpClient.Transport.(*GraphQLEngineTransport)
+		require.True(t, ok, "the http client transport should be wrapped")
+		assert.Equal(t, taggedRoundTripper("http"), httpTransport.originalTransport)
+		streamingTransport, ok := streamingClient.Transport.(*GraphQLEngineTransport)
+		require.True(t, ok, "the streaming client transport should be wrapped")
+		assert.Equal(t, taggedRoundTripper("streaming"), streamingTransport.originalTransport)
+	})
+
+	t.Run("should wrap a client that is shared between both roles only once", func(t *testing.T) {
+		// The gateway passes one client per API as both the http and the streaming client,
+		// see gateway/mw_graphql.go.
+		client := &http.Client{Transport: taggedRoundTripper("shared")}
+
+		newEngine(t, client, client)
+
+		transport, ok := client.Transport.(*GraphQLEngineTransport)
+		require.True(t, ok, "the client transport should be wrapped")
+		assert.Equal(t, taggedRoundTripper("shared"), transport.originalTransport)
+	})
+
+	t.Run("should not fail when a client is nil", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			newEngine(t, nil, nil)
+		})
 	})
 }
 

--- a/internal/graphengine/engine_v2_test.go
+++ b/internal/graphengine/engine_v2_test.go
@@ -3,16 +3,12 @@ package graphengine
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 
-	nhooyrwebsocket "github.com/coder/websocket"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,73 +19,6 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/internal/otel"
 )
-
-type authorizationRecordingRoundTripper struct {
-	mu       sync.Mutex
-	received []string
-}
-
-func (r *authorizationRecordingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
-	r.mu.Lock()
-	r.received = append(r.received, request.Header.Get("Authorization"))
-	r.mu.Unlock()
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     make(http.Header),
-		Body:       io.NopCloser(bytes.NewBufferString(`{"hello":"world"}`)),
-		Request:    request,
-	}, nil
-}
-
-func (r *authorizationRecordingRoundTripper) values() []string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return append([]string(nil), r.received...)
-}
-
-func newAuthorizationRecordingWSUpstream(t *testing.T) (*httptest.Server, *authorizationRecordingRoundTripper) {
-	t.Helper()
-	recorder := &authorizationRecordingRoundTripper{}
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		recorder.mu.Lock()
-		recorder.received = append(recorder.received, request.Header.Get("Authorization"))
-		recorder.mu.Unlock()
-
-		connection, err := nhooyrwebsocket.Accept(writer, request, &nhooyrwebsocket.AcceptOptions{
-			Subprotocols: []string{"graphql-ws"},
-		})
-		if err != nil {
-			return
-		}
-		defer connection.CloseNow()
-		ctx := request.Context()
-		_, _, err = connection.Read(ctx)
-		if err != nil {
-			return
-		}
-		if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(`{"type":"connection_ack"}`)); err != nil {
-			return
-		}
-		_, message, err := connection.Read(ctx)
-		if err != nil {
-			return
-		}
-		var start struct {
-			ID string `json:"id"`
-		}
-		if err = json.Unmarshal(message, &start); err != nil {
-			return
-		}
-		data := fmt.Sprintf(`{"type":"data","id":%q,"payload":{"data":{"count":1}}}`, start.ID)
-		if err = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(data)); err != nil {
-			return
-		}
-		complete := fmt.Sprintf(`{"type":"complete","id":%q}`, start.ID)
-		_ = connection.Write(ctx, nhooyrwebsocket.MessageText, []byte(complete))
-	}))
-	t.Cleanup(server.Close)
-	return server, recorder
-}
 
 type engineV2Mocks struct {
 	controller             *gomock.Controller
@@ -450,166 +379,41 @@ func TestEngineV2_HandleReverseProxy(t *testing.T) {
 }
 
 func TestEngineV2_HandleReverseProxyIsolatesCallerAuthorization(t *testing.T) {
-	apiDefinition := newTestApiDefinitionV2(apidef.GraphQLExecutionModeExecutionEngine, "http://upstream.example/graphql")
-	apiDefinition.UseStandardAuth = true
-	apiDefinition.StripAuthData = false
-	client := &http.Client{}
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	engine, err := NewEngineV2(EngineV2Options{
-		Logger:          logger,
-		ApiDefinition:   apiDefinition,
-		HttpClient:      client,
-		StreamingClient: client,
-		Injections: EngineV2Injections{
-			ContextRetrieveRequest: func(*http.Request) *graphql.Request {
-				return &graphql.Request{Query: "query { hello }"}
-			},
-			NewReusableBodyReadCloser: testReusableReadCloser,
-		},
-	})
-	require.NoError(t, err)
-	t.Cleanup(engine.Cancel)
+	engine := newIsolationEngineV2(t,
+		newUDGApiDefinition(apidef.GraphQLConfigVersion2, "http://upstream.example/graphql"),
+		"query { hello }")
 
-	upstream := &authorizationRecordingRoundTripper{}
+	upstream := newAuthorizationRecordingRoundTripper()
 	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
-		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
-		require.NoError(t, err)
-		request.Header.Set("Authorization", token)
-		response, hijacked, err := engine.HandleReverseProxy(ReverseProxyParams{
-			RoundTripper: upstream,
-			OutRequest:   request,
-			NeedsEngine:  true,
-		})
-		require.NoError(t, err)
-		assert.False(t, hijacked)
-		require.NotNil(t, response)
-		_ = response.Body.Close()
+		callAs(t, engine, upstream, "", token)
 	}
 
 	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
 }
 
 func TestEngineV2_SSESubscriptionIsolatesCallerAuthorization(t *testing.T) {
-	upstream := &authorizationRecordingRoundTripper{}
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		upstream.mu.Lock()
-		upstream.received = append(upstream.received, request.Header.Get("Authorization"))
-		upstream.mu.Unlock()
-		writer.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(writer, "event: next\ndata: {\"data\":{\"count\":1}}\n\nevent: complete\n\n")
-	}))
-	t.Cleanup(server.Close)
-
-	dataSourceConfig, err := json.Marshal(apidef.GraphQLEngineDataSourceConfigGraphQL{
-		URL:              server.URL,
-		Method:           http.MethodPost,
-		SubscriptionType: apidef.GQLSubscriptionSSE,
-		SSEUsePost:       true,
-	})
-	require.NoError(t, err)
-	apiDefinition := &apidef.APIDefinition{
-		UseStandardAuth: true,
-		GraphQL: apidef.GraphQLConfig{
-			Enabled:       true,
-			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
-			Version:       apidef.GraphQLConfigVersion2,
-			Schema:        "type Query { hello: String } type Subscription { count: Int }",
-			Engine: apidef.GraphQLEngineConfig{DataSources: []apidef.GraphQLEngineDataSource{{
-				Kind:       apidef.GraphQLEngineDataSourceKindGraphQL,
-				Name:       "subscription",
-				RootFields: []apidef.GraphQLTypeFields{{Type: "Subscription", Fields: []string{"count"}}},
-				Config:     dataSourceConfig,
-			}}},
-		},
-	}
-	client := &http.Client{}
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	engine, err := NewEngineV2(EngineV2Options{
-		Logger:          logger,
-		ApiDefinition:   apiDefinition,
-		HttpClient:      client,
-		StreamingClient: client,
-		Injections: EngineV2Injections{
-			ContextRetrieveRequest: func(*http.Request) *graphql.Request {
-				return &graphql.Request{Query: "subscription { count }"}
-			},
-			NewReusableBodyReadCloser: testReusableReadCloser,
-		},
-	})
-	require.NoError(t, err)
-	t.Cleanup(engine.Cancel)
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingSSEUpstream(t, upstream)
+	engine := newIsolationEngineV2(t,
+		newUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion2, apidef.GQLSubscriptionSSE, server.URL),
+		"subscription { count }")
 
 	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
-		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
-		require.NoError(t, err)
-		request.Header.Set("Authorization", token)
-		response, _, err := engine.HandleReverseProxy(ReverseProxyParams{
-			RoundTripper: http.DefaultTransport,
-			OutRequest:   request,
-			NeedsEngine:  true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, response)
-		_ = response.Body.Close()
+		callAs(t, engine, http.DefaultTransport, "", token)
 	}
 
 	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
 }
 
 func TestEngineV2_WebSocketSubscriptionIsolatesCallerAuthorization(t *testing.T) {
-	server, upstream := newAuthorizationRecordingWSUpstream(t)
-	dataSourceConfig, err := json.Marshal(apidef.GraphQLEngineDataSourceConfigGraphQL{
-		URL:              server.URL,
-		SubscriptionType: apidef.GQLSubscriptionWS,
-	})
-	require.NoError(t, err)
-	apiDefinition := &apidef.APIDefinition{
-		UseStandardAuth: true,
-		GraphQL: apidef.GraphQLConfig{
-			Enabled:       true,
-			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
-			Version:       apidef.GraphQLConfigVersion2,
-			Schema:        "type Query { hello: String } type Subscription { count: Int }",
-			Engine: apidef.GraphQLEngineConfig{DataSources: []apidef.GraphQLEngineDataSource{{
-				Kind:       apidef.GraphQLEngineDataSourceKindGraphQL,
-				Name:       "subscription",
-				RootFields: []apidef.GraphQLTypeFields{{Type: "Subscription", Fields: []string{"count"}}},
-				Config:     dataSourceConfig,
-			}}},
-		},
-	}
-	client := &http.Client{}
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	engine, err := NewEngineV2(EngineV2Options{
-		Logger:          logger,
-		ApiDefinition:   apiDefinition,
-		HttpClient:      client,
-		StreamingClient: client,
-		Injections: EngineV2Injections{
-			ContextRetrieveRequest: func(*http.Request) *graphql.Request {
-				return &graphql.Request{Query: "subscription { count }"}
-			},
-			NewReusableBodyReadCloser: testReusableReadCloser,
-		},
-	})
-	require.NoError(t, err)
-	t.Cleanup(engine.Cancel)
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLWS, messageTypeData)
+	engine := newIsolationEngineV2(t,
+		newUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion2, apidef.GQLSubscriptionWS, server.URL),
+		"subscription { count }")
 
 	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
-		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
-		require.NoError(t, err)
-		request.Header.Set("Authorization", token)
-		response, _, err := engine.HandleReverseProxy(ReverseProxyParams{
-			RoundTripper: http.DefaultTransport,
-			OutRequest:   request,
-			NeedsEngine:  true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, response)
-		_ = response.Body.Close()
+		callAs(t, engine, http.DefaultTransport, "", token)
 	}
 
 	assert.Equal(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())

--- a/internal/graphengine/engine_v3.go
+++ b/internal/graphengine/engine_v3.go
@@ -56,6 +56,9 @@ type EngineV3Options struct {
 func NewEngineV3(options EngineV3Options) (*EngineV3, error) {
 	logger := createAbstractLogrusLogger(options.Logger)
 	gqlTools := graphqlGoToolsV2{}
+	transportType := DetermineGraphQLEngineTransportType(options.ApiDefinition)
+	configureGraphQLEngineHTTPClient(options.HttpClient, transportType, options.Injections.NewReusableBodyReadCloser)
+	configureGraphQLEngineHTTPClient(options.StreamingClient, transportType, options.Injections.NewReusableBodyReadCloser)
 
 	var parsedSchema = options.Schema
 	if parsedSchema == nil {

--- a/internal/graphengine/engine_v3.go
+++ b/internal/graphengine/engine_v3.go
@@ -28,6 +28,7 @@ type EngineV3 struct {
 	complexityChecker         ComplexityChecker
 	granularAccessChecker     GranularAccessChecker
 	reverseProxyPreHandler    ReverseProxyPreHandler
+	specCtx                   context.Context
 	contextCancel             context.CancelFunc
 	newReusableBodyReadCloser NewReusableBodyReadCloserFunc
 	seekReadCloser            SeekReadCloserFunc
@@ -129,6 +130,7 @@ func NewEngineV3(options EngineV3Options) (*EngineV3, error) {
 		gqlTools:               gqlTools,
 		tykVariableReplacer:    options.Injections.TykVariableReplacer,
 		seekReadCloser:         options.Injections.SeekReadCloser,
+		specCtx:                specCtx,
 		contextCancel:          cancel,
 		complexityChecker:      complexityChecker,
 		granularAccessChecker:  granularAccessChecker,

--- a/internal/graphengine/engine_v3_reverse_proxy.go
+++ b/internal/graphengine/engine_v3_reverse_proxy.go
@@ -82,6 +82,7 @@ func (e *EngineV3) handoverWebSocketConnectionToGraphQLExecutionEngine(params *R
 		errChan,
 		conn,
 		executorPool,
+		gqlwebsocketv2.WithContext(params.OutRequest.Context()),
 		gqlwebsocketv2.WithLogger(e.logger),
 		gqlwebsocketv2.WithProtocolFromRequestHeaders(params.OutRequest),
 	)
@@ -103,6 +104,7 @@ func (e *EngineV3) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphqlv2
 	isProxyOnly := isProxyOnly(e.apiDefinition)
 	span := otel.SpanFromContext(outreq.Context())
 	reqCtx := otel.ContextWithSpan(context.Background(), span)
+	reqCtx = copyGraphQLEngineTransportContextValue(reqCtx, outreq.Context())
 	if isProxyOnly {
 		reqCtx = SetProxyOnlyContextValue(reqCtx, outreq)
 	}

--- a/internal/graphengine/engine_v3_reverse_proxy.go
+++ b/internal/graphengine/engine_v3_reverse_proxy.go
@@ -82,7 +82,7 @@ func (e *EngineV3) handoverWebSocketConnectionToGraphQLExecutionEngine(params *R
 		errChan,
 		conn,
 		executorPool,
-		gqlwebsocketv2.WithContext(params.OutRequest.Context()),
+		gqlwebsocketv2.WithContext(subscriptionRequestContext(e.specCtx, params.OutRequest)),
 		gqlwebsocketv2.WithLogger(e.logger),
 		gqlwebsocketv2.WithProtocolFromRequestHeaders(params.OutRequest),
 	)
@@ -138,9 +138,9 @@ func (e *EngineV3) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphqlv2
 		// This is a valid query for proxy-only mode: query { __typename }
 		// In this case, upstreamResponse is nil.
 		// See TT-6419 for further info.
-		if proxyOnlyCtx.upstreamResponse != nil {
-			header = proxyOnlyCtx.upstreamResponse.Header
-			httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
+		if upstreamResponse := proxyOnlyCtx.getUpstreamResponse(); upstreamResponse != nil {
+			header = upstreamResponse.Header
+			httpStatus = upstreamResponse.StatusCode
 			// change the value of the header's content encoding to use the content encoding defined by the accept encoding
 			contentEncoding := selectContentEncodingToBeUsed(proxyOnlyCtx.forwardedRequest.Header.Get(httpclientv2.AcceptEncodingHeader))
 			header.Set(httpclientv2.ContentEncodingHeader, contentEncoding)

--- a/internal/graphengine/engine_v3_test.go
+++ b/internal/graphengine/engine_v3_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/jensneuse/abstractlogger"
 	"github.com/sirupsen/logrus"
@@ -34,196 +33,45 @@ func NewTestEngine(t *testing.T) *EngineV3 {
 }
 
 func TestEngineV3_HandleReverseProxyIsolatesCallerAuthorization(t *testing.T) {
-	apiDefinition := newTestApiDefinitionV2(apidef.GraphQLExecutionModeExecutionEngine, "http://upstream.example/graphql")
-	apiDefinition.GraphQL.Version = apidef.GraphQLConfigVersion3Preview
-	apiDefinition.UseStandardAuth = true
-	apiDefinition.StripAuthData = false
-	schema, err := graphqlv2.NewSchemaFromString(apiDefinition.GraphQL.Schema)
-	require.NoError(t, err)
-	client := &http.Client{}
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	engine, err := NewEngineV3(EngineV3Options{
-		Logger:          logger,
-		Schema:          schema,
-		ApiDefinition:   apiDefinition,
-		HttpClient:      client,
-		StreamingClient: client,
-		Injections: EngineV3Injections{
-			ContextRetrieveRequest: func(*http.Request) *graphqlv2.Request {
-				return &graphqlv2.Request{Query: "query { hello }"}
-			},
-			NewReusableBodyReadCloser: testReusableReadCloser,
-			TykVariableReplacer: func(_ *http.Request, value string, _ bool) string {
-				return value
-			},
-		},
-	})
-	require.NoError(t, err)
-	t.Cleanup(engine.Cancel)
+	apiDefinition := newUDGApiDefinition(apidef.GraphQLConfigVersion3Preview, "http://upstream.example/graphql")
+	engine := newIsolationEngineV3(t, apiDefinition, "query { hello }")
 
-	upstream := &authorizationRecordingRoundTripper{}
+	upstream := newAuthorizationRecordingRoundTripper()
 	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
-		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
-		require.NoError(t, err)
-		request.Header.Set("Authorization", token)
-		response, hijacked, err := engine.HandleReverseProxy(ReverseProxyParams{
-			RoundTripper: upstream,
-			OutRequest:   request,
-			NeedsEngine:  true,
-		})
-		require.NoError(t, err)
-		assert.False(t, hijacked)
-		require.NotNil(t, response)
-		_ = response.Body.Close()
+		callAs(t, engine, upstream, "", token)
 	}
 
-	require.Eventually(t, func() bool {
-		return len(upstream.values()) == 2
-	}, 5*time.Second, 10*time.Millisecond)
+	waitForUpstreamCalls(t, upstream.authorizationRecorder, 2)
 	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
 }
 
 func TestEngineV3_SSESubscriptionIsolatesCallerAuthorization(t *testing.T) {
-	upstream := &authorizationRecordingRoundTripper{}
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		upstream.mu.Lock()
-		upstream.received = append(upstream.received, request.Header.Get("Authorization"))
-		upstream.mu.Unlock()
-		writer.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(writer, "event: next\ndata: {\"data\":{\"count\":1}}\n\nevent: complete\n\n")
-	}))
-	t.Cleanup(server.Close)
-
-	dataSourceConfig, err := json.Marshal(apidef.GraphQLEngineDataSourceConfigGraphQL{
-		URL:              server.URL,
-		Method:           http.MethodPost,
-		SubscriptionType: apidef.GQLSubscriptionSSE,
-		SSEUsePost:       true,
-	})
-	require.NoError(t, err)
-	apiDefinition := &apidef.APIDefinition{
-		UseStandardAuth: true,
-		GraphQL: apidef.GraphQLConfig{
-			Enabled:       true,
-			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
-			Version:       apidef.GraphQLConfigVersion3Preview,
-			Schema:        "type Query { hello: String } type Subscription { count: Int }",
-			Engine: apidef.GraphQLEngineConfig{DataSources: []apidef.GraphQLEngineDataSource{{
-				Kind:       apidef.GraphQLEngineDataSourceKindGraphQL,
-				Name:       "subscription",
-				RootFields: []apidef.GraphQLTypeFields{{Type: "Subscription", Fields: []string{"count"}}},
-				Config:     dataSourceConfig,
-			}}},
-		},
-	}
-	schema, err := graphqlv2.NewSchemaFromString(apiDefinition.GraphQL.Schema)
-	require.NoError(t, err)
-	client := &http.Client{}
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	engine, err := NewEngineV3(EngineV3Options{
-		Logger:          logger,
-		Schema:          schema,
-		ApiDefinition:   apiDefinition,
-		HttpClient:      client,
-		StreamingClient: client,
-		Injections: EngineV3Injections{
-			ContextRetrieveRequest: func(*http.Request) *graphqlv2.Request {
-				return &graphqlv2.Request{Query: "subscription { count }"}
-			},
-			NewReusableBodyReadCloser: testReusableReadCloser,
-			TykVariableReplacer: func(_ *http.Request, value string, _ bool) string {
-				return value
-			},
-		},
-	})
-	require.NoError(t, err)
-	t.Cleanup(engine.Cancel)
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingSSEUpstream(t, upstream)
+	engine := newIsolationEngineV3(t,
+		newUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion3Preview, apidef.GQLSubscriptionSSE, server.URL),
+		"subscription { count }")
 
 	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
-		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
-		require.NoError(t, err)
-		request.Header.Set("Authorization", token)
-		response, _, err := engine.HandleReverseProxy(ReverseProxyParams{
-			RoundTripper: http.DefaultTransport,
-			OutRequest:   request,
-			NeedsEngine:  true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, response)
-		_ = response.Body.Close()
+		callAs(t, engine, http.DefaultTransport, "", token)
 	}
 
-	require.Eventually(t, func() bool {
-		return len(upstream.values()) == 2
-	}, 5*time.Second, 10*time.Millisecond)
+	waitForUpstreamCalls(t, upstream, 2)
 	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
 }
 
 func TestEngineV3_WebSocketSubscriptionIsolatesCallerAuthorization(t *testing.T) {
-	server, upstream := newAuthorizationRecordingWSUpstream(t)
-	dataSourceConfig, err := json.Marshal(apidef.GraphQLEngineDataSourceConfigGraphQL{
-		URL:              server.URL,
-		SubscriptionType: apidef.GQLSubscriptionWS,
-	})
-	require.NoError(t, err)
-	apiDefinition := &apidef.APIDefinition{
-		UseStandardAuth: true,
-		GraphQL: apidef.GraphQLConfig{
-			Enabled:       true,
-			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
-			Version:       apidef.GraphQLConfigVersion3Preview,
-			Schema:        "type Query { hello: String } type Subscription { count: Int }",
-			Engine: apidef.GraphQLEngineConfig{DataSources: []apidef.GraphQLEngineDataSource{{
-				Kind:       apidef.GraphQLEngineDataSourceKindGraphQL,
-				Name:       "subscription",
-				RootFields: []apidef.GraphQLTypeFields{{Type: "Subscription", Fields: []string{"count"}}},
-				Config:     dataSourceConfig,
-			}}},
-		},
-	}
-	schema, err := graphqlv2.NewSchemaFromString(apiDefinition.GraphQL.Schema)
-	require.NoError(t, err)
-	client := &http.Client{}
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	engine, err := NewEngineV3(EngineV3Options{
-		Logger:          logger,
-		Schema:          schema,
-		ApiDefinition:   apiDefinition,
-		HttpClient:      client,
-		StreamingClient: client,
-		Injections: EngineV3Injections{
-			ContextRetrieveRequest: func(*http.Request) *graphqlv2.Request {
-				return &graphqlv2.Request{Query: "subscription { count }"}
-			},
-			NewReusableBodyReadCloser: testReusableReadCloser,
-			TykVariableReplacer: func(_ *http.Request, value string, _ bool) string {
-				return value
-			},
-		},
-	})
-	require.NoError(t, err)
-	t.Cleanup(engine.Cancel)
+	upstream := newAuthorizationRecorder("")
+	server := newRecordingWSUpstream(t, upstream, protocolGraphQLWS, messageTypeData)
+	engine := newIsolationEngineV3(t,
+		newUDGSubscriptionApiDefinition(t, apidef.GraphQLConfigVersion3Preview, apidef.GQLSubscriptionWS, server.URL),
+		"subscription { count }")
 
 	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
-		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
-		require.NoError(t, err)
-		request.Header.Set("Authorization", token)
-		response, _, err := engine.HandleReverseProxy(ReverseProxyParams{
-			RoundTripper: http.DefaultTransport,
-			OutRequest:   request,
-			NeedsEngine:  true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, response)
-		_ = response.Body.Close()
+		callAs(t, engine, http.DefaultTransport, "", token)
 	}
 
-	require.Eventually(t, func() bool {
-		return len(upstream.values()) == 2
-	}, 5*time.Second, 10*time.Millisecond)
+	waitForUpstreamCalls(t, upstream, 2)
 	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
 }
 

--- a/internal/graphengine/engine_v3_test.go
+++ b/internal/graphengine/engine_v3_test.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/jensneuse/abstractlogger"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	graphqlv2 "github.com/TykTechnologies/graphql-go-tools/v2/pkg/graphql"
+	"github.com/TykTechnologies/tyk/apidef"
 )
 
 func NewTestEngine(t *testing.T) *EngineV3 {
@@ -27,6 +31,258 @@ func NewTestEngine(t *testing.T) *EngineV3 {
 		logger:                 abstractlogger.Noop{},
 		ctxRetrieveRequestFunc: nil,
 	}
+}
+
+func TestEngineV3_HandleReverseProxyIsolatesCallerAuthorization(t *testing.T) {
+	apiDefinition := newTestApiDefinitionV2(apidef.GraphQLExecutionModeExecutionEngine, "http://upstream.example/graphql")
+	apiDefinition.GraphQL.Version = apidef.GraphQLConfigVersion3Preview
+	apiDefinition.UseStandardAuth = true
+	apiDefinition.StripAuthData = false
+	schema, err := graphqlv2.NewSchemaFromString(apiDefinition.GraphQL.Schema)
+	require.NoError(t, err)
+	client := &http.Client{}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	engine, err := NewEngineV3(EngineV3Options{
+		Logger:          logger,
+		Schema:          schema,
+		ApiDefinition:   apiDefinition,
+		HttpClient:      client,
+		StreamingClient: client,
+		Injections: EngineV3Injections{
+			ContextRetrieveRequest: func(*http.Request) *graphqlv2.Request {
+				return &graphqlv2.Request{Query: "query { hello }"}
+			},
+			NewReusableBodyReadCloser: testReusableReadCloser,
+			TykVariableReplacer: func(_ *http.Request, value string, _ bool) string {
+				return value
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(engine.Cancel)
+
+	upstream := &authorizationRecordingRoundTripper{}
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+		require.NoError(t, err)
+		request.Header.Set("Authorization", token)
+		response, hijacked, err := engine.HandleReverseProxy(ReverseProxyParams{
+			RoundTripper: upstream,
+			OutRequest:   request,
+			NeedsEngine:  true,
+		})
+		require.NoError(t, err)
+		assert.False(t, hijacked)
+		require.NotNil(t, response)
+		_ = response.Body.Close()
+	}
+
+	require.Eventually(t, func() bool {
+		return len(upstream.values()) == 2
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestEngineV3_SSESubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	upstream := &authorizationRecordingRoundTripper{}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		upstream.mu.Lock()
+		upstream.received = append(upstream.received, request.Header.Get("Authorization"))
+		upstream.mu.Unlock()
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(writer, "event: next\ndata: {\"data\":{\"count\":1}}\n\nevent: complete\n\n")
+	}))
+	t.Cleanup(server.Close)
+
+	dataSourceConfig, err := json.Marshal(apidef.GraphQLEngineDataSourceConfigGraphQL{
+		URL:              server.URL,
+		Method:           http.MethodPost,
+		SubscriptionType: apidef.GQLSubscriptionSSE,
+		SSEUsePost:       true,
+	})
+	require.NoError(t, err)
+	apiDefinition := &apidef.APIDefinition{
+		UseStandardAuth: true,
+		GraphQL: apidef.GraphQLConfig{
+			Enabled:       true,
+			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
+			Version:       apidef.GraphQLConfigVersion3Preview,
+			Schema:        "type Query { hello: String } type Subscription { count: Int }",
+			Engine: apidef.GraphQLEngineConfig{DataSources: []apidef.GraphQLEngineDataSource{{
+				Kind:       apidef.GraphQLEngineDataSourceKindGraphQL,
+				Name:       "subscription",
+				RootFields: []apidef.GraphQLTypeFields{{Type: "Subscription", Fields: []string{"count"}}},
+				Config:     dataSourceConfig,
+			}}},
+		},
+	}
+	schema, err := graphqlv2.NewSchemaFromString(apiDefinition.GraphQL.Schema)
+	require.NoError(t, err)
+	client := &http.Client{}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	engine, err := NewEngineV3(EngineV3Options{
+		Logger:          logger,
+		Schema:          schema,
+		ApiDefinition:   apiDefinition,
+		HttpClient:      client,
+		StreamingClient: client,
+		Injections: EngineV3Injections{
+			ContextRetrieveRequest: func(*http.Request) *graphqlv2.Request {
+				return &graphqlv2.Request{Query: "subscription { count }"}
+			},
+			NewReusableBodyReadCloser: testReusableReadCloser,
+			TykVariableReplacer: func(_ *http.Request, value string, _ bool) string {
+				return value
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(engine.Cancel)
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+		require.NoError(t, err)
+		request.Header.Set("Authorization", token)
+		response, _, err := engine.HandleReverseProxy(ReverseProxyParams{
+			RoundTripper: http.DefaultTransport,
+			OutRequest:   request,
+			NeedsEngine:  true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		_ = response.Body.Close()
+	}
+
+	require.Eventually(t, func() bool {
+		return len(upstream.values()) == 2
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestEngineV3_WebSocketSubscriptionIsolatesCallerAuthorization(t *testing.T) {
+	server, upstream := newAuthorizationRecordingWSUpstream(t)
+	dataSourceConfig, err := json.Marshal(apidef.GraphQLEngineDataSourceConfigGraphQL{
+		URL:              server.URL,
+		SubscriptionType: apidef.GQLSubscriptionWS,
+	})
+	require.NoError(t, err)
+	apiDefinition := &apidef.APIDefinition{
+		UseStandardAuth: true,
+		GraphQL: apidef.GraphQLConfig{
+			Enabled:       true,
+			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
+			Version:       apidef.GraphQLConfigVersion3Preview,
+			Schema:        "type Query { hello: String } type Subscription { count: Int }",
+			Engine: apidef.GraphQLEngineConfig{DataSources: []apidef.GraphQLEngineDataSource{{
+				Kind:       apidef.GraphQLEngineDataSourceKindGraphQL,
+				Name:       "subscription",
+				RootFields: []apidef.GraphQLTypeFields{{Type: "Subscription", Fields: []string{"count"}}},
+				Config:     dataSourceConfig,
+			}}},
+		},
+	}
+	schema, err := graphqlv2.NewSchemaFromString(apiDefinition.GraphQL.Schema)
+	require.NoError(t, err)
+	client := &http.Client{}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	engine, err := NewEngineV3(EngineV3Options{
+		Logger:          logger,
+		Schema:          schema,
+		ApiDefinition:   apiDefinition,
+		HttpClient:      client,
+		StreamingClient: client,
+		Injections: EngineV3Injections{
+			ContextRetrieveRequest: func(*http.Request) *graphqlv2.Request {
+				return &graphqlv2.Request{Query: "subscription { count }"}
+			},
+			NewReusableBodyReadCloser: testReusableReadCloser,
+			TykVariableReplacer: func(_ *http.Request, value string, _ bool) string {
+				return value
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(engine.Cancel)
+
+	for _, token := range []string{"Bearer AAA", "Bearer BBB"} {
+		request, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+		require.NoError(t, err)
+		request.Header.Set("Authorization", token)
+		response, _, err := engine.HandleReverseProxy(ReverseProxyParams{
+			RoundTripper: http.DefaultTransport,
+			OutRequest:   request,
+			NeedsEngine:  true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		_ = response.Body.Close()
+	}
+
+	require.Eventually(t, func() bool {
+		return len(upstream.values()) == 2
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.ElementsMatch(t, []string{"Bearer AAA", "Bearer BBB"}, upstream.values())
+}
+
+func TestNewEngineV3_ConfiguresHTTPClients(t *testing.T) {
+	newEngine := func(t *testing.T, httpClient, streamingClient *http.Client) *EngineV3 {
+		t.Helper()
+		apiDefinition := newTestApiDefinitionV2(apidef.GraphQLExecutionModeExecutionEngine, "http://upstream.example/graphql")
+		apiDefinition.GraphQL.Version = apidef.GraphQLConfigVersion3Preview
+		schema, err := graphqlv2.NewSchemaFromString(apiDefinition.GraphQL.Schema)
+		require.NoError(t, err)
+		logger := logrus.New()
+		logger.SetOutput(io.Discard)
+		engine, err := NewEngineV3(EngineV3Options{
+			Logger:          logger,
+			Schema:          schema,
+			ApiDefinition:   apiDefinition,
+			HttpClient:      httpClient,
+			StreamingClient: streamingClient,
+			Injections: EngineV3Injections{
+				ContextRetrieveRequest: func(*http.Request) *graphqlv2.Request {
+					return &graphqlv2.Request{Query: "query { hello }"}
+				},
+				NewReusableBodyReadCloser: testReusableReadCloser,
+				TykVariableReplacer: func(_ *http.Request, value string, _ bool) string {
+					return value
+				},
+			},
+		})
+		require.NoError(t, err)
+		t.Cleanup(engine.Cancel)
+		return engine
+	}
+
+	t.Run("should configure both the http client and the streaming client", func(t *testing.T) {
+		httpClient := &http.Client{Transport: taggedRoundTripper("http")}
+		streamingClient := &http.Client{Transport: taggedRoundTripper("streaming")}
+
+		newEngine(t, httpClient, streamingClient)
+
+		httpTransport, ok := httpClient.Transport.(*GraphQLEngineTransport)
+		require.True(t, ok, "the http client transport should be wrapped")
+		assert.Equal(t, taggedRoundTripper("http"), httpTransport.originalTransport)
+		streamingTransport, ok := streamingClient.Transport.(*GraphQLEngineTransport)
+		require.True(t, ok, "the streaming client transport should be wrapped")
+		assert.Equal(t, taggedRoundTripper("streaming"), streamingTransport.originalTransport)
+	})
+
+	t.Run("should not fail when the streaming client is nil", func(t *testing.T) {
+		// The gateway does not set a streaming client for version 3-preview,
+		// see gateway/mw_graphql.go.
+		httpClient := &http.Client{Transport: taggedRoundTripper("http")}
+
+		assert.NotPanics(t, func() {
+			newEngine(t, httpClient, nil)
+		})
+
+		_, ok := httpClient.Transport.(*GraphQLEngineTransport)
+		assert.True(t, ok, "the http client transport should be wrapped")
+	})
 }
 
 func TestEngineV3_ProcessRequest(t *testing.T) {

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -83,7 +83,7 @@ func (g graphqlGoToolsV1) headerModifier(additionalHeaders http.Header) postproc
 }
 
 func (g graphqlGoToolsV1) returnErrorsFromUpstream(proxyOnlyCtx *GraphQLProxyOnlyContextValues, resultWriter *graphql.EngineResultWriter, seekReadCloser SeekReadCloserFunc) error {
-	body, err := seekReadCloser(proxyOnlyCtx.upstreamResponse.Body)
+	body, err := seekReadCloser(proxyOnlyCtx.getUpstreamResponse().Body)
 	if body == nil {
 		// Response body already read by graphql-go-tools, and it's not re-readable. Quit silently.
 		return nil

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -481,12 +481,8 @@ type reverseProxyPreHandlerV1 struct {
 }
 
 func (r *reverseProxyPreHandlerV1) PreHandle(params ReverseProxyParams) (reverseProxyType ReverseProxyType, err error) {
-	r.httpClient.Transport = NewGraphQLEngineTransport(
-		DetermineGraphQLEngineTransportType(r.apiDefinition),
-		params.RoundTripper,
-		r.newReusableBodyReadCloser,
-		params.HeadersConfig,
-	)
+	requestContext := SetGraphQLEngineTransportContextValue(params.OutRequest.Context(), params.RoundTripper, params.HeadersConfig)
+	*params.OutRequest = *params.OutRequest.WithContext(requestContext)
 
 	switch {
 	case params.IsCORSPreflight:

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -72,12 +72,32 @@ func (g graphqlGoToolsV1) handleIntrospection(schema *graphql.Schema) (res *http
 	return
 }
 
-func (g graphqlGoToolsV1) headerModifier(additionalHeaders http.Header) postprocess.HeaderModifier {
+func (g graphqlGoToolsV1) headerModifier(outreq *http.Request, additionalHeaders http.Header, variableReplacer TykVariableReplacer) postprocess.HeaderModifier {
 	return func(header http.Header) {
-		for key := range additionalHeaders {
+		for key, values := range additionalHeaders {
+			// Assigned rather than Set so that a header with more than one value keeps
+			// all of them: the connection key of a subscription is built from every
+			// value, see connectionKey in the graphql-go-tools subscription client.
+			// Set would collapse them to the first one. The key has to be canonicalised
+			// by hand because a direct map write does not do it, while the Get above
+			// does.
 			if header.Get(key) == "" {
-				header.Set(key, additionalHeaders.Get(key))
+				header[http.CanonicalHeaderKey(key)] = append([]string(nil), values...)
 			}
+		}
+
+		// A nil replacer means the caller wants the additional headers merged and nothing
+		// resolved. EngineV1 has no header modifier at all, so this only guards a
+		// partially injected EngineV2.
+		if variableReplacer == nil {
+			return
+		}
+		for key, values := range header {
+			replaced := make([]string, len(values))
+			for index, value := range values {
+				replaced[index] = variableReplacer(outreq, value, false)
+			}
+			header[key] = replaced
 		}
 	}
 }

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -501,6 +501,12 @@ type reverseProxyPreHandlerV1 struct {
 }
 
 func (r *reverseProxyPreHandlerV1) PreHandle(params ReverseProxyParams) (reverseProxyType ReverseProxyType, err error) {
+	// EngineV1 is the only engine that needs this. Its data sources drop the execution
+	// context, so the request scoped round tripper below never reaches them and a tyk://
+	// internal data source has nothing that can route it. See fallbackRoundTripper.
+	if transport, ok := r.httpClient.Transport.(*GraphQLEngineTransport); ok {
+		transport.setFallbackRoundTripper(params.RoundTripper)
+	}
 	requestContext := SetGraphQLEngineTransportContextValue(params.OutRequest.Context(), params.RoundTripper, params.HeadersConfig)
 	*params.OutRequest = *params.OutRequest.WithContext(requestContext)
 

--- a/internal/graphengine/graphql_go_tools_v1_test.go
+++ b/internal/graphengine/graphql_go_tools_v1_test.go
@@ -915,7 +915,7 @@ func TestReverseProxyPreHandlerV1_PreHandle(t *testing.T) {
 		require.NoError(t, err)
 
 		reverseProxyPreHandler := newTestReverseProxyPreHandlerV1(t, apidef.GraphQLExecutionModeProxyOnly)
-		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphql.Request {
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(_ *http.Request) *graphql.Request {
 			return &graphql.Request{Query: `{ hello }`}
 		}
 		headersConfig := ReverseProxyHeadersConfig{
@@ -942,7 +942,7 @@ func TestReverseProxyPreHandlerV1_PreHandle(t *testing.T) {
 		require.NoError(t, err)
 
 		reverseProxyPreHandler := newTestReverseProxyPreHandlerV1(t, apidef.GraphQLExecutionModeProxyOnly)
-		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphql.Request {
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(_ *http.Request) *graphql.Request {
 			return nil
 		}
 
@@ -964,7 +964,7 @@ func TestReverseProxyPreHandlerV1_PreHandle(t *testing.T) {
 		require.NoError(t, err)
 
 		reverseProxyPreHandler := newTestReverseProxyPreHandlerV1(t, apidef.GraphQLExecutionModeProxyOnly)
-		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphql.Request {
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(_ *http.Request) *graphql.Request {
 			return &graphql.Request{Query: `{ hello }`}
 		}
 		configureGraphQLEngineHTTPClient(
@@ -986,7 +986,7 @@ func TestReverseProxyPreHandlerV1_PreHandle(t *testing.T) {
 
 	t.Run("should keep the round tripper of every request when called more than once", func(t *testing.T) {
 		reverseProxyPreHandler := newTestReverseProxyPreHandlerV1(t, apidef.GraphQLExecutionModeProxyOnly)
-		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphql.Request {
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(_ *http.Request) *graphql.Request {
 			return &graphql.Request{Query: `{ hello }`}
 		}
 

--- a/internal/graphengine/graphql_go_tools_v1_test.go
+++ b/internal/graphengine/graphql_go_tools_v1_test.go
@@ -909,6 +909,106 @@ func TestReverseProxyPreHandlerV1_PreHandle(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, ReverseProxyTypePreFlight, result)
 	})
+
+	t.Run("should attach the round tripper and the headers config to the request context", func(t *testing.T) {
+		request, err := http.NewRequest(http.MethodPost, "http://example.com", nil)
+		require.NoError(t, err)
+
+		reverseProxyPreHandler := newTestReverseProxyPreHandlerV1(t, apidef.GraphQLExecutionModeProxyOnly)
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphql.Request {
+			return &graphql.Request{Query: `{ hello }`}
+		}
+		headersConfig := ReverseProxyHeadersConfig{
+			ProxyOnly: ProxyOnlyHeadersConfig{UseImmutableHeaders: true},
+		}
+
+		_, err = reverseProxyPreHandler.PreHandle(ReverseProxyParams{
+			OutRequest:    request,
+			NeedsEngine:   true,
+			RoundTripper:  taggedRoundTripper("caller"),
+			HeadersConfig: headersConfig,
+		})
+		require.NoError(t, err)
+
+		// The values have to be readable through the request the caller owns.
+		values := getGraphQLEngineTransportContextValue(request.Context())
+		require.NotNil(t, values)
+		assert.Equal(t, taggedRoundTripper("caller"), values.roundTripper)
+		assert.Equal(t, headersConfig, values.headersConfig)
+	})
+
+	t.Run("should attach the round tripper on a request that does not reach the engine", func(t *testing.T) {
+		request, err := http.NewRequest(http.MethodOptions, "http://example.com", nil)
+		require.NoError(t, err)
+
+		reverseProxyPreHandler := newTestReverseProxyPreHandlerV1(t, apidef.GraphQLExecutionModeProxyOnly)
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphql.Request {
+			return nil
+		}
+
+		result, err := reverseProxyPreHandler.PreHandle(ReverseProxyParams{
+			OutRequest:      request,
+			IsCORSPreflight: true,
+			RoundTripper:    taggedRoundTripper("caller"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, ReverseProxyTypePreFlight, result)
+
+		values := getGraphQLEngineTransportContextValue(request.Context())
+		require.NotNil(t, values)
+		assert.Equal(t, taggedRoundTripper("caller"), values.roundTripper)
+	})
+
+	t.Run("should not modify the transport of the shared http client", func(t *testing.T) {
+		request, err := http.NewRequest(http.MethodPost, "http://example.com", nil)
+		require.NoError(t, err)
+
+		reverseProxyPreHandler := newTestReverseProxyPreHandlerV1(t, apidef.GraphQLExecutionModeProxyOnly)
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphql.Request {
+			return &graphql.Request{Query: `{ hello }`}
+		}
+		configureGraphQLEngineHTTPClient(
+			reverseProxyPreHandler.httpClient,
+			DetermineGraphQLEngineTransportType(reverseProxyPreHandler.apiDefinition),
+			testReusableReadCloser,
+		)
+		configuredTransport := reverseProxyPreHandler.httpClient.Transport
+
+		_, err = reverseProxyPreHandler.PreHandle(ReverseProxyParams{
+			OutRequest:   request,
+			NeedsEngine:  true,
+			RoundTripper: taggedRoundTripper("caller"),
+		})
+		require.NoError(t, err)
+
+		assert.Same(t, configuredTransport, reverseProxyPreHandler.httpClient.Transport)
+	})
+
+	t.Run("should keep the round tripper of every request when called more than once", func(t *testing.T) {
+		reverseProxyPreHandler := newTestReverseProxyPreHandlerV1(t, apidef.GraphQLExecutionModeProxyOnly)
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphql.Request {
+			return &graphql.Request{Query: `{ hello }`}
+		}
+
+		requests := make([]*http.Request, 0, 2)
+		for _, tag := range []string{"caller-a", "caller-b"} {
+			request, err := http.NewRequest(http.MethodPost, "http://example.com", nil)
+			require.NoError(t, err)
+			_, err = reverseProxyPreHandler.PreHandle(ReverseProxyParams{
+				OutRequest:   request,
+				NeedsEngine:  true,
+				RoundTripper: taggedRoundTripper(tag),
+			})
+			require.NoError(t, err)
+			requests = append(requests, request)
+		}
+
+		for i, tag := range []string{"caller-a", "caller-b"} {
+			values := getGraphQLEngineTransportContextValue(requests[i].Context())
+			require.NotNil(t, values)
+			assert.Equal(t, taggedRoundTripper(tag), values.roundTripper)
+		}
+	})
 }
 
 func newTestGraphqlRequestProcessorV1(t *testing.T) *graphqlRequestProcessorV1 {

--- a/internal/graphengine/graphql_go_tools_v2.go
+++ b/internal/graphengine/graphql_go_tools_v2.go
@@ -121,12 +121,8 @@ type reverseProxyPreHandlerV2 struct {
 }
 
 func (r *reverseProxyPreHandlerV2) PreHandle(params ReverseProxyParams) (reverseProxyType ReverseProxyType, err error) {
-	r.httpClient.Transport = NewGraphQLEngineTransport(
-		DetermineGraphQLEngineTransportType(r.apiDefinition),
-		params.RoundTripper,
-		r.newReusableBodyReadCloser,
-		params.HeadersConfig,
-	)
+	requestContext := SetGraphQLEngineTransportContextValue(params.OutRequest.Context(), params.RoundTripper, params.HeadersConfig)
+	*params.OutRequest = *params.OutRequest.WithContext(requestContext)
 
 	switch {
 	case params.IsCORSPreflight:

--- a/internal/graphengine/graphql_go_tools_v2.go
+++ b/internal/graphengine/graphql_go_tools_v2.go
@@ -76,15 +76,23 @@ func (g graphqlGoToolsV2) handleIntrospection(schema *graphqlv2.Schema) (res *ht
 
 func (g graphqlGoToolsV2) headerModifier(outreq *http.Request, additionalHeaders http.Header, variableReplacer TykVariableReplacer) postprocessv2.HeaderModifier {
 	return func(header http.Header) {
-		for key := range additionalHeaders {
+		for key, values := range additionalHeaders {
+			// See the v1 modifier: assigned rather than Set to keep every value of a
+			// multi-value header, canonicalised by hand because a map write does not.
 			if header.Get(key) == "" {
-				header.Set(key, additionalHeaders.Get(key))
+				header[http.CanonicalHeaderKey(key)] = append([]string(nil), values...)
 			}
 		}
 
-		for key := range header {
-			val := variableReplacer(outreq, header.Get(key), false)
-			header.Set(key, val)
+		if variableReplacer == nil {
+			return
+		}
+		for key, values := range header {
+			replaced := make([]string, len(values))
+			for index, value := range values {
+				replaced[index] = variableReplacer(outreq, value, false)
+			}
+			header[key] = replaced
 		}
 	}
 }

--- a/internal/graphengine/graphql_go_tools_v2.go
+++ b/internal/graphengine/graphql_go_tools_v2.go
@@ -90,7 +90,7 @@ func (g graphqlGoToolsV2) headerModifier(outreq *http.Request, additionalHeaders
 }
 
 func (g graphqlGoToolsV2) returnErrorsFromUpstream(proxyOnlyCtx *GraphQLProxyOnlyContextValues, resultWriter *graphqlv2.EngineResultWriter, seekReadCloser SeekReadCloserFunc) error {
-	body, err := seekReadCloser(proxyOnlyCtx.upstreamResponse.Body)
+	body, err := seekReadCloser(proxyOnlyCtx.getUpstreamResponse().Body)
 	if body == nil {
 		// Response body already read by graphql-go-tools, and it's not re-readable. Quit silently.
 		return nil

--- a/internal/graphengine/graphql_go_tools_v2_test.go
+++ b/internal/graphengine/graphql_go_tools_v2_test.go
@@ -165,7 +165,7 @@ func TestReverseProxyPreHandlerV2_PreHandle(t *testing.T) {
 		require.NoError(t, err)
 
 		reverseProxyPreHandler := newTestReverseProxyPreHandlerV2(t)
-		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphqlv2.Request {
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(_ *http.Request) *graphqlv2.Request {
 			return &graphqlv2.Request{Query: `{ hello }`}
 		}
 		headersConfig := ReverseProxyHeadersConfig{
@@ -192,7 +192,7 @@ func TestReverseProxyPreHandlerV2_PreHandle(t *testing.T) {
 		require.NoError(t, err)
 
 		reverseProxyPreHandler := newTestReverseProxyPreHandlerV2(t)
-		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphqlv2.Request {
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(_ *http.Request) *graphqlv2.Request {
 			return nil
 		}
 
@@ -214,7 +214,7 @@ func TestReverseProxyPreHandlerV2_PreHandle(t *testing.T) {
 		require.NoError(t, err)
 
 		reverseProxyPreHandler := newTestReverseProxyPreHandlerV2(t)
-		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphqlv2.Request {
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(_ *http.Request) *graphqlv2.Request {
 			return &graphqlv2.Request{Query: `{ hello }`}
 		}
 		configureGraphQLEngineHTTPClient(
@@ -236,7 +236,7 @@ func TestReverseProxyPreHandlerV2_PreHandle(t *testing.T) {
 
 	t.Run("should keep the round tripper of every request when called more than once", func(t *testing.T) {
 		reverseProxyPreHandler := newTestReverseProxyPreHandlerV2(t)
-		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphqlv2.Request {
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(_ *http.Request) *graphqlv2.Request {
 			return &graphqlv2.Request{Query: `{ hello }`}
 		}
 

--- a/internal/graphengine/graphql_go_tools_v2_test.go
+++ b/internal/graphengine/graphql_go_tools_v2_test.go
@@ -160,6 +160,105 @@ func TestReverseProxyPreHandlerV2_PreHandle(t *testing.T) {
 		assert.Equal(t, ReverseProxyTypeNone, result)
 	})
 
+	t.Run("should attach the round tripper and the headers config to the request context", func(t *testing.T) {
+		request, err := http.NewRequest(http.MethodPost, "http://example.com", nil)
+		require.NoError(t, err)
+
+		reverseProxyPreHandler := newTestReverseProxyPreHandlerV2(t)
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphqlv2.Request {
+			return &graphqlv2.Request{Query: `{ hello }`}
+		}
+		headersConfig := ReverseProxyHeadersConfig{
+			ProxyOnly: ProxyOnlyHeadersConfig{UseImmutableHeaders: true},
+		}
+
+		_, err = reverseProxyPreHandler.PreHandle(ReverseProxyParams{
+			OutRequest:    request,
+			NeedsEngine:   true,
+			RoundTripper:  taggedRoundTripper("caller"),
+			HeadersConfig: headersConfig,
+		})
+		require.NoError(t, err)
+
+		// The values have to be readable through the request the caller owns.
+		values := getGraphQLEngineTransportContextValue(request.Context())
+		require.NotNil(t, values)
+		assert.Equal(t, taggedRoundTripper("caller"), values.roundTripper)
+		assert.Equal(t, headersConfig, values.headersConfig)
+	})
+
+	t.Run("should attach the round tripper on a request that does not reach the engine", func(t *testing.T) {
+		request, err := http.NewRequest(http.MethodOptions, "http://example.com", nil)
+		require.NoError(t, err)
+
+		reverseProxyPreHandler := newTestReverseProxyPreHandlerV2(t)
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphqlv2.Request {
+			return nil
+		}
+
+		result, err := reverseProxyPreHandler.PreHandle(ReverseProxyParams{
+			OutRequest:      request,
+			IsCORSPreflight: true,
+			RoundTripper:    taggedRoundTripper("caller"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, ReverseProxyTypePreFlight, result)
+
+		values := getGraphQLEngineTransportContextValue(request.Context())
+		require.NotNil(t, values)
+		assert.Equal(t, taggedRoundTripper("caller"), values.roundTripper)
+	})
+
+	t.Run("should not modify the transport of the shared http client", func(t *testing.T) {
+		request, err := http.NewRequest(http.MethodPost, "http://example.com", nil)
+		require.NoError(t, err)
+
+		reverseProxyPreHandler := newTestReverseProxyPreHandlerV2(t)
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphqlv2.Request {
+			return &graphqlv2.Request{Query: `{ hello }`}
+		}
+		configureGraphQLEngineHTTPClient(
+			reverseProxyPreHandler.httpClient,
+			DetermineGraphQLEngineTransportType(reverseProxyPreHandler.apiDefinition),
+			testReusableReadCloser,
+		)
+		configuredTransport := reverseProxyPreHandler.httpClient.Transport
+
+		_, err = reverseProxyPreHandler.PreHandle(ReverseProxyParams{
+			OutRequest:   request,
+			NeedsEngine:  true,
+			RoundTripper: taggedRoundTripper("caller"),
+		})
+		require.NoError(t, err)
+
+		assert.Same(t, configuredTransport, reverseProxyPreHandler.httpClient.Transport)
+	})
+
+	t.Run("should keep the round tripper of every request when called more than once", func(t *testing.T) {
+		reverseProxyPreHandler := newTestReverseProxyPreHandlerV2(t)
+		reverseProxyPreHandler.ctxRetrieveGraphQLRequest = func(r *http.Request) *graphqlv2.Request {
+			return &graphqlv2.Request{Query: `{ hello }`}
+		}
+
+		requests := make([]*http.Request, 0, 2)
+		for _, tag := range []string{"caller-a", "caller-b"} {
+			request, err := http.NewRequest(http.MethodPost, "http://example.com", nil)
+			require.NoError(t, err)
+			_, err = reverseProxyPreHandler.PreHandle(ReverseProxyParams{
+				OutRequest:   request,
+				NeedsEngine:  true,
+				RoundTripper: taggedRoundTripper(tag),
+			})
+			require.NoError(t, err)
+			requests = append(requests, request)
+		}
+
+		for i, tag := range []string{"caller-a", "caller-b"} {
+			values := getGraphQLEngineTransportContextValue(requests[i].Context())
+			require.NotNil(t, values)
+			assert.Equal(t, taggedRoundTripper(tag), values.roundTripper)
+		}
+	})
 }
 
 func newTestReverseProxyPreHandlerV2(t *testing.T) *reverseProxyPreHandlerV2 {

--- a/internal/graphengine/header_modifier_test.go
+++ b/internal/graphengine/header_modifier_test.go
@@ -1,0 +1,146 @@
+package graphengine
+
+// The upstream header modifier of both graphql-go-tools versions. It is the one place where
+// a dynamic header value gets resolved, and it has to happen there rather than on the way to
+// the wire: the library applies the modifier before it computes the key that decides whether
+// two callers share an upstream subscription connection. See connectionKey in the v1
+// subscription client and UniqueRequestID in the v2 resolver.
+//
+// The two modifiers are the same function twice over, so the cases run against either.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// headerModifierConstructor builds the modifier under test.
+type headerModifierConstructor func(outreq *http.Request, additionalHeaders http.Header, variableReplacer TykVariableReplacer) func(http.Header)
+
+func TestGraphqlGoToolsV1_HeaderModifier(t *testing.T) {
+	runHeaderModifierCases(t, func(outreq *http.Request, additionalHeaders http.Header, variableReplacer TykVariableReplacer) func(http.Header) {
+		return graphqlGoToolsV1{}.headerModifier(outreq, additionalHeaders, variableReplacer)
+	})
+}
+
+func TestGraphqlGoToolsV2_HeaderModifier(t *testing.T) {
+	runHeaderModifierCases(t, func(outreq *http.Request, additionalHeaders http.Header, variableReplacer TykVariableReplacer) func(http.Header) {
+		return graphqlGoToolsV2{}.headerModifier(outreq, additionalHeaders, variableReplacer)
+	})
+}
+
+// newHeaderModifierRequest builds a caller request that carries caller in X-Caller, which is
+// what testHeaderVariableReplacer resolves $tyk_context.caller from.
+func newHeaderModifierRequest(caller string) *http.Request {
+	request := httptest.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+	request.Header.Set("X-Caller", caller)
+	return request
+}
+
+// testHeaderVariableReplacer stands in for Gateway.ReplaceTykVariables. It resolves against
+// the request it is handed, so a value that leaks in from another caller is visible.
+func testHeaderVariableReplacer(request *http.Request, value string, _ bool) string {
+	return strings.ReplaceAll(value, "$tyk_context.caller", request.Header.Get("X-Caller"))
+}
+
+func runHeaderModifierCases(t *testing.T, newModifier headerModifierConstructor) {
+	t.Helper()
+
+	t.Run("resolves the variable in every value of a multi value header", func(t *testing.T) {
+		header := http.Header{
+			"X-Api-Key": {"$tyk_context.caller", "prefix-$tyk_context.caller"},
+		}
+		additional := http.Header{"X-Static": {"one", "two"}}
+
+		newModifier(newHeaderModifierRequest("caller-a"), additional, testHeaderVariableReplacer)(header)
+
+		assert.Equal(t, []string{"caller-a", "prefix-caller-a"}, header.Values("X-Api-Key"))
+		assert.Equal(t, []string{"one", "two"}, header.Values("X-Static"))
+	})
+
+	t.Run("resolves an additional header too", func(t *testing.T) {
+		// The dynamic UDG global header, which is how an API definition asks for the
+		// caller's credential to be forwarded upstream.
+		header := http.Header{}
+		additional := http.Header{"X-Upstream-Authorization": {"Bearer $tyk_context.caller"}}
+
+		newModifier(newHeaderModifierRequest("caller-a"), additional, testHeaderVariableReplacer)(header)
+
+		assert.Equal(t, []string{"Bearer caller-a"}, header.Values("X-Upstream-Authorization"))
+	})
+
+	t.Run("an existing header value wins over an additional header", func(t *testing.T) {
+		header := http.Header{"X-Api-Key": {"from-the-data-source"}}
+		additional := http.Header{"X-Api-Key": {"from-tyk"}}
+
+		newModifier(newHeaderModifierRequest("caller-a"), additional, testHeaderVariableReplacer)(header)
+
+		assert.Equal(t, []string{"from-the-data-source"}, header.Values("X-Api-Key"))
+	})
+
+	t.Run("a multi value additional header is copied whole", func(t *testing.T) {
+		// Not reachable from an API definition, where both the UDG global headers and the
+		// data source headers are single valued, but the connection key of a subscription
+		// is built from every value, so dropping one would silently merge two callers.
+		header := http.Header{}
+		additional := http.Header{"X-Api-Key": {"first", "second", "third"}}
+
+		newModifier(newHeaderModifierRequest("caller-a"), additional, testHeaderVariableReplacer)(header)
+
+		assert.Equal(t, []string{"first", "second", "third"}, header.Values("X-Api-Key"))
+	})
+
+	t.Run("a nil replacer merges the additional headers and resolves nothing", func(t *testing.T) {
+		header := http.Header{"X-Api-Key": {"$tyk_context.caller"}}
+		additional := http.Header{"X-Static": {"one"}}
+
+		newModifier(newHeaderModifierRequest("caller-a"), additional, nil)(header)
+
+		assert.Equal(t, []string{"$tyk_context.caller"}, header.Values("X-Api-Key"))
+		assert.Equal(t, []string{"one"}, header.Values("X-Static"))
+	})
+
+	t.Run("a non canonical additional header key lands under the canonical one", func(t *testing.T) {
+		// The modifier assigns into the map to keep multiple values, and a map write does
+		// no canonicalisation, so it has to do it itself. Otherwise the key it writes is
+		// one that Get, Values and the upstream request cannot read back.
+		header := http.Header{}
+		additional := http.Header{"x-api-key": {"from-tyk"}}
+
+		newModifier(newHeaderModifierRequest("caller-a"), additional, testHeaderVariableReplacer)(header)
+
+		assert.Equal(t, []string{"from-tyk"}, header.Values("X-Api-Key"))
+		assert.NotContains(t, header, "x-api-key")
+	})
+
+	t.Run("resolves against the request of this caller", func(t *testing.T) {
+		request := newHeaderModifierRequest("caller-a")
+		var seen []*http.Request
+		recording := func(outreq *http.Request, value string, escape bool) string {
+			seen = append(seen, outreq)
+			return testHeaderVariableReplacer(outreq, value, escape)
+		}
+
+		newModifier(request, http.Header{}, recording)(http.Header{"X-Api-Key": {"$tyk_context.caller"}})
+
+		require.Len(t, seen, 1)
+		assert.Same(t, request, seen[0], "the modifier has to resolve against the request it was built for")
+	})
+
+	t.Run("two modifiers resolve to their own caller", func(t *testing.T) {
+		// The modifier is built per request, so the value of one caller must not reach the
+		// other. This is the unit level shape of the credential isolation tests.
+		for _, caller := range []string{"caller-a", "caller-b"} {
+			header := http.Header{}
+			additional := http.Header{"X-Upstream-Authorization": {"Bearer $tyk_context.caller"}}
+
+			newModifier(newHeaderModifierRequest(caller), additional, testHeaderVariableReplacer)(header)
+
+			assert.Equal(t, "Bearer "+caller, header.Get("X-Upstream-Authorization"))
+		}
+	})
+}

--- a/internal/graphengine/transport.go
+++ b/internal/graphengine/transport.go
@@ -22,6 +22,9 @@ func NewGraphQLEngineTransport(
 	newReusableBodyReadCloser NewReusableBodyReadCloserFunc,
 	headersConfig ReverseProxyHeadersConfig,
 ) *GraphQLEngineTransport {
+	if originalTransport == nil {
+		originalTransport = http.DefaultTransport
+	}
 	transport := &GraphQLEngineTransport{
 		originalTransport:         originalTransport,
 		transportType:             transportType,
@@ -31,16 +34,39 @@ func NewGraphQLEngineTransport(
 	return transport
 }
 
+func configureGraphQLEngineHTTPClient(client *http.Client, transportType GraphQLEngineTransportType, newReusableBodyReadCloser NewReusableBodyReadCloserFunc) {
+	if client == nil {
+		return
+	}
+	if _, ok := client.Transport.(*GraphQLEngineTransport); ok {
+		return
+	}
+	client.Transport = NewGraphQLEngineTransport(transportType, client.Transport, newReusableBodyReadCloser, ReverseProxyHeadersConfig{})
+}
+
 func (g *GraphQLEngineTransport) RoundTrip(request *http.Request) (res *http.Response, err error) {
-	switch g.transportType {
-	case GraphQLEngineTransportTypeProxyOnly:
-		val := GetProxyOnlyContextValue(request.Context())
-		if val != nil {
-			return g.handleProxyOnly(val, request)
+	requestTransport := g
+	if values := getGraphQLEngineTransportContextValue(request.Context()); values != nil {
+		requestTransport = &GraphQLEngineTransport{
+			originalTransport:         values.roundTripper,
+			transportType:             g.transportType,
+			newReusableBodyReadCloser: g.newReusableBodyReadCloser,
+			headersConfig:             values.headersConfig,
+		}
+		if requestTransport.originalTransport == nil {
+			requestTransport.originalTransport = g.originalTransport
 		}
 	}
 
-	return g.originalTransport.RoundTrip(request)
+	switch requestTransport.transportType {
+	case GraphQLEngineTransportTypeProxyOnly:
+		val := GetProxyOnlyContextValue(request.Context())
+		if val != nil {
+			return requestTransport.handleProxyOnly(val, request)
+		}
+	}
+
+	return requestTransport.originalTransport.RoundTrip(request)
 }
 
 func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyValues *GraphQLProxyOnlyContextValues, request *http.Request) (*http.Response, error) {

--- a/internal/graphengine/transport.go
+++ b/internal/graphengine/transport.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 
@@ -255,12 +256,27 @@ func (g *GraphQLEngineTransport) setProxyOnlyHeaders(proxyOnlyValues *GraphQLPro
 			continue
 		}
 
+		// Prioritize consumer's header value when immutable headers are turned on.
+		// Delete the header from request_headers add the consumer's value. See TT-11990 and TT-12190.
+		//
+		// Deleted once, before any of the consumer's values are added. Inside the loop
+		// below it deleted the value added on the previous pass, so a consumer header
+		// with more than one value came out holding only its last one.
+		if g.headersConfig.ProxyOnly.UseImmutableHeaders && r.Header.Get(forwardedHeaderKey) != "" {
+			r.Header.Del(forwardedHeaderKey)
+		}
+
+		// What the engine put on the request, before the consumer's values are added. The
+		// engine and this loop are two writers that do not know about each other: with
+		// strip_auth_data off, additionalUpstreamHeaders has already added the consumer's
+		// auth header to the fetch input, and adding it again here sends the credential
+		// upstream twice. Compared against a snapshot rather than the header as it grows,
+		// so a consumer that really did send the same value twice keeps both.
+		engineValues := slices.Clone(r.Header.Values(forwardedHeaderKey))
+
 		for _, forwardedHeaderValue := range forwardedHeaderValues {
-			exitingHeaderValue := r.Header.Get(forwardedHeaderKey)
-			// Prioritize consumer's header value when immutable headers are turned on.
-			// Delete the header from request_headers add the consumer's value. See TT-11990 and TT-12190.
-			if g.headersConfig.ProxyOnly.UseImmutableHeaders && exitingHeaderValue != "" {
-				r.Header.Del(forwardedHeaderKey)
+			if slices.Contains(engineValues, forwardedHeaderValue) {
+				continue
 			}
 			r.Header.Add(forwardedHeaderKey, forwardedHeaderValue)
 		}

--- a/internal/graphengine/transport.go
+++ b/internal/graphengine/transport.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 
 	"golang.org/x/net/http/httpguts"
 
@@ -19,6 +20,22 @@ type GraphQLEngineTransport struct {
 	transportType             GraphQLEngineTransportType
 	newReusableBodyReadCloser NewReusableBodyReadCloserFunc
 	headersConfig             ReverseProxyHeadersConfig
+
+	// fallbackRoundTripper serves the engines whose upstream requests cannot carry the
+	// per request round tripper, which today means EngineV1 alone: its legacy data
+	// sources build the upstream request with http.NewRequest and drop the execution
+	// context, so getGraphQLEngineTransportContextValue below finds nothing. Without it
+	// those fetches fall through to the plain transport of the API client, which cannot
+	// reach the gateway and so cannot serve a tyk:// internal data source.
+	//
+	// Shared across callers, unlike everything else here, so it is only sound while the
+	// round tripper the gateway hands over carries no caller state. It does not: it is
+	// the *TykRoundTripper cached on the API spec, whose only per request input is the
+	// request itself. The wrapper that used to make it caller specific was removed along
+	// with the double variable resolution, see handleGraphQL in gateway/reverse_proxy.go.
+	// Do not restore a caller specific round tripper there without removing this.
+	mu                   sync.RWMutex
+	fallbackRoundTripper http.RoundTripper
 }
 
 func NewGraphQLEngineTransport(
@@ -49,6 +66,25 @@ func configureGraphQLEngineHTTPClient(client *http.Client, transportType GraphQL
 	client.Transport = NewGraphQLEngineTransport(transportType, client.Transport, newReusableBodyReadCloser, ReverseProxyHeadersConfig{})
 }
 
+// setFallbackRoundTripper records the round tripper to use for requests that arrive without
+// one of their own. Refreshed per request rather than stored once, because the gateway
+// rebuilds the transport of an API when max_conn_time expires and the old one stops opening
+// connections.
+func (g *GraphQLEngineTransport) setFallbackRoundTripper(roundTripper http.RoundTripper) {
+	if roundTripper == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.fallbackRoundTripper = roundTripper
+}
+
+func (g *GraphQLEngineTransport) fallback() http.RoundTripper {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.fallbackRoundTripper
+}
+
 func (g *GraphQLEngineTransport) RoundTrip(request *http.Request) (res *http.Response, err error) {
 	requestTransport := g
 	if values := getGraphQLEngineTransportContextValue(request.Context()); values != nil {
@@ -71,6 +107,12 @@ func (g *GraphQLEngineTransport) RoundTrip(request *http.Request) (res *http.Res
 		}
 	}
 
+	// requestTransport == g means the request carried no round tripper of its own.
+	if requestTransport == g {
+		if fallback := g.fallback(); fallback != nil {
+			return fallback.RoundTrip(request)
+		}
+	}
 	return requestTransport.originalTransport.RoundTrip(request)
 }
 

--- a/internal/graphengine/transport.go
+++ b/internal/graphengine/transport.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
+
+	"golang.org/x/net/http/httpguts"
+
+	"github.com/TykTechnologies/tyk/header"
 )
 
 type NewReusableBodyReadCloserFunc func(io.ReadCloser) (io.ReadCloser, error)
@@ -69,8 +74,21 @@ func (g *GraphQLEngineTransport) RoundTrip(request *http.Request) (res *http.Res
 	return requestTransport.originalTransport.RoundTrip(request)
 }
 
+// isWebSocketHandshake reports whether the request is a websocket upgrade handshake.
+// Mirrors upgradeType in gateway/reverse_proxy.go.
+func isWebSocketHandshake(request *http.Request) bool {
+	if !httpguts.HeaderValuesContainsToken(request.Header[header.Connection], "Upgrade") {
+		return false
+	}
+	return strings.EqualFold(request.Header.Get(header.Upgrade), "websocket")
+}
+
 func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyValues *GraphQLProxyOnlyContextValues, request *http.Request) (*http.Response, error) {
-	request.Method = proxyOnlyValues.forwardedRequest.Method
+	// A websocket handshake has to stay a GET. Taking the method of the caller's request
+	// turns the upstream handshake into a POST, which every websocket server rejects.
+	if !isWebSocketHandshake(request) {
+		request.Method = proxyOnlyValues.forwardedRequest.Method
+	}
 	g.setProxyOnlyHeaders(proxyOnlyValues, request)
 	g.applyRequestHeadersRewriteRules(request)
 
@@ -99,7 +117,7 @@ func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyValues *GraphQLProxyOn
 		}
 		response.Body = reusableBody
 	}
-	proxyOnlyValues.upstreamResponse = response
+	proxyOnlyValues.setUpstreamResponse(response)
 	return response, err
 }
 

--- a/internal/graphengine/transport_test.go
+++ b/internal/graphengine/transport_test.go
@@ -9,9 +9,227 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
 )
 
 func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
+	t.Run("uses the transport attached to each request context", func(t *testing.T) {
+		fallback := taggedRoundTripper("fallback")
+		transport := NewGraphQLEngineTransport(
+			GraphQLEngineTransportTypeMultiUpstream,
+			fallback,
+			testReusableReadCloser,
+			ReverseProxyHeadersConfig{},
+		)
+
+		type result struct {
+			want string
+			got  string
+			err  error
+		}
+		results := make(chan result, 100)
+		for i := 0; i < cap(results); i++ {
+			tag := []string{"caller-a", "caller-b"}[i%2]
+			go func() {
+				request, err := http.NewRequest(http.MethodPost, "http://example.com/graphql", nil)
+				if err != nil {
+					results <- result{want: tag, err: err}
+					return
+				}
+				ctx := SetGraphQLEngineTransportContextValue(request.Context(), taggedRoundTripper(tag), ReverseProxyHeadersConfig{})
+				response, err := transport.RoundTrip(request.WithContext(ctx))
+				if err != nil {
+					results <- result{want: tag, err: err}
+					return
+				}
+				results <- result{want: tag, got: response.Header.Get("X-Transport")}
+			}()
+		}
+		for i := 0; i < cap(results); i++ {
+			result := <-results
+			require.NoError(t, result.err)
+			assert.Equal(t, result.want, result.got)
+		}
+	})
+
+	t.Run("falls back to the transport of the client when the request context carries none", func(t *testing.T) {
+		transport := NewGraphQLEngineTransport(
+			GraphQLEngineTransportTypeMultiUpstream,
+			taggedRoundTripper("fallback"),
+			testReusableReadCloser,
+			ReverseProxyHeadersConfig{},
+		)
+
+		request, err := http.NewRequest(http.MethodPost, "http://example.com/graphql", nil)
+		require.NoError(t, err)
+
+		response, err := transport.RoundTrip(request)
+		require.NoError(t, err)
+		assert.Equal(t, "fallback", response.Header.Get("X-Transport"))
+	})
+
+	t.Run("falls back to the transport of the client when the request context carries a nil round tripper", func(t *testing.T) {
+		transport := NewGraphQLEngineTransport(
+			GraphQLEngineTransportTypeMultiUpstream,
+			taggedRoundTripper("fallback"),
+			testReusableReadCloser,
+			ReverseProxyHeadersConfig{},
+		)
+
+		request, err := http.NewRequest(http.MethodPost, "http://example.com/graphql", nil)
+		require.NoError(t, err)
+		ctx := SetGraphQLEngineTransportContextValue(request.Context(), nil, ReverseProxyHeadersConfig{})
+
+		response, err := transport.RoundTrip(request.WithContext(ctx))
+		require.NoError(t, err)
+		assert.Equal(t, "fallback", response.Header.Get("X-Transport"))
+	})
+
+	t.Run("uses http.DefaultTransport when the client has no transport at all", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusTeapot)
+		}))
+		t.Cleanup(upstream.Close)
+
+		transport := NewGraphQLEngineTransport(
+			GraphQLEngineTransportTypeMultiUpstream,
+			nil,
+			testReusableReadCloser,
+			ReverseProxyHeadersConfig{},
+		)
+		require.Equal(t, http.DefaultTransport, transport.originalTransport)
+
+		request, err := http.NewRequest(http.MethodPost, upstream.URL, nil)
+		require.NoError(t, err)
+
+		response, err := transport.RoundTrip(request)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = response.Body.Close()
+		})
+		assert.Equal(t, http.StatusTeapot, response.StatusCode)
+	})
+
+	t.Run("prefers the headers config of the request over the one of the client", func(t *testing.T) {
+		// The client is configured with the opposite of what every request asks for,
+		// so a leaking client-level config would be visible in the forwarded headers.
+		t.Run("should overwrite request headers when the request turns use_immutable_headers off", func(t *testing.T) {
+			transport := NewGraphQLEngineTransport(
+				GraphQLEngineTransportTypeProxyOnly,
+				nopRoundTripper{},
+				testReusableReadCloser,
+				ReverseProxyHeadersConfig{
+					ProxyOnly: ProxyOnlyHeadersConfig{UseImmutableHeaders: true},
+				},
+			)
+
+			_, ctx, err := prepareInboundRequest(http.MethodPost, "http://example.com/graphql", nil, map[string]string{
+				"Authorization": "Bearer 123",
+			})
+			require.NoError(t, err)
+			ctx = SetGraphQLEngineTransportContextValue(ctx, nopRoundTripper{}, ReverseProxyHeadersConfig{
+				ProxyOnly: ProxyOnlyHeadersConfig{UseImmutableHeaders: false},
+			})
+
+			outboundRequest, err := prepareOutboundRequest(ctx, http.MethodPost, "http://example.com/graphql", nil, map[string]string{
+				"Authorization": "none",
+			})
+			require.NoError(t, err)
+
+			_, err = transport.RoundTrip(outboundRequest)
+			assert.NoError(t, err)
+			assert.Equal(t, "none", outboundRequest.Header.Get("Authorization"))
+		})
+
+		t.Run("should not overwrite request headers when the request turns use_immutable_headers on", func(t *testing.T) {
+			transport := NewGraphQLEngineTransport(
+				GraphQLEngineTransportTypeProxyOnly,
+				nopRoundTripper{},
+				testReusableReadCloser,
+				ReverseProxyHeadersConfig{
+					ProxyOnly: ProxyOnlyHeadersConfig{UseImmutableHeaders: false},
+				},
+			)
+
+			_, ctx, err := prepareInboundRequest(http.MethodPost, "http://example.com/graphql", nil, map[string]string{
+				"Authorization": "Bearer 123",
+			})
+			require.NoError(t, err)
+			ctx = SetGraphQLEngineTransportContextValue(ctx, nopRoundTripper{}, ReverseProxyHeadersConfig{
+				ProxyOnly: ProxyOnlyHeadersConfig{UseImmutableHeaders: true},
+			})
+
+			outboundRequest, err := prepareOutboundRequest(ctx, http.MethodPost, "http://example.com/graphql", nil, map[string]string{
+				"Authorization": "none",
+			})
+			require.NoError(t, err)
+
+			_, err = transport.RoundTrip(outboundRequest)
+			assert.NoError(t, err)
+			assert.Equal(t, "Bearer 123", outboundRequest.Header.Get("Authorization"))
+		})
+
+		t.Run("should apply the request headers rewrite rules of the request", func(t *testing.T) {
+			transport := NewGraphQLEngineTransport(
+				GraphQLEngineTransportTypeProxyOnly,
+				nopRoundTripper{},
+				testReusableReadCloser,
+				ReverseProxyHeadersConfig{},
+			)
+
+			_, ctx, err := prepareInboundRequest(http.MethodPost, "http://example.com/graphql", nil, nil)
+			require.NoError(t, err)
+			ctx = SetGraphQLEngineTransportContextValue(ctx, nopRoundTripper{}, ReverseProxyHeadersConfig{
+				ProxyOnly: ProxyOnlyHeadersConfig{
+					RequestHeadersRewrite: map[string]apidef.RequestHeadersRewriteConfig{
+						"X-Overwritten": {Value: "rewritten"},
+						"X-Removed":     {Remove: true},
+						"X-Added":       {Value: "added"},
+					},
+				},
+			})
+
+			outboundRequest, err := prepareOutboundRequest(ctx, http.MethodPost, "http://example.com/graphql", nil, map[string]string{
+				"X-Overwritten": "from-client",
+				"X-Removed":     "from-client",
+			})
+			require.NoError(t, err)
+
+			_, err = transport.RoundTrip(outboundRequest)
+			assert.NoError(t, err)
+			assert.Equal(t, "rewritten", outboundRequest.Header.Get("X-Overwritten"))
+			assert.Empty(t, outboundRequest.Header.Values("X-Removed"))
+			assert.Equal(t, "added", outboundRequest.Header.Get("X-Added"))
+		})
+
+		t.Run("should not apply the request headers rewrite rules of the client", func(t *testing.T) {
+			transport := NewGraphQLEngineTransport(
+				GraphQLEngineTransportTypeProxyOnly,
+				nopRoundTripper{},
+				testReusableReadCloser,
+				ReverseProxyHeadersConfig{
+					ProxyOnly: ProxyOnlyHeadersConfig{
+						RequestHeadersRewrite: map[string]apidef.RequestHeadersRewriteConfig{
+							"X-Leaked": {Value: "leaked"},
+						},
+					},
+				},
+			)
+
+			_, ctx, err := prepareInboundRequest(http.MethodPost, "http://example.com/graphql", nil, nil)
+			require.NoError(t, err)
+			ctx = SetGraphQLEngineTransportContextValue(ctx, nopRoundTripper{}, ReverseProxyHeadersConfig{})
+
+			outboundRequest, err := prepareOutboundRequest(ctx, http.MethodPost, "http://example.com/graphql", nil, nil)
+			require.NoError(t, err)
+
+			_, err = transport.RoundTrip(outboundRequest)
+			assert.NoError(t, err)
+			assert.Empty(t, outboundRequest.Header.Values("X-Leaked"))
+		})
+	})
+
 	t.Run("feature use_immutable_headers", func(t *testing.T) {
 		t.Run("should overwrite request headers when use_immutable_headers is false", func(t *testing.T) {
 			transport := NewGraphQLEngineTransport(
@@ -73,6 +291,64 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 	})
 }
 
+func TestConfigureGraphQLEngineHTTPClient(t *testing.T) {
+	t.Run("should not panic when the client is nil", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			configureGraphQLEngineHTTPClient(nil, GraphQLEngineTransportTypeMultiUpstream, testReusableReadCloser)
+		})
+	})
+
+	t.Run("should keep the transport of the client as the fallback", func(t *testing.T) {
+		client := &http.Client{Transport: taggedRoundTripper("client")}
+
+		configureGraphQLEngineHTTPClient(client, GraphQLEngineTransportTypeMultiUpstream, testReusableReadCloser)
+
+		transport, ok := client.Transport.(*GraphQLEngineTransport)
+		require.True(t, ok, "the client transport should be wrapped")
+		assert.Equal(t, taggedRoundTripper("client"), transport.originalTransport)
+		assert.Equal(t, GraphQLEngineTransportTypeMultiUpstream, transport.transportType)
+		assert.NotNil(t, transport.newReusableBodyReadCloser)
+		assert.Equal(t, ReverseProxyHeadersConfig{}, transport.headersConfig)
+	})
+
+	t.Run("should fall back to http.DefaultTransport when the client has no transport", func(t *testing.T) {
+		client := &http.Client{}
+
+		configureGraphQLEngineHTTPClient(client, GraphQLEngineTransportTypeProxyOnly, testReusableReadCloser)
+
+		transport, ok := client.Transport.(*GraphQLEngineTransport)
+		require.True(t, ok, "the client transport should be wrapped")
+		assert.Equal(t, http.DefaultTransport, transport.originalTransport)
+		assert.Equal(t, GraphQLEngineTransportTypeProxyOnly, transport.transportType)
+	})
+
+	t.Run("should not wrap an already configured client twice", func(t *testing.T) {
+		client := &http.Client{Transport: taggedRoundTripper("client")}
+
+		configureGraphQLEngineHTTPClient(client, GraphQLEngineTransportTypeMultiUpstream, testReusableReadCloser)
+		configured := client.Transport
+		configureGraphQLEngineHTTPClient(client, GraphQLEngineTransportTypeProxyOnly, testReusableReadCloser)
+
+		assert.Same(t, configured, client.Transport)
+	})
+
+	t.Run("should route a request through the round tripper of its own context", func(t *testing.T) {
+		client := &http.Client{Transport: taggedRoundTripper("client")}
+		configureGraphQLEngineHTTPClient(client, GraphQLEngineTransportTypeMultiUpstream, testReusableReadCloser)
+
+		request, err := http.NewRequest(http.MethodPost, "http://example.com/graphql", nil)
+		require.NoError(t, err)
+		ctx := SetGraphQLEngineTransportContextValue(request.Context(), taggedRoundTripper("caller"), ReverseProxyHeadersConfig{})
+
+		response, err := client.Do(request.WithContext(ctx))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = response.Body.Close()
+		})
+		assert.Equal(t, "caller", response.Header.Get("X-Transport"))
+	})
+}
+
 func prepareInboundRequest(method string, url string, body io.Reader, headers map[string]string) (*http.Request, context.Context, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
@@ -107,6 +383,15 @@ func (m nopRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp := httptest.NewRecorder()
 	resp.WriteHeader(http.StatusOK)
 	return resp.Result(), nil
+}
+
+type taggedRoundTripper string
+
+func (t taggedRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	response := httptest.NewRecorder()
+	response.Header().Set("X-Transport", string(t))
+	response.WriteHeader(http.StatusOK)
+	return response.Result(), nil
 }
 
 func testReusableReadCloser(readCloser io.ReadCloser) (io.ReadCloser, error) {

--- a/internal/graphengine/transport_test.go
+++ b/internal/graphengine/transport_test.go
@@ -2,9 +2,11 @@ package graphengine
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -473,5 +475,85 @@ func TestIsWebSocketHandshake(t *testing.T) {
 			"Connection": "Upgrade",
 			"Upgrade":    "h2c",
 		})))
+	})
+}
+
+// The fallback round tripper serves the engines whose upstream requests cannot carry one of
+// their own, which today is EngineV1 alone. It is the only state of the engine transport
+// shared between callers, so it needs both the fallback behaviour and the locking.
+func TestGraphQLEngineTransport_FallbackRoundTripper(t *testing.T) {
+	newTransport := func() *GraphQLEngineTransport {
+		return NewGraphQLEngineTransport(
+			GraphQLEngineTransportTypeMultiUpstream,
+			taggedRoundTripper("original"),
+			testReusableReadCloser,
+			ReverseProxyHeadersConfig{},
+		)
+	}
+
+	request := func(t *testing.T) *http.Request {
+		t.Helper()
+		outreq, err := http.NewRequest(http.MethodPost, "http://upstream.example/graphql", nil)
+		require.NoError(t, err)
+		return outreq
+	}
+
+	t.Run("falls back to the original transport when none was set", func(t *testing.T) {
+		response, err := newTransport().RoundTrip(request(t))
+		require.NoError(t, err)
+		assert.Equal(t, "original", response.Header.Get("X-Transport"))
+	})
+
+	t.Run("uses the fallback for a request that carries no round tripper", func(t *testing.T) {
+		transport := newTransport()
+		transport.setFallbackRoundTripper(taggedRoundTripper("gateway"))
+
+		response, err := transport.RoundTrip(request(t))
+		require.NoError(t, err)
+		assert.Equal(t, "gateway", response.Header.Get("X-Transport"))
+	})
+
+	t.Run("the round tripper of the request still wins over the fallback", func(t *testing.T) {
+		// EngineV2 and EngineV3 stay fully request scoped: their fetches carry the round
+		// tripper of the caller and must never reach the shared fallback.
+		transport := newTransport()
+		transport.setFallbackRoundTripper(taggedRoundTripper("gateway"))
+
+		outreq := request(t)
+		outreq = outreq.WithContext(SetGraphQLEngineTransportContextValue(
+			outreq.Context(), taggedRoundTripper("caller"), ReverseProxyHeadersConfig{}))
+
+		response, err := transport.RoundTrip(outreq)
+		require.NoError(t, err)
+		assert.Equal(t, "caller", response.Header.Get("X-Transport"))
+	})
+
+	t.Run("a nil round tripper does not clear the fallback", func(t *testing.T) {
+		transport := newTransport()
+		transport.setFallbackRoundTripper(taggedRoundTripper("gateway"))
+		transport.setFallbackRoundTripper(nil)
+
+		response, err := transport.RoundTrip(request(t))
+		require.NoError(t, err)
+		assert.Equal(t, "gateway", response.Header.Get("X-Transport"))
+	})
+
+	t.Run("refreshing the fallback while it is in use does not race", func(t *testing.T) {
+		transport := newTransport()
+		var waitGroup sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			waitGroup.Add(2)
+			go func(i int) {
+				defer waitGroup.Done()
+				transport.setFallbackRoundTripper(taggedRoundTripper(fmt.Sprintf("gateway-%02d", i)))
+			}(i)
+			go func() {
+				defer waitGroup.Done()
+				response, err := transport.RoundTrip(request(t))
+				require.NoError(t, err)
+				assert.NotEmpty(t, response.Header.Get("X-Transport"))
+			}()
+		}
+		waitGroup.Wait()
 	})
 }

--- a/internal/graphengine/transport_test.go
+++ b/internal/graphengine/transport_test.go
@@ -141,7 +141,7 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 
 			_, err = transport.RoundTrip(outboundRequest)
 			assert.NoError(t, err)
-			assert.Equal(t, "none", outboundRequest.Header.Get("Authorization"))
+			assert.Equal(t, []string{"none", "Bearer 123"}, outboundRequest.Header.Values("Authorization"))
 		})
 
 		t.Run("should not overwrite request headers when the request turns use_immutable_headers on", func(t *testing.T) {
@@ -169,7 +169,7 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 
 			_, err = transport.RoundTrip(outboundRequest)
 			assert.NoError(t, err)
-			assert.Equal(t, "Bearer 123", outboundRequest.Header.Get("Authorization"))
+			assert.Equal(t, []string{"Bearer 123"}, outboundRequest.Header.Values("Authorization"))
 		})
 
 		t.Run("should apply the request headers rewrite rules of the request", func(t *testing.T) {
@@ -258,8 +258,10 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 
 			_, err = transport.RoundTrip(outboundRequest)
 			assert.NoError(t, err)
-			assert.Equal(t, "none", outboundRequest.Header.Get("Authorization"))
-			assert.Equal(t, "added-custom-value", outboundRequest.Header.Get("X-Custom"))
+			// Both values reach the upstream, the engine's first. Asserted as a list
+			// because Get would hide a duplicate.
+			assert.Equal(t, []string{"none", "Bearer 123"}, outboundRequest.Header.Values("Authorization"))
+			assert.Equal(t, []string{"added-custom-value"}, outboundRequest.Header.Values("X-Custom"))
 		})
 
 		t.Run("should not overwrite request headers when use_immutable_headers is true", func(t *testing.T) {
@@ -287,8 +289,8 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 
 			_, err = transport.RoundTrip(outboundRequest)
 			assert.NoError(t, err)
-			assert.Equal(t, "Bearer 123", outboundRequest.Header.Get("Authorization"))
-			assert.Equal(t, "added-custom-value", outboundRequest.Header.Get("X-Custom"))
+			assert.Equal(t, []string{"Bearer 123"}, outboundRequest.Header.Values("Authorization"))
+			assert.Equal(t, []string{"added-custom-value"}, outboundRequest.Header.Values("X-Custom"))
 		})
 	})
 }
@@ -555,5 +557,108 @@ func TestGraphQLEngineTransport_FallbackRoundTripper(t *testing.T) {
 			}()
 		}
 		waitGroup.Wait()
+	})
+}
+
+// setProxyOnlyHeaders forwards the consumer's headers onto the upstream request that the
+// engine already built. Two writers meet here: with strip_auth_data off the engine has
+// already put the consumer's auth header on the request through additionalUpstreamHeaders,
+// and forwarding it again sends the credential upstream twice.
+func TestGraphQLEngineTransport_SetProxyOnlyHeaders(t *testing.T) {
+	// forward runs setProxyOnlyHeaders with the consumer's headers over the headers the
+	// engine had already placed on the upstream request, and returns the result.
+	forward := func(t *testing.T, useImmutableHeaders bool, engineHeader, consumerHeader http.Header) http.Header {
+		t.Helper()
+		inbound, err := http.NewRequest(http.MethodPost, "http://gateway.example/graphql", nil)
+		require.NoError(t, err)
+		inbound.Header = consumerHeader
+
+		outbound, err := http.NewRequest(http.MethodPost, "http://upstream.example/graphql", nil)
+		require.NoError(t, err)
+		outbound.Header = engineHeader
+
+		transport := NewGraphQLEngineTransport(
+			GraphQLEngineTransportTypeProxyOnly,
+			nopRoundTripper{},
+			testReusableReadCloser,
+			ReverseProxyHeadersConfig{
+				ProxyOnly: ProxyOnlyHeadersConfig{UseImmutableHeaders: useImmutableHeaders},
+			},
+		)
+		transport.setProxyOnlyHeaders(GetProxyOnlyContextValue(SetProxyOnlyContextValue(inbound.Context(), inbound)), outbound)
+		return outbound.Header
+	}
+
+	t.Run("does not forward a value the engine already set", func(t *testing.T) {
+		// The reported defect: the upstream received x-api-key twice, same value.
+		header := forward(t, false,
+			http.Header{"X-Api-Key": {"key-aaa"}},
+			http.Header{"X-Api-Key": {"key-aaa"}})
+
+		assert.Equal(t, []string{"key-aaa"}, header.Values("X-Api-Key"))
+	})
+
+	t.Run("keeps a differing configured value alongside the consumer's", func(t *testing.T) {
+		// request_headers semantics, TT-11990 and TT-12190: with immutable headers off
+		// both values reach the upstream.
+		header := forward(t, false,
+			http.Header{"X-Custom": {"from-request-headers"}},
+			http.Header{"X-Custom": {"from-consumer"}})
+
+		assert.Equal(t, []string{"from-request-headers", "from-consumer"}, header.Values("X-Custom"))
+	})
+
+	t.Run("the consumer wins when immutable headers are on", func(t *testing.T) {
+		header := forward(t, true,
+			http.Header{"X-Custom": {"from-request-headers"}},
+			http.Header{"X-Custom": {"from-consumer"}})
+
+		assert.Equal(t, []string{"from-consumer"}, header.Values("X-Custom"))
+	})
+
+	t.Run("keeps every value of a multi value consumer header when immutable headers are on", func(t *testing.T) {
+		// The delete used to sit inside the value loop, so it removed the value added on
+		// the previous pass and only the last one survived.
+		header := forward(t, true,
+			http.Header{"X-Custom": {"from-request-headers"}},
+			http.Header{"X-Custom": {"first", "second", "third"}})
+
+		assert.Equal(t, []string{"first", "second", "third"}, header.Values("X-Custom"))
+	})
+
+	t.Run("keeps every value of a multi value consumer header when immutable headers are off", func(t *testing.T) {
+		header := forward(t, false,
+			http.Header{},
+			http.Header{"X-Custom": {"first", "second", "third"}})
+
+		assert.Equal(t, []string{"first", "second", "third"}, header.Values("X-Custom"))
+	})
+
+	t.Run("forwards a duplicate the consumer itself sent", func(t *testing.T) {
+		// Only an overlap with what the engine wrote is dropped. What the consumer sent
+		// twice is none of this function's business.
+		header := forward(t, false,
+			http.Header{},
+			http.Header{"X-Custom": {"same", "same"}})
+
+		assert.Equal(t, []string{"same", "same"}, header.Values("X-Custom"))
+	})
+
+	t.Run("drops only the overlapping value of a partially overlapping header", func(t *testing.T) {
+		header := forward(t, false,
+			http.Header{"X-Custom": {"shared"}},
+			http.Header{"X-Custom": {"shared", "extra"}})
+
+		assert.Equal(t, []string{"shared", "extra"}, header.Values("X-Custom"))
+	})
+
+	t.Run("still skips the ignored headers", func(t *testing.T) {
+		header := forward(t, false,
+			http.Header{"Content-Type": {"application/json"}},
+			http.Header{"Content-Type": {"text/plain"}, "Content-Length": {"12"}, "Date": {"now"}})
+
+		assert.Equal(t, []string{"application/json"}, header.Values("Content-Type"))
+		assert.Empty(t, header.Values("Content-Length"))
+		assert.Empty(t, header.Values("Date"))
 	})
 }

--- a/internal/graphengine/transport_test.go
+++ b/internal/graphengine/transport_test.go
@@ -397,3 +397,81 @@ func (t taggedRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 func testReusableReadCloser(readCloser io.ReadCloser) (io.ReadCloser, error) {
 	return readCloser, nil
 }
+
+func TestGraphQLEngineTransport_ProxyOnlyMethod(t *testing.T) {
+	newProxyOnlyTransport := func() *GraphQLEngineTransport {
+		return NewGraphQLEngineTransport(
+			GraphQLEngineTransportTypeProxyOnly,
+			nopRoundTripper{},
+			testReusableReadCloser,
+			ReverseProxyHeadersConfig{},
+		)
+	}
+
+	t.Run("should take the method of the caller for a normal request", func(t *testing.T) {
+		transport := newProxyOnlyTransport()
+		_, ctx, err := prepareInboundRequest(http.MethodPost, "http://example.com/graphql", nil, nil)
+		require.NoError(t, err)
+		outboundRequest, err := prepareOutboundRequest(ctx, http.MethodGet, "http://example.com/graphql", nil, nil)
+		require.NoError(t, err)
+
+		_, err = transport.RoundTrip(outboundRequest)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.MethodPost, outboundRequest.Method)
+	})
+
+	// The upstream subscription handshake is a GET even when the caller used POST. Taking
+	// the caller's method turns it into a POST, which every websocket server rejects.
+	t.Run("should keep the method of a websocket handshake", func(t *testing.T) {
+		transport := newProxyOnlyTransport()
+		_, ctx, err := prepareInboundRequest(http.MethodPost, "http://example.com/graphql", nil, nil)
+		require.NoError(t, err)
+		outboundRequest, err := prepareOutboundRequest(ctx, http.MethodGet, "http://example.com/graphql", nil, map[string]string{
+			"Connection": "Upgrade",
+			"Upgrade":    "websocket",
+		})
+		require.NoError(t, err)
+
+		_, err = transport.RoundTrip(outboundRequest)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.MethodGet, outboundRequest.Method)
+	})
+}
+
+func TestIsWebSocketHandshake(t *testing.T) {
+	newRequest := func(t *testing.T, headers map[string]string) *http.Request {
+		t.Helper()
+		request, err := http.NewRequest(http.MethodGet, "http://example.com/graphql", nil)
+		require.NoError(t, err)
+		for key, value := range headers {
+			request.Header.Set(key, value)
+		}
+		return request
+	}
+
+	t.Run("should detect a handshake", func(t *testing.T) {
+		assert.True(t, isWebSocketHandshake(newRequest(t, map[string]string{
+			"Connection": "Upgrade",
+			"Upgrade":    "websocket",
+		})))
+	})
+
+	t.Run("should ignore the case of the header values", func(t *testing.T) {
+		assert.True(t, isWebSocketHandshake(newRequest(t, map[string]string{
+			"Connection": "keep-alive, upgrade",
+			"Upgrade":    "WebSocket",
+		})))
+	})
+
+	t.Run("should not detect a handshake without both headers", func(t *testing.T) {
+		assert.False(t, isWebSocketHandshake(newRequest(t, nil)))
+		assert.False(t, isWebSocketHandshake(newRequest(t, map[string]string{"Upgrade": "websocket"})))
+		assert.False(t, isWebSocketHandshake(newRequest(t, map[string]string{"Connection": "Upgrade"})))
+		assert.False(t, isWebSocketHandshake(newRequest(t, map[string]string{
+			"Connection": "Upgrade",
+			"Upgrade":    "h2c",
+		})))
+	})
+}

--- a/internal/graphengine/utils.go
+++ b/internal/graphengine/utils.go
@@ -141,10 +141,14 @@ func additionalUpstreamHeaders(logger abstractlogger.Logger, outreq *http.Reques
 	}
 
 	// When StripAuthData is false, propagate auth headers from the original request
-	// to the upstream. For regular proxy-only queries the transport layer also
-	// forwards headers via setProxyOnlyHeaders, but the headerModifier guards
-	// against double-writes (only sets when absent). For proxy-only subscriptions,
-	// the transport path is not used so this is the only propagation point.
+	// to the upstream. This is the only propagation point for a proxy-only websocket
+	// upgrade, where the transport is not involved at all.
+	//
+	// Every other proxy-only path also reaches setProxyOnlyHeaders, which forwards the
+	// consumer's headers again, so this writes a value that is about to be written a
+	// second time. The only-when-absent guard in the header modifier does not prevent
+	// that: it runs while the fetch input is built, long before the transport adds
+	// anything. setProxyOnlyHeaders is what drops the duplicate.
 	if !apiDefinition.StripAuthData {
 		propagateAuthHeaders(outreq, upstreamHeaders, apiDefinition)
 	}


### PR DESCRIPTION
## Summary

Values that belong to a single request — the round tripper, the resolved upstream headers, the
upstream response — were being written into, or keyed on, state that outlives the request: the
shared per-API `http.Client`, the plan cache, and the upstream connection-reuse key. Under
concurrency the result was not deterministic: which request's values a fetch used depended on
timing.

This makes that state request-scoped, and fixes the header handling that depended on it. Seven
commits, each independently revertable. 

`internal/graphengine` goes from 22 to 76 test functions (273 including subtests), green under
`-race -count=10`.

Behavioural detail and reproduction steps are on the ticket.

## What changed

### scope transports to requests

`reverseProxyPreHandlerV1/V2.PreHandle` assigned `params.RoundTripper` onto the per-API
`httpClient.Transport` on every request, so concurrent requests overwrote each other's. The round
tripper and headers config now travel in the request context
(`SetGraphQLEngineTransportContextValue`), and `GraphQLEngineTransport.RoundTrip` builds a
per-request view from them, falling back to the client's own transport.

### keep subscriptions alive, isolate proxy-only responses

Three defects, two of them introduced by the commit above:

- **WebSocket subscriptions never delivered.** The handovers passed
  `WithContext(params.OutRequest.Context())`, but `net/http` calls `w.cancelCtx()` as soon as
  `ServeHTTP` returns — before the hijacked check in `conn.serve` — and the gateway returns as soon
  as the connection is hijacked. The subscription context was cancelled before anything was sent.
  `subscriptionRequestContext` roots the subscription at the long-lived engine spec context while
  carrying the opening request's transport values across. EngineV1 passes no context: its legacy
  data sources drop it, so inheriting the request's cancellation could only break the subscription.
- **`handleProxyOnly` rewrote the outgoing method**, turning a proxy-only upstream WebSocket
  handshake into a POST, which WebSocket servers reject. Handshakes now stay `GET`.
- **`GraphQLProxyOnlyContextValues.upstreamResponse` was unsynchronised.** The transport writes it
  on the resolver's trigger goroutine while the engine reads it (~1 in 20 under `-race`). Now
  behind a mutex.

### cover the request isolation matrix

`credential_isolation_test.go`: proxy-only, UDG and supergraph × HTTP, SSE, `graphql-ws` and
`graphql-transport-ws` × EngineV2 and EngineV3. Each test drives more than one request through one
engine and asserts what each upstream connection actually received, with negative controls
(`strip_auth_data`, a custom auth header name, a request that sets no header after one that did),
20-request concurrent bursts, a per-request round tripper test that shared mutable transport state
cannot pass, and the client WebSocket-upgrade path that the regression above had slipped through.

### move to the fixed graphql-go-tools, cover the cold path

Both module pins move to the library branch; `coder/websocket` becomes a direct dependency. Two
races are fixed upstream — v1 `Schema.Hash` writing `s.hash` on first use, and v2
`ResolveGraphQLResponse` writing `Info` on the cached plan — so the cold-start concurrent burst
becomes permanent coverage instead of something a warm-up had to work around.

### resolve dynamic upstream headers before the fetch is keyed

The v1 header modifier merged Tyk's additional headers and stopped, leaving `tykVariableReplacer`
injected but never read, so `$tyk_context.*` in an upstream header reached the fetch unresolved on
config version 2. That matters for more than the value that arrives upstream: the library applies
the modifier before it derives the key that groups equivalent subscriptions onto one upstream
connection (`connectionKey` in the v1 subscription client, `UniqueRequestID` in the v2 resolver).
An unresolved template is the same string for every request, so requests that should have been
distinct were treated as equivalent and pooled together.

Resolving there is only correct now that the library moved header modification to the execution
phase. TT-14357 (`adca34d46`) had removed it because the modifier ran at plan post-process time and
the result was cached into the plan, and added `variableReplaceRoundTripper` as the workaround.
That wrapper is retired here: it ran after the grouping key was derived, it collapsed multi-value
headers via `Get`/`Set` on the way to the wire, and it expanded variables in header values that did
not come from the API definition. Its one remaining job, `request_headers_rewrite`, is resolved
once where the rules are built, from configuration only.

### restore the gateway round tripper for EngineV1 fetches

Regression from `cf506a971`, caught while verifying the above:
`TestGraphQL_InternalDataSource/graphql_engine_v1` fails at the branch tip and passes at the base —
a config version 1 API with a `tyk://` data source answers 500. The transport assignment that
commit removed was also the only thing giving EngineV1 the gateway round tripper, and only that
round tripper can route `tyk://`. Since EngineV1's data sources drop the execution context, the
round tripper is handed over as a mutex-guarded transport-level fallback, used only when a request
carries none of its own. EngineV2 and EngineV3 stay fully request-scoped.

That fallback is the one piece of transport state shared between requests, and it is only sound
because the round tripper the gateway hands over no longer carries request-specific state — the
wrapper retired in `4d67f9af4` did. **The two commits must not be reverted independently**; both
sides carry comments saying so.

### forward a consumer header to the upstream once

Two writers put the consumer's headers on the upstream request and neither knew about the other:
`propagateAuthHeaders` adds them to the fetch input when `strip_auth_data` is off, and
`setProxyOnlyHeaders` then forwards every consumer header again with `Header.Add`. With
`use_immutable_headers` off nothing removed the first copy, so a header present in both arrived
duplicated. It went unnoticed because the wrapper retired in `4d67f9af4` had been collapsing
repeated values with `Get`/`Set` since before the second writer was added.

`setProxyOnlyHeaders` now skips a value the engine already placed there, compared against a
snapshot taken before forwarding so a consumer that genuinely sent the same value twice keeps both.
It also hoists the `use_immutable_headers` delete out of the value loop, where it removed the value
added on the previous pass and left a multi-value consumer header holding only its last value.

## Behaviour changes worth a reviewer's sign-off

1. **An API reload or release now ends that API's subscriptions.** Previously they ran on
   `context.Background()` and outlived the reload.
2. **No header value is resolved twice** on config version 2 or 3-preview. Values that do not come
   from the API definition are no longer expanded, and a value that resolved into another template
   token no longer gets a second pass.
3. **An exact overlap between a configured `request_headers` value and a consumer value now reaches
   the upstream once**, not twice. Differing values still both go upstream — TT-11990 / TT-12190
   semantics are unchanged.
4. **Multi-value headers survive to the upstream.** `Accept-Encoding: gzip, deflate, br` used to
   arrive as `gzip` alone.


<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17921" title="TT-17921" target="_blank">TT-17921</a>
</summary>

|         |    |
|---------|----|
| Status  | Merge |
| Summary | Federated supergraph reuses first caller’s JWT across users and can share HTTP responses via single-flight |

Generated at: 2026-08-21 09:06:43

</details>

<!---TykTechnologies/jira-linter ends here-->


