### PR TITLE
TT-17641: gromit: publish the NG plugin compiler for arm64 (release-5.15.0)

### DIFF
--- a/.github/workflows/plugin-compiler-ng-build.yml
+++ b/.github/workflows/plugin-compiler-ng-build.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The runners are amd64. Every other image platform is built and gated
+      # under emulation, so binfmt has to be registered before buildx starts.
+      # Rendered only while linux/amd64,linux/arm64 asks for a non-native
+      # platform -- an amd64-only image installs nothing.
+      - name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
@@ -227,6 +235,20 @@ jobs:
             platform_digest="$digest"
           fi
           case "$platform_digest" in sha256:*) ;; *) echo "unexpected source platform digest: $platform_digest" >&2; exit 1 ;; esac
+          # BASE_IMAGE is passed as the index digest, so buildx picks the right
+          # manifest per platform on its own. Check up front that every platform
+          # we are about to build is actually in there: a missing one otherwise
+          # surfaces much later as a bare "no match for platform" from a build
+          # step that has no idea which of its inputs was at fault.
+          for want in linux/amd64 linux/arm64; do
+            jq -e --arg want "$want" '
+              [.manifest.manifests[]? | select("\(.platform.os)/\(.platform.architecture)" == $want)]
+              | length == 1
+            ' <<<"$inspect" >/dev/null || {
+              echo "::error title=Base image is missing a platform::${source} does not publish ${want}; the DHI customization has to be built for it first" >&2
+              exit 1
+            }
+          done
           if [[ "$source" == *@sha256:* ]]; then
             test "${source##*@}" = "$digest"
             ref="$source"
@@ -245,6 +267,9 @@ jobs:
           digest="$(jq -er '.manifest.digest' <<<"$inspect")"
           test -n "$digest"
           case "$digest" in sha256:*) ;; *) echo "unexpected Go toolchain digest: $digest" >&2; exit 1 ;; esac
+          # amd64 on purpose, and not a copy of the base check above: golang-cross
+          # is published for amd64 only. Other platforms take the Go distribution
+          # from go.dev instead -- see the sha256 resolution further down.
           if jq -e '(.manifest.manifests? | type) == "array"' <<<"$inspect" >/dev/null; then
             platform_digest="$(jq -er '
               [.manifest.manifests[] | select(
@@ -264,13 +289,50 @@ jobs:
           echo "platform_digest=$platform_digest" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
+          # golang-cross is the authority for WHICH Go version the gateway uses,
+          # because the gateway release runs this same image. Read the version
+          # out of it so platforms that cannot COPY from it can still be pinned
+          # to exactly that version.
+          #
+          # This costs a full pull of golang-cross into the daemon, which is why
+          # it is not done unconditionally: an amd64 image COPYs its toolchain
+          # from that image anyway and reads the version out of it for free.
+          go_version="$(docker run --rm --platform linux/amd64 "$ref" go version | awk '{print $3}')"
+          case "$go_version" in
+            go1.*) ;;
+            *) echo "unexpected Go version from ${ref}: $go_version" >&2; exit 1 ;;
+          esac
+          echo "version=$go_version" >> "$GITHUB_OUTPUT"
+
+          # golang-cross is published for amd64 only, so every other platform
+          # takes the stock go.dev tarball at the version resolved above. Pin the
+          # checksum here, before anything is downloaded, so the image build
+          # verifies against a value settled outside it.
+          #
+          # Deliberately fatal: this only renders when a platform that needs the
+          # tarball is being built, and guessing a checksum is not an option.
+          sha_arm64="$(curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+            'https://go.dev/dl/?mode=json&include=all' | jq -er --arg v "$go_version" '
+              [.[] | select(.version == $v) | .files[]
+                 | select(.os == "linux" and .arch == "arm64" and .kind == "archive")]
+              | if length == 1 then .[0].sha256
+                else error("no unique linux-arm64 archive for \($v)")
+                end')"
+          case "$sha_arm64" in
+            ????????????????????????????????????????????????????????????????) ;;
+            *) echo "unexpected sha256 for ${go_version} linux-arm64: $sha_arm64" >&2; exit 1 ;;
+          esac
+          echo "sha256_arm64=$sha_arm64" >> "$GITHUB_OUTPUT"
+
       - name: Build workflow-local NG base
         id: build-ng-base
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: ci/images/plugin-compiler-ng
           file: ci/images/plugin-compiler-ng/Dockerfile.base
-          platforms: linux/amd64
+          # Pull requests use the `docker` driver, which builds one platform
+          # only, and they never push -- so they stay on the gate platform.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           sbom: ${{ github.event_name != 'pull_request' }}
@@ -319,6 +381,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -326,6 +389,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -348,7 +413,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -357,6 +422,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -415,6 +482,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -451,6 +540,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -458,6 +548,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -473,6 +565,48 @@ jobs:
         run: VALIDATE_ONLY=1 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate:ee ee arm64
 
 
+      # Tier B gate. The push below emits a single OCI index covering every
+      # platform, so a broken linux/arm64 image blocks the whole push --
+      # including platforms that are perfectly fine. Build and exercise this one
+      # on its own first, where a failure is attributable and nothing has been
+      # published yet.
+      #
+      # WITH_GATEWAY_SELFTEST=0 on purpose: VALIDATE_ONLY skips the load/HTTP
+      # gate, so the gateway binary would be built under emulation and never run.
+      - name: Build linux/arm64 NG gate image EE
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
+        with:
+          context: .
+          file: ci/images/plugin-compiler-ng/Dockerfile.release
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: tyk-plugin-compiler-ng-gate-linux-arm64:ee
+          build-args: |
+            BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
+            GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_TAG=${{ github.ref_name }}
+            WITH_GATEWAY_SELFTEST=0
+            DEFAULT_EDITION=ee
+            EE_AVAILABLE=true
+            EE_BUILD_TAG=ee
+            SELFTEST_BUILD_TAG=ee
+
+      # Proves the linux/arm64 toolchain executes and emits a loadable
+      # object for its own architecture -- strictly more than the cross-build
+      # checks above, which only ever exercise the amd64 image.
+      #
+      # It stops short of plugin.Open in a linux/arm64 gateway: that needs a
+      # runner of this architecture. See the PR for the gap and the follow-up.
+      - name: Validate linux/arm64 NG toolchain EE
+        if: ${{ github.event_name != 'pull_request' }}
+        run: VALIDATE_ONLY=1 COMPILER_PLATFORM=linux/arm64 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate-linux-arm64:ee ee
+
+
       - name: Build and push NG image EE
         if: ${{ github.event_name != 'pull_request' }}
         id: build-push-ee-ng
@@ -480,7 +614,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -489,6 +623,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -550,6 +686,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -586,6 +744,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -593,6 +752,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -617,7 +778,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -626,6 +787,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -688,6 +851,28 @@ jobs:
 
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
+
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
 
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"

--- a/ci/images/plugin-compiler-ng/Dockerfile.release
+++ b/ci/images/plugin-compiler-ng/Dockerfile.release
@@ -1,14 +1,75 @@
 # syntax=docker/dockerfile:1.7
 ARG GOLANG_IMAGE=tykio/golang-cross:1.26-bullseye
 ARG BASE_IMAGE
+# The exact Go version the gateway is built with, e.g. go1.26.4, as reported by
+# GOLANG_IMAGE. A compiler whose Go differs from the gateway's by so much as a
+# patch release produces plugins that fail at plugin.Open, so wherever the
+# toolchain does not come from GOLANG_IMAGE itself this has to be stated.
+#
+# Empty is legitimate and means "whatever GOLANG_IMAGE carries": on amd64 the
+# toolchain is COPYed out of that image, so the two agree by construction and
+# there is nothing to assert. Platforms that fetch Go elsewhere require it, and
+# say so where they use it.
+ARG GO_VERSION=
+ARG GO_TARBALL_SHA256_ARM64=
 
-FROM ${GOLANG_IMAGE} AS go-toolchain
+# amd64 takes the toolchain straight from golang-cross, exactly as before. The
+# gateway release runs that same image, so on this architecture the two are
+# identical by construction rather than by assertion.
+FROM --platform=linux/amd64 ${GOLANG_IMAGE} AS go-src-amd64
+
+# golang-cross is published for amd64 only, so arm64 fetches the stock go.dev
+# tarball at the version golang-cross reports. The version still originates from
+# the same image the gateway uses; only the bits come from upstream.
+#
+# Pinned to BUILDPLATFORM so the download and unpack run on the build host and
+# are never emulated -- the same approach Dockerfile.base uses for the sysroots.
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS go-src-arm64
+ARG GO_VERSION
+ARG GO_TARBALL_SHA256_ARM64
+RUN set -eux; \
+    if [ -z "$GO_VERSION" ] || [ -z "$GO_TARBALL_SHA256_ARM64" ]; then \
+        echo "ERROR: building for arm64 needs GO_VERSION and GO_TARBALL_SHA256_ARM64." >&2; \
+        echo "ERROR: golang-cross is amd64-only, so there is nothing to copy from." >&2; \
+        exit 1; \
+    fi; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+        -o /tmp/go.tgz "https://go.dev/dl/${GO_VERSION}.linux-arm64.tar.gz"; \
+    echo "${GO_TARBALL_SHA256_ARM64}  /tmp/go.tgz" | sha256sum -c -; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz; \
+    test "$(head -1 /usr/local/go/VERSION)" = "$GO_VERSION"
+
+# Selects one of the two stages above. Any other TARGETARCH fails here with
+# "failed to find stage go-src-<arch>", which is the intent: a platform with
+# no toolchain source must not silently fall through to one that has.
+FROM go-src-${TARGETARCH} AS go-toolchain
 
 FROM ${BASE_IMAGE}
+ARG GO_VERSION
 
 COPY --from=go-toolchain /usr/local/go /usr/local/go
 
-ENV GOTOOLCHAIN=local
+# When set, this is the gateway's Go version as declared from outside the image.
+# build.sh prefers it over `go version`, so validate-plugin.sh compares a built
+# plugin against the gateway's version rather than restating the image's own.
+ENV GOTOOLCHAIN=local \
+    TYK_GATEWAY_GO_VERSION=${GO_VERSION}
+
+# The toolchain that ends up here must be the gateway's, whichever stage it came
+# from. Unset means it was COPYed from GOLANG_IMAGE, where that holds by
+# construction; set means it was fetched independently and has to be proven.
+RUN set -eux; \
+    have="$(go version | awk '{print $3}')"; \
+    case "$have" in go1.*) ;; *) echo "ERROR: no usable Go toolchain: $have" >&2; exit 1 ;; esac; \
+    if [ -n "$GO_VERSION" ] && [ "$have" != "$GO_VERSION" ]; then \
+        echo "ERROR: image Go $have does not match the gateway's $GO_VERSION" >&2; \
+        echo "ERROR: plugins built here would fail to load." >&2; \
+        exit 1; \
+    fi
 
 COPY go.mod go.sum $TYK_GW_PATH/
 WORKDIR $TYK_GW_PATH

--- a/ci/images/plugin-compiler-ng/data/build.sh
+++ b/ci/images/plugin-compiler-ng/data/build.sh
@@ -495,7 +495,7 @@ set +x
 
 # --- Post-build validation (opt-out with VALIDATE=0) ------------------------
 if [[ "$VALIDATE" != "0" ]] && [ -x /usr/local/bin/validate-plugin.sh ]; then
-	GATEWAY_GO_VERSION="$(go version | awk '{print $3}')" \
+	GATEWAY_GO_VERSION="${TYK_GATEWAY_GO_VERSION:-$(go version | awk '{print $3}')}" \
 	EXPECT_GOARCH="$GOARCH" EXPECT_GOOS="$GOOS" \
 	MAX_GLIBC="$TYK_GLIBC_TARGET" \
 	GW_TYK_REVISION="$GITHUB_SHA" \

--- a/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
+++ b/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
@@ -84,8 +84,9 @@ EOF
 
 archenv=(); platform=()
 if [ -n "$GOARCH" ]; then archenv=(-e GOARCH="$GOARCH"); platform=(--platform "linux/$GOARCH"); fi
-# Optional: pin the COMPILER's own runtime platform (e.g. exercise the amd64 image under QEMU on an
-# arm64 host). Default empty = run the compiler on the host's native arch. CI never sets it.
+# Optional: pin the COMPILER's own runtime platform. Default empty = run the compiler on the host's
+# native arch. The Tier B gate sets it to exercise a non-native image under emulation, which is why
+# it pairs with VALIDATE_ONLY=1 -- the load/HTTP gate below needs a Gateway of that architecture.
 cplat=(); [ -n "${COMPILER_PLATFORM:-}" ] && cplat=(--platform "$COMPILER_PLATFORM")
 echo "== gate: building test-plugin with $COMPILER (EDITION=$EDITION GOARCH=${GOARCH:-native} compiler=${COMPILER_PLATFORM:-native}) =="
 docker run --rm -e EDITION="$EDITION" ${archenv[@]+"${archenv[@]}"} ${cplat[@]+"${cplat[@]}"} -v "$PLUGDIR:/plugin-source" "$COMPILER" plugin.so


### PR DESCRIPTION
Regenerated from gromit **[PR #538](https://github.com/TykTechnologies/gromit/pull/538)** — that PR carries the rationale and design trade-offs. This one is the rendered output, byte-identical to gromit's goldens for this branch.

The NG compiler image publishes `linux/arm64` alongside `linux/amd64`, so it runs natively on Apple silicon and Graviton instead of under emulation. Both compilers already cross-compiled arm64 *plugins*; what was missing was a compiler that *runs* on an arm64 host.

- **amd64 is untouched** — still `COPY --from=golang-cross`, identical by construction.
- **arm64** takes the stock go.dev tarball at the version golang-cross reports, sha256-pinned before anything downloads, unpacked on `$BUILDPLATFORM` so it is never emulated.

`data/build.sh` no longer derives `GATEWAY_GO_VERSION` from the image's own toolchain — that only ever proved `plugin == image`, never `image == gateway`, so a drifted arm64 toolchain would have validated cleanly and shipped plugins that fail at `plugin.Open`.

A new Tier B gate builds the arm64 image on its own and exercises its toolchain before anything is pushed, because the push emits a single OCI index and an arm64 failure would otherwise block the amd64 push with no attributable cause. It runs for **EE only** — the toolchain is identical across variants and the gate runs emulated, so it is paid once. Emulated work never runs on pull requests.

## Verification

Proven end-to-end on native arm64 hardware for **CE and FIPS** — compiler builds a plugin, `tyk plugin load` opens it in an arm64 gateway, and the plugin executes in a live request:

```
[ok] architecture: AArch64
[ok] go toolchain: go1.26.7 (matches gateway)
[ok] FIPS: GOFIPS140=v1.0.0-c2097c7c (embedded build setting)
[file=/gate-plugin.so, symbol=AddFooBarHeader] loaded ok, got 0xffff052b8b60
GATE PASS: AddFooBarHeader changed the proxied request (Foo: Bar) for EDITION=ee-fips
```

## Known gap

CI never exercises arm64 `plugin.Open` — that needs an arm64 runner the org does not have, so `gateplatform` stays `linux/amd64`. The load-and-run path above was proven manually and is not re-checked per release. That evidence came from Apple silicon rather than a Graviton-class Linux host: same architecture and images, so the ABI result carries, but it does not rule out Docker Desktop's VM differing from a Linux runner in ways unrelated to arch.

**Merge order:** gromit #538 must merge first, or the drift check fails by construction — gromit `master` does not yet generate these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)