### PR TITLE
[TT-17873] proxy_default_timeout overrides enforced timeout middleware but should only be applied when enforced timeout is unset

### DIFF
--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -835,7 +835,7 @@ func getScopeFromClaim(claims jwt.MapClaims, scopeClaimName string) []string {
 	return toScopeStringsSlice(lookedUp, nil, false)
 }
 
-func mapScopeToPolicies(mapping map[string]string, scope []string) []string {
+func mapScopeToPolicies(mapping map[string]string, scope []string, log *logrus.Logger) []string {
 	// add all policies matched from scope-policy mapping
 	var policiesToApplySet map[string]struct{}
 	var unmatchedScopes map[string]struct{}
@@ -1070,7 +1070,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			}
 
 			// add all policies matched from scope-policy mapping
-			mappedPolIDs := mapScopeToPolicies(scopeMap, scope)
+			mappedPolIDs := mapScopeToPolicies(scopeMap, scope, log)
 			if len(mappedPolIDs) > 0 {
 				k.Logger().Debugf("Identified policy(s) to apply to this token from scope claim: %s", scopeClaimName)
 			} else {

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -5369,30 +5369,23 @@ func TestJWTPostExpiry(t *testing.T) {
 func Test_mapScopeToPolicies_TT5893(t *testing.T) {
 	// https://tyktech.atlassian.net/browse/TT-5893
 
-	injectLogger := func(t *testing.T) (tmpLogger *logrus.Logger, hook *logrustest.Hook) {
+	makeLogger := func(t *testing.T) (tmpLogger *logrus.Logger, hook *logrustest.Hook) {
 		t.Helper()
 
 		tmpLogger, hook = logrustest.NewNullLogger()
 		tmpLogger.SetLevel(logrus.TraceLevel)
-
-		realLogger := log
-
-		log = tmpLogger
-		t.Cleanup(func() {
-			log = realLogger
-		})
 
 		return
 	}
 
 	t.Run("Unmatched scopes should be logged at the DEBUG level when at least one scope successfully matches a policy", func(t *testing.T) {
 		t.Run("logs only matches with debug level", func(t *testing.T) {
-			_, hook := injectLogger(t)
+			logger, hook := makeLogger(t)
 
 			res := mapScopeToPolicies(map[string]string{
 				"scope1": "policy1",
 				"scope2": "policy2",
-			}, []string{"scope1", "scope2"})
+			}, []string{"scope1", "scope2"}, logger)
 
 			entries := hook.AllEntries()
 
@@ -5405,12 +5398,12 @@ func Test_mapScopeToPolicies_TT5893(t *testing.T) {
 		})
 
 		t.Run("logs error if no one scope matches", func(t *testing.T) {
-			_, hook := injectLogger(t)
+			logger, hook := makeLogger(t)
 
 			res := mapScopeToPolicies(map[string]string{
 				"scope1": "policy1",
 				"scope2": "policy2",
-			}, []string{"scope3"})
+			}, []string{"scope3"}, logger)
 
 			entries := hook.AllEntries()
 			assert.Len(t, entries, 1)
@@ -5422,12 +5415,12 @@ func Test_mapScopeToPolicies_TT5893(t *testing.T) {
 		})
 
 		t.Run("logs if at least one scope matches", func(t *testing.T) {
-			_, hook := injectLogger(t)
+			logger, hook := makeLogger(t)
 
 			res := mapScopeToPolicies(map[string]string{
 				"scope1": "policy1",
 				"scope2": "policy2",
-			}, []string{"scope1", "scope3"})
+			}, []string{"scope1", "scope3"}, logger)
 
 			entries := hook.AllEntries()
 

--- a/gateway/mw_openid.go
+++ b/gateway/mw_openid.go
@@ -193,7 +193,7 @@ func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inte
 
 		if scope := getScopeFromClaim(token.Claims.(jwt.MapClaims), scopeClaimName); scope != nil {
 			// add all policies matched from scope-policy mapping
-			policiesToApply = mapScopeToPolicies(k.Spec.GetScopeToPolicyMapping(), scope)
+			policiesToApply = mapScopeToPolicies(k.Spec.GetScopeToPolicyMapping(), scope, log)
 		}
 	}
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1275,6 +1275,12 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 	requestTimeout, isRequestTimeoutEnforced := p.GetEnforcedTimeoutSettings(p.TykAPISpec, outreq)
 
+	if isRequestTimeoutEnforced {
+		timeoutContext, cancel := context.WithCancel(outreq.Context())
+		defer cancel()
+		outreq = outreq.WithContext(timeoutContext)
+	}
+
 	// create HTTP transport
 	createTransport := p.TykAPISpec.HTTPTransport == nil
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -846,10 +846,10 @@ func (p *ReverseProxy) httpTransport(dialTimeout float64, req *http.Request, out
 			},
 			AllowHTTP: true,
 		}
-		return &TykRoundTripper{transport, h2t, p.logger, p.Gw}
+		return &TykRoundTripper{transport: transport, h2ctransport: h2t}
 	}
 
-	return &TykRoundTripper{transport, nil, p.logger, p.Gw}
+	return &TykRoundTripper{transport: transport, h2ctransport: nil}
 }
 
 func (p *ReverseProxy) setCommonNameVerifyPeerCertificate(tlsConfig *tls.Config, hostName string) {
@@ -901,39 +901,45 @@ func (p *ReverseProxy) setCommonNameVerifyPeerCertificate(tlsConfig *tls.Config,
 	}
 }
 
+func isInternalLoop(r *http.Request) bool {
+	if r.URL == nil {
+		return false
+	}
+
+	hasInternalHeader := r.Header.Get(apidef.TykInternalApiHeader) != ""
+
+	return r.URL.Scheme == "tyk" || r.URL.Scheme == "tyk-internal" || hasInternalHeader
+}
+
+func internalLoopRoundTripperMiddleware(gw *Gateway, logger *logrus.Entry) roundtrippers.Middleware {
+	return func(next roundtrippers.RoundTripper) roundtrippers.RoundTripper {
+		return roundtrippers.RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			if !isInternalLoop(r) {
+				return next.RoundTrip(r)
+			}
+
+			r.Header.Del(apidef.TykInternalApiHeader)
+
+			handler, _, found := gw.findInternalHTTPHandlerForLoop(r.Host, nil, r)
+
+			if !found {
+				logger.WithField("looping_url", "tyk://"+r.Host).Error("Couldn't detect target")
+				return nil, errors.New("handler could")
+			}
+
+			logger.WithField("looping_url", "tyk://"+r.Host).Debug("Executing request on internal route")
+
+			return handleInMemoryLoop(handler, r)
+		})
+	}
+}
+
 type TykRoundTripper struct {
 	transport    *http.Transport
 	h2ctransport *http2.Transport
-	logger       *logrus.Entry
-	Gw           *Gateway `json:"-"`
 }
 
 func (rt *TykRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-
-	if isInternalLoop(r) {
-		r.Header.Del(apidef.TykInternalApiHeader)
-
-		handler, _, found := rt.Gw.findInternalHTTPHandlerForLoop(r.Host, nil, r)
-		if !found {
-			rt.logger.WithField("looping_url", "tyk://"+r.Host).Error("Couldn't detect target")
-			return nil, errors.New("handler could")
-		}
-
-		rt.logger.WithField("looping_url", "tyk://"+r.Host).Debug("Executing request on internal route")
-
-		return handleInMemoryLoop(handler, r)
-	}
-
-	if rt.Gw.GetConfig().OpenTelemetry.TracesEnabled() {
-		var baseRoundTripper http.RoundTripper = rt.transport
-		if rt.h2ctransport != nil {
-			baseRoundTripper = rt.h2ctransport
-		}
-
-		tr := otel.HTTPRoundTripper(baseRoundTripper)
-		return tr.RoundTrip(r)
-	}
-
 	if rt.h2ctransport != nil {
 		return rt.h2ctransport.RoundTrip(r)
 	}
@@ -1338,14 +1344,12 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 	var decoratedRoundTripper = roundtrippers.Combine(
 		roundTripper,
-		roundtrippers.Timeout(
-			requestTimeout,
-			roundtrippers.WithTimeoutDisableFn(isInternalLoop),
-		),
-		roundtrippers.HeadersTimeout(
-			fallbackHeadersTimeout,
-			roundtrippers.WithHeadersTimeoutDisableFn(isInternalLoop),
-			roundtrippers.WithHeadersTimeoutDisabled(isRequestTimeoutEnforced),
+		internalLoopRoundTripperMiddleware(p.Gw, p.logger),
+		roundtrippers.SkipIf(otel.HTTPRoundTripper, !p.Gw.GetConfig().OpenTelemetry.TracesEnabled()),
+		roundtrippers.Timeout(requestTimeout),
+		roundtrippers.SkipIf(
+			roundtrippers.HeadersTimeout(fallbackHeadersTimeout),
+			isRequestTimeoutEnforced,
 		),
 	)
 
@@ -2137,14 +2141,4 @@ func (p *ReverseProxy) checkUpstreamCertificateExpiry(cert *tls.Certificate) {
 			WithError(err).
 			Warning("Failed to add upstream certificate to expiry check batch")
 	}
-}
-
-func isInternalLoop(r *http.Request) bool {
-	if r.URL == nil {
-		return false
-	}
-
-	hasInternalHeader := r.Header.Get(apidef.TykInternalApiHeader) != ""
-
-	return r.URL.Scheme == "tyk" || r.URL.Scheme == "tyk-internal" || hasInternalHeader
 }

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1145,7 +1145,7 @@ func (p *ReverseProxy) sendRequestToUpstream(roundTripper http.RoundTripper, out
 	return roundTripper.RoundTrip(outreq)
 }
 
-func (p *ReverseProxy) applyTimeout(r *http.Request) *http.Request {
+func (p *ReverseProxy) applyTimeout(r *http.Request) (*http.Request, context.CancelFunc) {
 	httpDialTimeout := calculateDialTimeout(p.TykAPISpec)
 	reqTimeout, isTimeoutEnforced := p.GetEnforcedTimeoutSettings(p.TykAPISpec, r)
 
@@ -1155,10 +1155,7 @@ func (p *ReverseProxy) applyTimeout(r *http.Request) *http.Request {
 	}
 
 	timeoutContext, cancel := context.WithTimeout(r.Context(), reqTimeout)
-	defer cancel()
-	r = r.WithContext(timeoutContext)
-
-	return r
+	return r.WithContext(timeoutContext), cancel
 }
 
 func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Request, withCache bool) ProxyResponse {
@@ -1279,7 +1276,8 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	}
 
 	p.TykAPISpec.Lock()
-	outreq = p.applyTimeout(outreq)
+	outreq, cancel := p.applyTimeout(outreq)
+	defer cancel()
 
 	// create HTTP transport
 	createTransport := p.TykAPISpec.HTTPTransport == nil

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -432,11 +432,15 @@ func (p *ReverseProxy) defaultTransport(dialTimeout float64) *http.Transport {
 	}
 
 	transport := &http.Transport{
-		DialContext:           dialContextFunc,
-		MaxIdleConns:          p.Gw.GetConfig().MaxIdleConns,
-		MaxIdleConnsPerHost:   p.Gw.GetConfig().MaxIdleConnsPerHost, // default is 100
-		IdleConnTimeout:       time.Duration(idleConnTimeout) * time.Second,
-		ResponseHeaderTimeout: time.Duration(0), // Response timeout has to be controlled within context
+		DialContext:         dialContextFunc,
+		MaxIdleConns:        p.Gw.GetConfig().MaxIdleConns,
+		MaxIdleConnsPerHost: p.Gw.GetConfig().MaxIdleConnsPerHost, // default is 100
+		IdleConnTimeout:     time.Duration(idleConnTimeout) * time.Second,
+
+		// ResponseHeaderTimeout logic moved to roundtrippers.HeadersTimeout decorator.
+		// It was colliding with the enforced (endpoint-level/api-level) timeout.
+		// @see https://tyktech.atlassian.net/browse/TT-17873
+		ResponseHeaderTimeout: time.Duration(0),
 		TLSHandshakeTimeout:   10 * time.Second,
 	}
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1345,12 +1345,12 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	var decoratedRoundTripper = roundtrippers.Combine(
 		roundTripper,
 		internalLoopRoundTripperMiddleware(p.Gw, p.logger),
-		roundtrippers.SkipIf(otel.HTTPRoundTripper, !p.Gw.GetConfig().OpenTelemetry.TracesEnabled()),
 		roundtrippers.Timeout(requestTimeout),
 		roundtrippers.SkipIf(
 			roundtrippers.HeadersTimeout(fallbackHeadersTimeout),
 			isRequestTimeoutEnforced,
 		),
+		roundtrippers.SkipIf(otel.HTTPRoundTripper, !p.Gw.GetConfig().OpenTelemetry.TracesEnabled()),
 	)
 
 	if breakerEnforced {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -409,15 +409,15 @@ type ReverseProxy struct {
 
 var idleConnTimeout = 90
 
-func (p *ReverseProxy) defaultTransport(dialerTimeout float64) *http.Transport {
-	timeout := 30.0
-	if dialerTimeout > 0 {
-		log.Debug("Setting timeout for outbound request to: ", dialerTimeout)
-		timeout = dialerTimeout
+func (p *ReverseProxy) defaultTransport(dialTimeout float64) *http.Transport {
+	if dialTimeout == 0 {
+		dialTimeout = 30.0
 	}
 
+	log.Debug("Setting timeout for outbound request to: ", dialTimeout)
+
 	dialer := &net.Dialer{
-		Timeout:   time.Duration(float64(timeout) * float64(time.Second)),
+		Timeout:   time.Duration(dialTimeout * float64(time.Second)),
 		KeepAlive: 30 * time.Second,
 		DualStack: true,
 	}
@@ -435,7 +435,7 @@ func (p *ReverseProxy) defaultTransport(dialerTimeout float64) *http.Transport {
 		MaxIdleConns:          p.Gw.GetConfig().MaxIdleConns,
 		MaxIdleConnsPerHost:   p.Gw.GetConfig().MaxIdleConnsPerHost, // default is 100
 		IdleConnTimeout:       time.Duration(idleConnTimeout) * time.Second,
-		ResponseHeaderTimeout: time.Duration(dialerTimeout) * time.Second,
+		ResponseHeaderTimeout: time.Duration(0), // Response timeout has to be controlled within context
 		TLSHandshakeTimeout:   10 * time.Second,
 	}
 
@@ -625,13 +625,15 @@ func (p *ReverseProxy) ServeHTTPForCache(rw http.ResponseWriter, req *http.Reque
 	return resp
 }
 
-const defaultProxyTimeout float64 = 30
-
-func proxyTimeout(spec *APISpec) float64 {
+func calculateDialTimeout(spec *APISpec) float64 {
+	const defaultDialTimeoutTimeout float64 = 30
 	if spec.GlobalConfig.ProxyDefaultTimeout > 0 {
+		// I don't know why, but `proxy_default_timeout` is being treated like a DialTimeout.
+		// IMO it makes sense providing other optional config value like `http_deal_tomeout`.
+		// Actual function adds ambiguity into sense of `proxy_default_timeout`.
 		return spec.GlobalConfig.ProxyDefaultTimeout
 	}
-	return defaultProxyTimeout
+	return defaultDialTimeoutTimeout
 }
 
 // GetEnforcedTimeoutSettings returns the enforced timeout for the current request by checking
@@ -770,9 +772,9 @@ func tlsClientConfig(s *APISpec, gw *Gateway) *tls.Config {
 	return config
 }
 
-func (p *ReverseProxy) httpTransport(timeOut float64, rw http.ResponseWriter, req *http.Request, outReq *http.Request) *TykRoundTripper {
+func (p *ReverseProxy) httpTransport(dialTimeout float64, req *http.Request, outReq *http.Request) *TykRoundTripper {
 	p.logger.Debug("Creating new transport")
-	transport := p.defaultTransport(timeOut) // modifies a newly created transport
+	transport := p.defaultTransport(dialTimeout) // modifies a newly created transport
 	transport.TLSClientConfig = &tls.Config{}
 	transport.Proxy = proxyFromAPI(p.TykAPISpec)
 
@@ -933,6 +935,7 @@ func (rt *TykRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		tr := otel.HTTPRoundTripper(baseRoundTripper)
 		return tr.RoundTrip(r)
 	}
+
 	if rt.h2ctransport != nil {
 		return rt.h2ctransport.RoundTrip(r)
 	}
@@ -1138,8 +1141,24 @@ func (p *ReverseProxy) handleGraphQL(roundTripper *TykRoundTripper, outreq *http
 	return res, hijacked, err
 }
 
-func (p *ReverseProxy) sendRequestToUpstream(roundTripper *TykRoundTripper, outreq *http.Request) (res *http.Response, err error) {
+func (p *ReverseProxy) sendRequestToUpstream(roundTripper http.RoundTripper, outreq *http.Request) (res *http.Response, err error) {
 	return roundTripper.RoundTrip(outreq)
+}
+
+func (p *ReverseProxy) applyTimeout(r *http.Request) *http.Request {
+	httpDialTimeout := calculateDialTimeout(p.TykAPISpec)
+	reqTimeout, isTimeoutEnforced := p.GetEnforcedTimeoutSettings(p.TykAPISpec, r)
+
+	if !isTimeoutEnforced {
+		// set to global (gw-scoped value) if is not enforced by endpoint-level or api-level
+		reqTimeout = time.Duration(httpDialTimeout) * time.Second
+	}
+
+	timeoutContext, cancel := context.WithTimeout(r.Context(), reqTimeout)
+	defer cancel()
+	r = r.WithContext(timeoutContext)
+
+	return r
 }
 
 func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Request, withCache bool) ProxyResponse {
@@ -1260,16 +1279,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	}
 
 	p.TykAPISpec.Lock()
-
-	enforcedTimeout, isTimeoutEnforced := p.GetEnforcedTimeoutSettings(p.TykAPISpec, outreq)
-
-	// limit request time with context timeout
-	if isTimeoutEnforced {
-		timeoutContext, cancel := context.WithTimeout(outreq.Context(), enforcedTimeout)
-		defer cancel()
-
-		outreq = outreq.WithContext(timeoutContext)
-	}
+	outreq = p.applyTimeout(outreq)
 
 	// create HTTP transport
 	createTransport := p.TykAPISpec.HTTPTransport == nil
@@ -1288,22 +1298,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			oldTransport.DisableKeepAlives = true
 		}
 
-		timeout := proxyTimeout(p.TykAPISpec)
-		transportTimeout := timeout
-
-		// If an enforced timeout is configured for this API endpoint, we use context timeout instead of transport timeout
-		// to avoid conflicts between ResponseHeaderTimeout and context timeout
-		if isTimeoutEnforced {
-			// Don't pass the enforced timeout to transport - let context timeout handle it
-			// Use the default proxy timeout for transport instead
-			transportTimeout = proxyTimeout(p.TykAPISpec)
-			p.logger.Debug("Using context timeout for hard timeout, transport timeout: ", transportTimeout)
-		} else {
-			// For non-enforced timeouts, we can use the global timeout on transport
-			p.logger.Debug("Using transport timeout: ", timeout)
-		}
-
-		p.TykAPISpec.HTTPTransport = p.httpTransport(transportTimeout, rw, req, outreq)
+		p.TykAPISpec.HTTPTransport = p.httpTransport(calculateDialTimeout(p.TykAPISpec), req, outreq)
 		p.TykAPISpec.HTTPTransportCreated = time.Now()
 
 		if oldTransport != nil {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -46,6 +46,7 @@ import (
 	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/internal/otel"
+	"github.com/TykTechnologies/tyk/internal/roundtrippers"
 	"github.com/TykTechnologies/tyk/internal/service/core"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/storage"
@@ -625,15 +626,12 @@ func (p *ReverseProxy) ServeHTTPForCache(rw http.ResponseWriter, req *http.Reque
 	return resp
 }
 
-func calculateDialTimeout(spec *APISpec) float64 {
-	const defaultDialTimeoutTimeout float64 = 30
+func proxyTimeout(spec *APISpec) float64 {
+	const defaultProxyTimeout float64 = 30
 	if spec.GlobalConfig.ProxyDefaultTimeout > 0 {
-		// I don't know why, but `proxy_default_timeout` is being treated like a DialTimeout.
-		// IMO it makes sense providing other optional config value like `http_deal_tomeout`.
-		// Actual function adds ambiguity into sense of `proxy_default_timeout`.
 		return spec.GlobalConfig.ProxyDefaultTimeout
 	}
-	return defaultDialTimeoutTimeout
+	return defaultProxyTimeout
 }
 
 // GetEnforcedTimeoutSettings returns the enforced timeout for the current request by checking
@@ -1073,7 +1071,12 @@ func handleInMemoryLoop(handler http.Handler, r *http.Request) (resp *http.Respo
 	return memConnClient.Do(r)
 }
 
-func (p *ReverseProxy) handleOutboundRequest(roundTripper *TykRoundTripper, outreq *http.Request, w http.ResponseWriter) (res *http.Response, hijacked bool, latency time.Duration, err error) {
+func (p *ReverseProxy) handleOutboundRequest(
+	roundTripper http.RoundTripper,
+	outreq *http.Request,
+	w http.ResponseWriter,
+) (res *http.Response, hijacked bool, latency time.Duration, err error) {
+
 	begin := time.Now()
 	defer func() {
 		latency = time.Since(begin)
@@ -1092,7 +1095,7 @@ func isCORSPreflight(r *http.Request) bool {
 	return r.Method == http.MethodOptions
 }
 
-func (p *ReverseProxy) handleGraphQL(roundTripper *TykRoundTripper, outreq *http.Request, w http.ResponseWriter) (res *http.Response, hijacked bool, err error) {
+func (p *ReverseProxy) handleGraphQL(roundTripper http.RoundTripper, outreq *http.Request, w http.ResponseWriter) (res *http.Response, hijacked bool, err error) {
 	isWebSocketUpgrade := ctxGetGraphQLIsWebSocketUpgrade(outreq)
 	needsEngine := needsGraphQLExecutionEngine(p.TykAPISpec)
 
@@ -1143,19 +1146,6 @@ func (p *ReverseProxy) handleGraphQL(roundTripper *TykRoundTripper, outreq *http
 
 func (p *ReverseProxy) sendRequestToUpstream(roundTripper http.RoundTripper, outreq *http.Request) (res *http.Response, err error) {
 	return roundTripper.RoundTrip(outreq)
-}
-
-func (p *ReverseProxy) applyTimeout(r *http.Request) (*http.Request, context.CancelFunc) {
-	httpDialTimeout := calculateDialTimeout(p.TykAPISpec)
-	reqTimeout, isTimeoutEnforced := p.GetEnforcedTimeoutSettings(p.TykAPISpec, r)
-
-	if !isTimeoutEnforced {
-		// set to global (gw-scoped value) if is not enforced by endpoint-level or api-level
-		reqTimeout = time.Duration(httpDialTimeout) * time.Second
-	}
-
-	timeoutContext, cancel := context.WithTimeout(r.Context(), reqTimeout)
-	return r.WithContext(timeoutContext), cancel
 }
 
 func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Request, withCache bool) ProxyResponse {
@@ -1276,8 +1266,10 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	}
 
 	p.TykAPISpec.Lock()
-	outreq, cancel := p.applyTimeout(outreq)
-	defer cancel()
+	dialOrHeadersTimeout := proxyTimeout(p.TykAPISpec)
+	fallbackHeadersTimeout := time.Duration(dialOrHeadersTimeout) * time.Second
+
+	requestTimeout, isRequestTimeoutEnforced := p.GetEnforcedTimeoutSettings(p.TykAPISpec, outreq)
 
 	// create HTTP transport
 	createTransport := p.TykAPISpec.HTTPTransport == nil
@@ -1296,7 +1288,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			oldTransport.DisableKeepAlives = true
 		}
 
-		p.TykAPISpec.HTTPTransport = p.httpTransport(calculateDialTimeout(p.TykAPISpec), req, outreq)
+		p.TykAPISpec.HTTPTransport = p.httpTransport(dialOrHeadersTimeout, req, outreq)
 		p.TykAPISpec.HTTPTransportCreated = time.Now()
 
 		if oldTransport != nil {
@@ -1344,6 +1336,15 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		err             error
 	)
 
+	var decoratedRoundTripper = roundtrippers.Combine(
+		roundTripper,
+		roundtrippers.Timeout(requestTimeout),
+		roundtrippers.HeadersTimeout(
+			fallbackHeadersTimeout,
+			roundtrippers.WithHeadersTimeoutDisabled(isRequestTimeoutEnforced),
+		),
+	)
+
 	if breakerEnforced {
 		if !breakerConf.CB.Ready() {
 			p.logger.Debug("ON REQUEST: Circuit Breaker is in OPEN state")
@@ -1354,14 +1355,14 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		}
 		p.logger.Debug("ON REQUEST: Circuit Breaker is in CLOSED or HALF-OPEN state")
 
-		res, isHijacked, upstreamLatency, err = p.handleOutboundRequest(roundTripper, outreq, rw)
+		res, isHijacked, upstreamLatency, err = p.handleOutboundRequest(decoratedRoundTripper, outreq, rw)
 		if err != nil || res.StatusCode/100 == 5 {
 			breakerConf.CB.Fail()
 		} else {
 			breakerConf.CB.Success()
 		}
 	} else {
-		res, isHijacked, upstreamLatency, err = p.handleOutboundRequest(roundTripper, outreq, rw)
+		res, isHijacked, upstreamLatency, err = p.handleOutboundRequest(decoratedRoundTripper, outreq, rw)
 	}
 
 	if err != nil {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -910,12 +910,8 @@ type TykRoundTripper struct {
 
 func (rt *TykRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
-	hasInternalHeader := r.Header.Get(apidef.TykInternalApiHeader) != ""
-
-	if r.URL.Scheme == "tyk" || hasInternalHeader {
-		if hasInternalHeader {
-			r.Header.Del(apidef.TykInternalApiHeader)
-		}
+	if isInternalLoop(r) {
+		r.Header.Del(apidef.TykInternalApiHeader)
 
 		handler, _, found := rt.Gw.findInternalHTTPHandlerForLoop(r.Host, nil, r)
 		if !found {
@@ -1275,12 +1271,6 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 	requestTimeout, isRequestTimeoutEnforced := p.GetEnforcedTimeoutSettings(p.TykAPISpec, outreq)
 
-	if isRequestTimeoutEnforced {
-		timeoutContext, cancel := context.WithCancel(outreq.Context())
-		defer cancel()
-		outreq = outreq.WithContext(timeoutContext)
-	}
-
 	// create HTTP transport
 	createTransport := p.TykAPISpec.HTTPTransport == nil
 
@@ -1348,9 +1338,13 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 	var decoratedRoundTripper = roundtrippers.Combine(
 		roundTripper,
-		roundtrippers.Timeout(requestTimeout),
+		roundtrippers.Timeout(
+			requestTimeout,
+			roundtrippers.WithTimeoutDisableFn(isInternalLoop),
+		),
 		roundtrippers.HeadersTimeout(
 			fallbackHeadersTimeout,
+			roundtrippers.WithHeadersTimeoutDisableFn(isInternalLoop),
 			roundtrippers.WithHeadersTimeoutDisabled(isRequestTimeoutEnforced),
 		),
 	)
@@ -2143,4 +2137,14 @@ func (p *ReverseProxy) checkUpstreamCertificateExpiry(cert *tls.Certificate) {
 			WithError(err).
 			Warning("Failed to add upstream certificate to expiry check batch")
 	}
+}
+
+func isInternalLoop(r *http.Request) bool {
+	if r.URL == nil {
+		return false
+	}
+
+	hasInternalHeader := r.Header.Get(apidef.TykInternalApiHeader) != ""
+
+	return r.URL.Scheme == "tyk" || r.URL.Scheme == "tyk-internal" || hasInternalHeader
 }

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1345,12 +1345,12 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	var decoratedRoundTripper = roundtrippers.Combine(
 		roundTripper,
 		internalLoopRoundTripperMiddleware(p.Gw, p.logger),
+		roundtrippers.SkipIf(otel.HTTPRoundTripper, !p.Gw.GetConfig().OpenTelemetry.TracesEnabled()),
 		roundtrippers.Timeout(requestTimeout),
 		roundtrippers.SkipIf(
 			roundtrippers.HeadersTimeout(fallbackHeadersTimeout),
 			isRequestTimeoutEnforced,
 		),
-		roundtrippers.SkipIf(otel.HTTPRoundTripper, !p.Gw.GetConfig().OpenTelemetry.TracesEnabled()),
 	)
 
 	if breakerEnforced {

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -2705,10 +2705,12 @@ func TestTimeoutCachingBugFix(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/default") {
 			time.Sleep(1 * time.Second)
-			w.Write([]byte("Default OK"))
+			_, err := w.Write([]byte("Default OK"))
+			assert.NoError(t, err)
 		} else if strings.HasPrefix(r.URL.Path, "/enforced") {
 			time.Sleep(3 * time.Second) // Delay (3s) is BETWEEN default (2s) and enforced (5s)
-			w.Write([]byte("Enforced OK"))
+			_, err := w.Write([]byte("Enforced OK"))
+			assert.NoError(t, err)
 		}
 	}))
 	defer upstream.Close()
@@ -2721,9 +2723,9 @@ func TestTimeoutCachingBugFix(t *testing.T) {
 			version.UseExtendedPaths = true
 			version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
 				{
-					Path:     "/enforced",
-					Method:   http.MethodGet,
-					TimeOut:  5, // Enforced timeout: 5s
+					Path:    "/enforced",
+					Method:  http.MethodGet,
+					TimeOut: 5, // Enforced timeout: 5s
 				},
 			}
 		})
@@ -2749,7 +2751,6 @@ func TestTimeoutCachingBugFix(t *testing.T) {
 		BodyMatch: "Enforced OK",
 	})
 }
-
 
 func TestAPILevelTimeout(t *testing.T) {
 	t.Parallel()

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	texttemplate "text/template"
 	"time"
 
@@ -2697,58 +2698,60 @@ func TestTimeoutPrioritization(t *testing.T) {
 func TestTimeoutCachingBugFix(t *testing.T) {
 	t.Parallel()
 
-	ts := StartTest(func(c *config.Config) {
-		c.ProxyDefaultTimeout = 2 // Default transport timeout: 2s
-	})
-	defer ts.Close()
-
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/default") {
-			time.Sleep(1 * time.Second)
-			_, err := w.Write([]byte("Default OK"))
-			assert.NoError(t, err)
-		} else if strings.HasPrefix(r.URL.Path, "/enforced") {
-			time.Sleep(3 * time.Second) // Delay (3s) is BETWEEN default (2s) and enforced (5s)
-			_, err := w.Write([]byte("Enforced OK"))
-			assert.NoError(t, err)
-		}
-	}))
-	defer upstream.Close()
-
-	api := BuildAPI(func(spec *APISpec) {
-		spec.Proxy.ListenPath = "/"
-		spec.Proxy.TargetURL = upstream.URL
-		spec.EnforcedTimeoutEnabled = true
-		UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
-			version.UseExtendedPaths = true
-			version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
-				{
-					Path:    "/enforced",
-					Method:  http.MethodGet,
-					TimeOut: 5, // Enforced timeout: 5s
-				},
-			}
+	synctest.Test(t, func(t *testing.T) {
+		ts := StartTest(func(c *config.Config) {
+			c.ProxyDefaultTimeout = 0.02 // Default transport timeout: 20ms
 		})
-	})[0]
-	ts.Gw.LoadAPI(api)
+		defer ts.Close()
 
-	// REQUEST 1: Endpoint WITHOUT enforced timeout.
-	// This forces the creation and caching of the transport.
-	_, _ = ts.Run(t, test.TestCase{
-		Method:    http.MethodGet,
-		Path:      "/default",
-		Code:      http.StatusOK,
-		BodyMatch: "Default OK",
-	})
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/default") {
+				time.Sleep(10 * time.Millisecond)
+				_, err := w.Write([]byte("Default OK"))
+				assert.NoError(t, err)
+			} else if strings.HasPrefix(r.URL.Path, "/enforced") {
+				time.Sleep(30 * time.Millisecond) // Delay (30ms) is BETWEEN default (20ms) and enforced (50ms)
+				_, err := w.Write([]byte("Enforced OK"))
+				assert.NoError(t, err)
+			}
+		}))
+		defer upstream.Close()
 
-	// REQUEST 2: Endpoint WITH enforced timeout (5s).
-	// Delay is 3s. Since 3s < 5s, it should SUCCEED.
-	// If the bug exists, the cached transport (2s) will kill this request, returning 504.
-	_, _ = ts.Run(t, test.TestCase{
-		Method:    http.MethodGet,
-		Path:      "/enforced",
-		Code:      http.StatusOK,
-		BodyMatch: "Enforced OK",
+		api := BuildAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.Proxy.TargetURL = upstream.URL
+			spec.EnforcedTimeoutEnabled = true
+			UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
+				version.UseExtendedPaths = true
+				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
+					{
+						Path:            "/enforced",
+						Method:          http.MethodGet,
+						TimeoutDuration: tyktime.ReadableDuration(50 * time.Millisecond), // Enforced timeout: 50ms
+					},
+				}
+			})
+		})[0]
+		ts.Gw.LoadAPI(api)
+
+		// REQUEST 1: Endpoint WITHOUT enforced timeout.
+		// This forces the creation and caching of the transport.
+		_, _ = ts.Run(t, test.TestCase{
+			Method:    http.MethodGet,
+			Path:      "/default",
+			Code:      http.StatusOK,
+			BodyMatch: "Default OK",
+		})
+
+		// REQUEST 2: Endpoint WITH enforced timeout (50ms).
+		// Delay is 30ms. Since 30ms < 50ms, it should SUCCEED.
+		// If the bug exists, the cached transport (20ms) will kill this request, returning 504.
+		_, _ = ts.Run(t, test.TestCase{
+			Method:    http.MethodGet,
+			Path:      "/enforced",
+			Code:      http.StatusOK,
+			BodyMatch: "Enforced OK",
+		})
 	})
 }
 

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -2694,6 +2694,62 @@ func TestTimeoutPrioritization(t *testing.T) {
 		})
 	})
 }
+func TestTimeoutCachingBugFix(t *testing.T) {
+	t.Parallel()
+
+	ts := StartTest(func(c *config.Config) {
+		c.ProxyDefaultTimeout = 2 // Default transport timeout: 2s
+	})
+	defer ts.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/default") {
+			time.Sleep(1 * time.Second)
+			w.Write([]byte("Default OK"))
+		} else if strings.HasPrefix(r.URL.Path, "/enforced") {
+			time.Sleep(3 * time.Second) // Delay (3s) is BETWEEN default (2s) and enforced (5s)
+			w.Write([]byte("Enforced OK"))
+		}
+	}))
+	defer upstream.Close()
+
+	api := BuildAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.Proxy.TargetURL = upstream.URL
+		spec.EnforcedTimeoutEnabled = true
+		UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
+			version.UseExtendedPaths = true
+			version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
+				{
+					Path:     "/enforced",
+					Method:   http.MethodGet,
+					TimeOut:  5, // Enforced timeout: 5s
+				},
+			}
+		})
+	})[0]
+	ts.Gw.LoadAPI(api)
+
+	// REQUEST 1: Endpoint WITHOUT enforced timeout.
+	// This forces the creation and caching of the transport.
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/default",
+		Code:      http.StatusOK,
+		BodyMatch: "Default OK",
+	})
+
+	// REQUEST 2: Endpoint WITH enforced timeout (5s).
+	// Delay is 3s. Since 3s < 5s, it should SUCCEED.
+	// If the bug exists, the cached transport (2s) will kill this request, returning 504.
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/enforced",
+		Code:      http.StatusOK,
+		BodyMatch: "Enforced OK",
+	})
+}
+
 
 func TestAPILevelTimeout(t *testing.T) {
 	t.Parallel()

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"testing/synctest"
 	texttemplate "text/template"
 	"time"
 
@@ -2695,63 +2694,60 @@ func TestTimeoutPrioritization(t *testing.T) {
 		})
 	})
 }
+
 func TestTimeoutCachingBugFix(t *testing.T) {
-	t.Parallel()
+	ts := StartTest(func(c *config.Config) {
+		c.ProxyDefaultTimeout = 0.02 // Default transport timeout: 20ms
+	})
+	defer ts.Close()
 
-	synctest.Test(t, func(t *testing.T) {
-		ts := StartTest(func(c *config.Config) {
-			c.ProxyDefaultTimeout = 0.02 // Default transport timeout: 20ms
-		})
-		defer ts.Close()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/default") {
+			time.Sleep(10 * time.Millisecond)
+			_, err := w.Write([]byte("Default OK"))
+			assert.NoError(t, err)
+		} else if strings.HasPrefix(r.URL.Path, "/enforced") {
+			time.Sleep(30 * time.Millisecond) // Delay (30ms) is BETWEEN default (20ms) and enforced (50ms)
+			_, err := w.Write([]byte("Enforced OK"))
+			assert.NoError(t, err)
+		}
+	}))
+	defer upstream.Close()
 
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/default") {
-				time.Sleep(10 * time.Millisecond)
-				_, err := w.Write([]byte("Default OK"))
-				assert.NoError(t, err)
-			} else if strings.HasPrefix(r.URL.Path, "/enforced") {
-				time.Sleep(30 * time.Millisecond) // Delay (30ms) is BETWEEN default (20ms) and enforced (50ms)
-				_, err := w.Write([]byte("Enforced OK"))
-				assert.NoError(t, err)
+	api := BuildAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.Proxy.TargetURL = upstream.URL
+		spec.EnforcedTimeoutEnabled = true
+		UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
+			version.UseExtendedPaths = true
+			version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
+				{
+					Path:            "/enforced",
+					Method:          http.MethodGet,
+					TimeoutDuration: tyktime.ReadableDuration(50 * time.Millisecond), // Enforced timeout: 50ms
+				},
 			}
-		}))
-		defer upstream.Close()
-
-		api := BuildAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
-			spec.Proxy.TargetURL = upstream.URL
-			spec.EnforcedTimeoutEnabled = true
-			UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
-				version.UseExtendedPaths = true
-				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
-					{
-						Path:            "/enforced",
-						Method:          http.MethodGet,
-						TimeoutDuration: tyktime.ReadableDuration(50 * time.Millisecond), // Enforced timeout: 50ms
-					},
-				}
-			})
-		})[0]
-		ts.Gw.LoadAPI(api)
-
-		// REQUEST 1: Endpoint WITHOUT enforced timeout.
-		// This forces the creation and caching of the transport.
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/default",
-			Code:      http.StatusOK,
-			BodyMatch: "Default OK",
 		})
+	})[0]
+	ts.Gw.LoadAPI(api)
 
-		// REQUEST 2: Endpoint WITH enforced timeout (50ms).
-		// Delay is 30ms. Since 30ms < 50ms, it should SUCCEED.
-		// If the bug exists, the cached transport (20ms) will kill this request, returning 504.
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/enforced",
-			Code:      http.StatusOK,
-			BodyMatch: "Enforced OK",
-		})
+	// REQUEST 1: Endpoint WITHOUT enforced timeout.
+	// This forces the creation and caching of the transport.
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/default",
+		Code:      http.StatusOK,
+		BodyMatch: "Default OK",
+	})
+
+	// REQUEST 2: Endpoint WITH enforced timeout (50ms).
+	// Delay is 30ms. Since 30ms < 50ms, it should SUCCEED.
+	// If the bug exists, the cached transport (20ms) will kill this request, returning 504.
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/enforced",
+		Code:      http.StatusOK,
+		BodyMatch: "Enforced OK",
 	})
 }
 

--- a/internal/roundtrippers/errors.go
+++ b/internal/roundtrippers/errors.go
@@ -1,0 +1,7 @@
+package roundtrippers
+
+import "errors"
+
+var (
+	ErrHeadersTimeout = errors.New("timeout awaiting response headers")
+)

--- a/internal/roundtrippers/header_timeout.go
+++ b/internal/roundtrippers/header_timeout.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptrace"
+	"sync/atomic"
 	"time"
+
+	"github.com/TykTechnologies/tyk/internal/errors"
 )
 
 type headersTimeoutOpts struct {
@@ -24,12 +27,13 @@ func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware
 			return next
 		}
 
-		return RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+		return RoundTripperFn(func(r *http.Request) (response *http.Response, err error) {
 			ctx, cancel := context.WithCancel(r.Context())
-			defer cancel()
 
 			timer := time.NewTimer(timeout)
 			timer.Stop()
+
+			var timedOut atomic.Bool
 
 			trace := &httptrace.ClientTrace{
 				WroteRequest: func(_ httptrace.WroteRequestInfo) {
@@ -38,6 +42,7 @@ func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware
 					go func() {
 						select {
 						case <-timer.C:
+							timedOut.Store(true)
 							cancel()
 						case <-ctx.Done():
 						}
@@ -48,8 +53,17 @@ func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware
 				},
 			}
 
-			ctx = httptrace.WithClientTrace(ctx, trace)
-			return next.RoundTrip(r.WithContext(ctx))
+			response, err = invokeRtWithCancel(
+				next,
+				r.WithContext(httptrace.WithClientTrace(ctx, trace)),
+				cancel,
+			)
+
+			if err != nil && timedOut.Load() {
+				err = errors.Join(err, ErrHeadersTimeout)
+			}
+
+			return
 		})
 	}
 }

--- a/internal/roundtrippers/header_timeout.go
+++ b/internal/roundtrippers/header_timeout.go
@@ -2,7 +2,6 @@ package roundtrippers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptrace"
 	"sync"
@@ -35,8 +34,7 @@ func HeadersTimeout(timeout time.Duration) Middleware {
 			)
 
 			if err != nil && tracker.HasTimedOut() {
-				// original error is masked intentionally because of it conflicts with ErrorClassifier
-				err = fmt.Errorf("%w: %v", ErrHeadersTimeout, err)
+				err = ErrHeadersTimeout
 			}
 
 			return

--- a/internal/roundtrippers/header_timeout.go
+++ b/internal/roundtrippers/header_timeout.go
@@ -11,15 +11,16 @@ import (
 	"github.com/TykTechnologies/tyk/internal/errors"
 )
 
-type headersTimeoutOpts struct {
-	disabled bool
+type headersTimeoutOpt struct {
+	disabled   bool
+	disabledFn func(*http.Request) bool
 }
 
-type HeadersTimeoutOpt func(*headersTimeoutOpts)
+type HeadersTimeoutOpt func(*headersTimeoutOpt)
 
 func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware {
 	return func(next RoundTripper) RoundTripper {
-		opt := headersTimeoutOpts{disabled: false}
+		opt := headersTimeoutOpt{disabled: false}
 		for _, apply := range opts {
 			apply(&opt)
 		}
@@ -29,6 +30,10 @@ func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware
 		}
 
 		return RoundTripperFn(func(r *http.Request) (response *http.Response, err error) {
+			if opt.disabledFn != nil && opt.disabledFn(r) {
+				return next.RoundTrip(r)
+			}
+
 			ctx, cancel := context.WithCancel(r.Context())
 
 			// The tracker takes full ownership of the state
@@ -56,8 +61,14 @@ func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware
 }
 
 func WithHeadersTimeoutDisabled(disabled bool) HeadersTimeoutOpt {
-	return func(opts *headersTimeoutOpts) {
+	return func(opts *headersTimeoutOpt) {
 		opts.disabled = disabled
+	}
+}
+
+func WithHeadersTimeoutDisableFn(disabledFn func(*http.Request) bool) HeadersTimeoutOpt {
+	return func(opt *headersTimeoutOpt) {
+		opt.disabledFn = disabledFn
 	}
 }
 

--- a/internal/roundtrippers/header_timeout.go
+++ b/internal/roundtrippers/header_timeout.go
@@ -2,6 +2,7 @@ package roundtrippers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptrace"
 	"sync"
@@ -33,7 +34,7 @@ func HeadersTimeout(timeout time.Duration) Middleware {
 				cancel,
 			)
 
-			if err != nil && tracker.HasTimedOut() {
+			if tracker.HasTimedOut() && errors.Is(err, context.Canceled) {
 				err = ErrHeadersTimeout
 			}
 

--- a/internal/roundtrippers/header_timeout.go
+++ b/internal/roundtrippers/header_timeout.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptrace"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -30,27 +31,13 @@ func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware
 		return RoundTripperFn(func(r *http.Request) (response *http.Response, err error) {
 			ctx, cancel := context.WithCancel(r.Context())
 
-			timer := time.NewTimer(timeout)
-			timer.Stop()
-
-			var timedOut atomic.Bool
+			// The tracker takes full ownership of the state
+			tracker := newHeadersTimeoutTracker(ctx, timeout, cancel)
+			defer tracker.Stop()
 
 			trace := &httptrace.ClientTrace{
-				WroteRequest: func(_ httptrace.WroteRequestInfo) {
-					timer.Reset(timeout)
-
-					go func() {
-						select {
-						case <-timer.C:
-							timedOut.Store(true)
-							cancel()
-						case <-ctx.Done():
-						}
-					}()
-				},
-				GotFirstResponseByte: func() {
-					timer.Stop()
-				},
+				WroteRequest:         tracker.OnWroteRequest,
+				GotFirstResponseByte: tracker.OnGotFirstByte,
 			}
 
 			response, err = invokeRtWithCancel(
@@ -59,7 +46,7 @@ func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware
 				cancel,
 			)
 
-			if err != nil && timedOut.Load() {
+			if err != nil && tracker.HasTimedOut() {
 				err = errors.Join(err, ErrHeadersTimeout)
 			}
 
@@ -72,4 +59,65 @@ func WithHeadersTimeoutDisabled(disabled bool) HeadersTimeoutOpt {
 	return func(opts *headersTimeoutOpts) {
 		opts.disabled = disabled
 	}
+}
+
+// headersTimeoutTracker encapsulates state and synchronization for the headers timeout.
+type headersTimeoutTracker struct {
+	mu       sync.Mutex
+	timer    *time.Timer
+	timedOut atomic.Bool
+
+	ctx     context.Context
+	timeout time.Duration
+	cancel  context.CancelFunc
+}
+
+// newHeadersTimeoutTracker is a factory initializing the tracker's state.
+func newHeadersTimeoutTracker(
+	ctx context.Context,
+	timeout time.Duration,
+	cancel context.CancelFunc,
+) *headersTimeoutTracker {
+
+	return &headersTimeoutTracker{
+		ctx:     ctx,
+		timeout: timeout,
+		cancel:  cancel,
+	}
+}
+
+// OnWroteRequest matches the httptrace.WroteRequest signature.
+func (t *headersTimeoutTracker) OnWroteRequest(_ httptrace.WroteRequestInfo) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// If the request was already canceled (e.g., lower-level error), ignore the timer.
+	if t.ctx.Err() != nil {
+		return
+	}
+
+	t.timer = time.AfterFunc(t.timeout, func() {
+		t.timedOut.Store(true)
+		t.cancel()
+	})
+}
+
+// OnGotFirstByte matches the httptrace.GotFirstResponseByte signature.
+func (t *headersTimeoutTracker) OnGotFirstByte() {
+	t.Stop()
+}
+
+// Stop unconditionally stops the timer and prevents leaks.
+func (t *headersTimeoutTracker) Stop() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.timer != nil {
+		t.timer.Stop()
+	}
+}
+
+// HasTimedOut returns whether the timeout actually triggered.
+func (t *headersTimeoutTracker) HasTimedOut() bool {
+	return t.timedOut.Load()
 }

--- a/internal/roundtrippers/header_timeout.go
+++ b/internal/roundtrippers/header_timeout.go
@@ -1,0 +1,61 @@
+package roundtrippers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptrace"
+	"time"
+)
+
+type headersTimeoutOpts struct {
+	disabled bool
+}
+
+type HeadersTimeoutOpt func(*headersTimeoutOpts)
+
+func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware {
+	return func(next RoundTripper) RoundTripper {
+		opt := headersTimeoutOpts{disabled: false}
+		for _, apply := range opts {
+			apply(&opt)
+		}
+
+		if timeout == 0 || opt.disabled {
+			return next
+		}
+
+		return RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			ctx, cancel := context.WithCancel(r.Context())
+			defer cancel()
+
+			timer := time.NewTimer(timeout)
+			timer.Stop()
+
+			trace := &httptrace.ClientTrace{
+				WroteRequest: func(_ httptrace.WroteRequestInfo) {
+					timer.Reset(timeout)
+
+					go func() {
+						select {
+						case <-timer.C:
+							cancel()
+						case <-ctx.Done():
+						}
+					}()
+				},
+				GotFirstResponseByte: func() {
+					timer.Stop()
+				},
+			}
+
+			ctx = httptrace.WithClientTrace(ctx, trace)
+			return next.RoundTrip(r.WithContext(ctx))
+		})
+	}
+}
+
+func WithHeadersTimeoutDisabled(disabled bool) HeadersTimeoutOpt {
+	return func(opts *headersTimeoutOpts) {
+		opts.disabled = disabled
+	}
+}

--- a/internal/roundtrippers/header_timeout.go
+++ b/internal/roundtrippers/header_timeout.go
@@ -79,6 +79,11 @@ func (t *headersTimeoutTracker) OnWroteRequest(_ httptrace.WroteRequestInfo) {
 		return
 	}
 
+	// Ignore secondary timer initialization
+	if t.timer != nil {
+		return
+	}
+
 	t.timer = time.AfterFunc(t.timeout, func() {
 		t.timedOut.Store(true)
 		t.cancel()

--- a/internal/roundtrippers/header_timeout.go
+++ b/internal/roundtrippers/header_timeout.go
@@ -2,13 +2,12 @@ package roundtrippers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptrace"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/TykTechnologies/tyk/internal/errors"
 )
 
 func HeadersTimeout(timeout time.Duration) Middleware {
@@ -36,7 +35,8 @@ func HeadersTimeout(timeout time.Duration) Middleware {
 			)
 
 			if err != nil && tracker.HasTimedOut() {
-				err = errors.Join(err, ErrHeadersTimeout)
+				// original error is masked intentionally because of it conflicts with ErrorClassifier
+				err = fmt.Errorf("%w: %v", ErrHeadersTimeout, err)
 			}
 
 			return

--- a/internal/roundtrippers/header_timeout.go
+++ b/internal/roundtrippers/header_timeout.go
@@ -11,29 +11,13 @@ import (
 	"github.com/TykTechnologies/tyk/internal/errors"
 )
 
-type headersTimeoutOpt struct {
-	disabled   bool
-	disabledFn func(*http.Request) bool
-}
-
-type HeadersTimeoutOpt func(*headersTimeoutOpt)
-
-func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware {
+func HeadersTimeout(timeout time.Duration) Middleware {
 	return func(next RoundTripper) RoundTripper {
-		opt := headersTimeoutOpt{disabled: false}
-		for _, apply := range opts {
-			apply(&opt)
-		}
-
-		if timeout == 0 || opt.disabled {
+		if timeout == 0 {
 			return next
 		}
 
 		return RoundTripperFn(func(r *http.Request) (response *http.Response, err error) {
-			if opt.disabledFn != nil && opt.disabledFn(r) {
-				return next.RoundTrip(r)
-			}
-
 			ctx, cancel := context.WithCancel(r.Context())
 
 			// The tracker takes full ownership of the state
@@ -57,18 +41,6 @@ func HeadersTimeout(timeout time.Duration, opts ...HeadersTimeoutOpt) Middleware
 
 			return
 		})
-	}
-}
-
-func WithHeadersTimeoutDisabled(disabled bool) HeadersTimeoutOpt {
-	return func(opts *headersTimeoutOpt) {
-		opts.disabled = disabled
-	}
-}
-
-func WithHeadersTimeoutDisableFn(disabledFn func(*http.Request) bool) HeadersTimeoutOpt {
-	return func(opt *headersTimeoutOpt) {
-		opt.disabledFn = disabledFn
 	}
 }
 

--- a/internal/roundtrippers/header_timeout_test.go
+++ b/internal/roundtrippers/header_timeout_test.go
@@ -37,7 +37,7 @@ func TestHeadersTimeout(t *testing.T) {
 
 		_, err := rt.RoundTrip(req)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, context.Canceled)
+		assert.ErrorContains(t, err, context.Canceled.Error())
 	})
 
 	t.Run("timeout is not applied when headers arrive in time", func(t *testing.T) {

--- a/internal/roundtrippers/header_timeout_test.go
+++ b/internal/roundtrippers/header_timeout_test.go
@@ -20,7 +20,7 @@ func TestHeadersTimeout(t *testing.T) {
 		next := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
 			trace := httptrace.ContextClientTrace(r.Context())
 			require.NotNil(t, trace)
-			
+
 			// Simulate writing request
 			if trace.WroteRequest != nil {
 				trace.WroteRequest(httptrace.WroteRequestInfo{})
@@ -28,16 +28,16 @@ func TestHeadersTimeout(t *testing.T) {
 
 			// Wait longer than timeout
 			time.Sleep(20 * time.Millisecond)
-			
+
 			return nil, r.Context().Err()
 		})
 
 		rt := mw(next)
 		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-		
+
 		_, err := rt.RoundTrip(req)
 		require.Error(t, err)
-		assert.Equal(t, context.Canceled, err)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("timeout is not applied when headers arrive in time", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestHeadersTimeout(t *testing.T) {
 		next := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
 			trace := httptrace.ContextClientTrace(r.Context())
 			require.NotNil(t, trace)
-			
+
 			// Simulate writing request
 			if trace.WroteRequest != nil {
 				trace.WroteRequest(httptrace.WroteRequestInfo{})
@@ -60,13 +60,13 @@ func TestHeadersTimeout(t *testing.T) {
 
 			// Wait longer than timeout to ensure it was cancelled
 			time.Sleep(60 * time.Millisecond)
-			
+
 			return &http.Response{StatusCode: http.StatusOK}, r.Context().Err()
 		})
 
 		rt := mw(next)
 		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-		
+
 		res, err := rt.RoundTrip(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
@@ -84,7 +84,7 @@ func TestHeadersTimeout(t *testing.T) {
 
 		rt := mw(next)
 		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-		
+
 		res, err := rt.RoundTrip(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)

--- a/internal/roundtrippers/header_timeout_test.go
+++ b/internal/roundtrippers/header_timeout_test.go
@@ -1,7 +1,6 @@
 package roundtrippers
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
@@ -37,7 +36,7 @@ func TestHeadersTimeout(t *testing.T) {
 
 		_, err := rt.RoundTrip(req)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, context.Canceled.Error())
+		assert.ErrorIs(t, err, ErrHeadersTimeout)
 	})
 
 	t.Run("timeout is not applied when headers arrive in time", func(t *testing.T) {

--- a/internal/roundtrippers/header_timeout_test.go
+++ b/internal/roundtrippers/header_timeout_test.go
@@ -71,22 +71,4 @@ func TestHeadersTimeout(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
 	})
-
-	t.Run("timeout is disabled", func(t *testing.T) {
-		timeout := 10 * time.Millisecond
-		mw := HeadersTimeout(timeout, WithHeadersTimeoutDisabled(true))
-
-		next := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
-			trace := httptrace.ContextClientTrace(r.Context())
-			assert.Nil(t, trace) // Trace shouldn't be injected if disabled
-			return &http.Response{StatusCode: http.StatusOK}, nil
-		})
-
-		rt := mw(next)
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
-
-		res, err := rt.RoundTrip(req)
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, res.StatusCode)
-	})
 }

--- a/internal/roundtrippers/header_timeout_test.go
+++ b/internal/roundtrippers/header_timeout_test.go
@@ -1,0 +1,92 @@
+package roundtrippers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadersTimeout(t *testing.T) {
+	t.Run("timeout is applied when headers take too long", func(t *testing.T) {
+		timeout := 10 * time.Millisecond
+		mw := HeadersTimeout(timeout)
+
+		next := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			trace := httptrace.ContextClientTrace(r.Context())
+			require.NotNil(t, trace)
+			
+			// Simulate writing request
+			if trace.WroteRequest != nil {
+				trace.WroteRequest(httptrace.WroteRequestInfo{})
+			}
+
+			// Wait longer than timeout
+			time.Sleep(20 * time.Millisecond)
+			
+			return nil, r.Context().Err()
+		})
+
+		rt := mw(next)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		
+		_, err := rt.RoundTrip(req)
+		require.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("timeout is not applied when headers arrive in time", func(t *testing.T) {
+		timeout := 50 * time.Millisecond
+		mw := HeadersTimeout(timeout)
+
+		next := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			trace := httptrace.ContextClientTrace(r.Context())
+			require.NotNil(t, trace)
+			
+			// Simulate writing request
+			if trace.WroteRequest != nil {
+				trace.WroteRequest(httptrace.WroteRequestInfo{})
+			}
+
+			// Simulate getting first byte before timeout
+			if trace.GotFirstResponseByte != nil {
+				trace.GotFirstResponseByte()
+			}
+
+			// Wait longer than timeout to ensure it was cancelled
+			time.Sleep(60 * time.Millisecond)
+			
+			return &http.Response{StatusCode: http.StatusOK}, r.Context().Err()
+		})
+
+		rt := mw(next)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("timeout is disabled", func(t *testing.T) {
+		timeout := 10 * time.Millisecond
+		mw := HeadersTimeout(timeout, WithHeadersTimeoutDisabled(true))
+
+		next := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			trace := httptrace.ContextClientTrace(r.Context())
+			assert.Nil(t, trace) // Trace shouldn't be injected if disabled
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		})
+
+		rt := mw(next)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+}

--- a/internal/roundtrippers/header_timeout_test.go
+++ b/internal/roundtrippers/header_timeout_test.go
@@ -33,7 +33,7 @@ func TestHeadersTimeout(t *testing.T) {
 		})
 
 		rt := mw(next)
-		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
 
 		_, err := rt.RoundTrip(req)
 		require.Error(t, err)
@@ -65,7 +65,7 @@ func TestHeadersTimeout(t *testing.T) {
 		})
 
 		rt := mw(next)
-		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
 
 		res, err := rt.RoundTrip(req)
 		require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestHeadersTimeout(t *testing.T) {
 		})
 
 		rt := mw(next)
-		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
 
 		res, err := rt.RoundTrip(req)
 		require.NoError(t, err)

--- a/internal/roundtrippers/roundtrippers.go
+++ b/internal/roundtrippers/roundtrippers.go
@@ -1,0 +1,26 @@
+package roundtrippers
+
+import (
+	"net/http"
+	"slices"
+)
+
+type RoundTripper = http.RoundTripper
+type Middleware func(next RoundTripper) RoundTripper
+
+func Combine(init RoundTripper, middlewares ...Middleware) RoundTripper {
+	for _, mw := range slices.Backward(middlewares) {
+		if mw == nil {
+			continue
+		}
+		init = mw(init)
+	}
+
+	return init
+}
+
+type RoundTripperFn func(*http.Request) (*http.Response, error)
+
+func (rt RoundTripperFn) RoundTrip(request *http.Request) (*http.Response, error) {
+	return rt(request)
+}

--- a/internal/roundtrippers/roundtrippers.go
+++ b/internal/roundtrippers/roundtrippers.go
@@ -39,7 +39,6 @@ func (c *cancelReadCloser) Close() error {
 	}
 	return nil
 }
-
 func invokeRtWithCancel(
 	rt RoundTripper,
 	req *http.Request,
@@ -65,10 +64,30 @@ func invokeRtWithCancel(
 		return
 	}
 
-	response.Body = &cancelReadCloser{
-		ReadCloser: response.Body,
-		cancel:     cancel,
+	if rwc, ok := response.Body.(io.ReadWriteCloser); ok {
+		response.Body = &cancelReadWriteCloser{
+			ReadWriteCloser: rwc,
+			cancel:          cancel,
+		}
+	} else {
+		response.Body = &cancelReadCloser{
+			ReadCloser: response.Body,
+			cancel:     cancel,
+		}
 	}
 
 	return
+}
+
+type cancelReadWriteCloser struct {
+	io.ReadWriteCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelReadWriteCloser) Close() error {
+	c.cancel()
+	if c.ReadWriteCloser != nil {
+		return c.ReadWriteCloser.Close()
+	}
+	return nil
 }

--- a/internal/roundtrippers/roundtrippers.go
+++ b/internal/roundtrippers/roundtrippers.go
@@ -39,6 +39,20 @@ func (c *cancelReadCloser) Close() error {
 	}
 	return nil
 }
+
+type cancelReadWriteCloser struct {
+	io.ReadWriteCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelReadWriteCloser) Close() error {
+	c.cancel()
+	if c.ReadWriteCloser != nil {
+		return c.ReadWriteCloser.Close()
+	}
+	return nil
+}
+
 func invokeRtWithCancel(
 	rt RoundTripper,
 	req *http.Request,
@@ -77,17 +91,4 @@ func invokeRtWithCancel(
 	}
 
 	return
-}
-
-type cancelReadWriteCloser struct {
-	io.ReadWriteCloser
-	cancel context.CancelFunc
-}
-
-func (c *cancelReadWriteCloser) Close() error {
-	c.cancel()
-	if c.ReadWriteCloser != nil {
-		return c.ReadWriteCloser.Close()
-	}
-	return nil
 }

--- a/internal/roundtrippers/roundtrippers.go
+++ b/internal/roundtrippers/roundtrippers.go
@@ -1,6 +1,8 @@
 package roundtrippers
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"slices"
 )
@@ -23,4 +25,49 @@ type RoundTripperFn func(*http.Request) (*http.Response, error)
 
 func (rt RoundTripperFn) RoundTrip(request *http.Request) (*http.Response, error) {
 	return rt(request)
+}
+
+type cancelReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelReadCloser) Close() error {
+	c.cancel()
+	if c.ReadCloser != nil {
+		return c.ReadCloser.Close()
+	}
+	return nil
+}
+
+func invokeRtWithCancel(
+	rt RoundTripper,
+	req *http.Request,
+	cancel context.CancelFunc,
+) (response *http.Response, err error) {
+	defer func() {
+		if err := recover(); err != nil {
+			cancel()
+			panic(err)
+		}
+	}()
+
+	response, err = rt.RoundTrip(req)
+
+	if err != nil {
+		cancel()
+		return
+	}
+
+	if response == nil || response.Body == nil {
+		cancel()
+		return
+	}
+
+	response.Body = &cancelReadCloser{
+		ReadCloser: response.Body,
+		cancel:     cancel,
+	}
+
+	return
 }

--- a/internal/roundtrippers/roundtrippers.go
+++ b/internal/roundtrippers/roundtrippers.go
@@ -45,6 +45,7 @@ func invokeRtWithCancel(
 	req *http.Request,
 	cancel context.CancelFunc,
 ) (response *http.Response, err error) {
+
 	defer func() {
 		if err := recover(); err != nil {
 			cancel()

--- a/internal/roundtrippers/roundtrippers_test.go
+++ b/internal/roundtrippers/roundtrippers_test.go
@@ -1,0 +1,71 @@
+package roundtrippers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCombine(t *testing.T) {
+	t.Run("combines middlewares in correct order", func(t *testing.T) {
+		var order []string
+
+		mw1 := func(next RoundTripper) RoundTripper {
+			return RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+				order = append(order, "mw1-before")
+				res, err := next.RoundTrip(r)
+				order = append(order, "mw1-after")
+				return res, err
+			})
+		}
+
+		mw2 := func(next RoundTripper) RoundTripper {
+			return RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+				order = append(order, "mw2-before")
+				res, err := next.RoundTrip(r)
+				order = append(order, "mw2-after")
+				return res, err
+			})
+		}
+
+		init := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			order = append(order, "init")
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		})
+
+		rt := Combine(init, mw1, mw2)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		expectedOrder := []string{"mw1-before", "mw2-before", "init", "mw2-after", "mw1-after"}
+		assert.Equal(t, expectedOrder, order)
+	})
+
+	t.Run("ignores nil middlewares", func(t *testing.T) {
+		var called bool
+		mw1 := func(next RoundTripper) RoundTripper {
+			return RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+				called = true
+				return next.RoundTrip(r)
+			})
+		}
+
+		init := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		})
+
+		rt := Combine(init, nil, mw1, nil)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		assert.True(t, called)
+	})
+}

--- a/internal/roundtrippers/roundtrippers_test.go
+++ b/internal/roundtrippers/roundtrippers_test.go
@@ -31,14 +31,14 @@ func TestCombine(t *testing.T) {
 			})
 		}
 
-		init := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+		init := RoundTripperFn(func(_ *http.Request) (*http.Response, error) {
 			order = append(order, "init")
 			return &http.Response{StatusCode: http.StatusOK}, nil
 		})
 
 		rt := Combine(init, mw1, mw2)
-		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-		
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
+
 		res, err := rt.RoundTrip(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
@@ -56,13 +56,13 @@ func TestCombine(t *testing.T) {
 			})
 		}
 
-		init := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+		init := RoundTripperFn(func(_ *http.Request) (*http.Response, error) {
 			return &http.Response{StatusCode: http.StatusOK}, nil
 		})
 
 		rt := Combine(init, nil, mw1, nil)
-		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-		
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
+
 		res, err := rt.RoundTrip(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)

--- a/internal/roundtrippers/skip_if.go
+++ b/internal/roundtrippers/skip_if.go
@@ -1,0 +1,8 @@
+package roundtrippers
+
+func SkipIf(mw Middleware, skip bool) Middleware {
+	if skip {
+		return nil
+	}
+	return mw
+}

--- a/internal/roundtrippers/timeout.go
+++ b/internal/roundtrippers/timeout.go
@@ -6,43 +6,15 @@ import (
 	"time"
 )
 
-type timeoutOpt struct {
-	disabled   bool
-	disabledFn func(*http.Request) bool
-}
-
-type TimeoutOpt func(*timeoutOpt)
-
-func Timeout(timeout time.Duration, opts ...TimeoutOpt) Middleware {
+func Timeout(timeout time.Duration) Middleware {
 	return func(next RoundTripper) RoundTripper {
-		opt := timeoutOpt{disabled: false}
-		for _, apply := range opts {
-			apply(&opt)
-		}
-
-		if timeout == 0 || opt.disabled {
+		if timeout == 0 {
 			return next
 		}
 
 		return RoundTripperFn(func(r *http.Request) (*http.Response, error) {
-			if opt.disabledFn != nil && opt.disabledFn(r) {
-				return next.RoundTrip(r)
-			}
-
 			ctx, cancel := context.WithTimeout(r.Context(), timeout)
 			return invokeRtWithCancel(next, r.WithContext(ctx), cancel)
 		})
-	}
-}
-
-func WithTimeoutDisable(disabled bool) TimeoutOpt {
-	return func(opt *timeoutOpt) {
-		opt.disabled = disabled
-	}
-}
-
-func WithTimeoutDisableFn(disabledFn func(*http.Request) bool) TimeoutOpt {
-	return func(opt *timeoutOpt) {
-		opt.disabledFn = disabledFn
 	}
 }

--- a/internal/roundtrippers/timeout.go
+++ b/internal/roundtrippers/timeout.go
@@ -1,0 +1,21 @@
+package roundtrippers
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+func Timeout(timeout time.Duration) Middleware {
+	return func(next RoundTripper) RoundTripper {
+		if timeout == 0 {
+			return next
+		}
+
+		return RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			ctx, cancel := context.WithTimeout(r.Context(), timeout)
+			defer cancel()
+			return next.RoundTrip(r.WithContext(ctx))
+		})
+	}
+}

--- a/internal/roundtrippers/timeout.go
+++ b/internal/roundtrippers/timeout.go
@@ -6,15 +6,43 @@ import (
 	"time"
 )
 
-func Timeout(timeout time.Duration) Middleware {
+type timeoutOpt struct {
+	disabled   bool
+	disabledFn func(*http.Request) bool
+}
+
+type TimeoutOpt func(*timeoutOpt)
+
+func Timeout(timeout time.Duration, opts ...TimeoutOpt) Middleware {
 	return func(next RoundTripper) RoundTripper {
-		if timeout == 0 {
+		opt := timeoutOpt{disabled: false}
+		for _, apply := range opts {
+			apply(&opt)
+		}
+
+		if timeout == 0 || opt.disabled {
 			return next
 		}
 
 		return RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			if opt.disabledFn != nil && opt.disabledFn(r) {
+				return next.RoundTrip(r)
+			}
+
 			ctx, cancel := context.WithTimeout(r.Context(), timeout)
 			return invokeRtWithCancel(next, r.WithContext(ctx), cancel)
 		})
+	}
+}
+
+func WithTimeoutDisable(disabled bool) TimeoutOpt {
+	return func(opt *timeoutOpt) {
+		opt.disabled = disabled
+	}
+}
+
+func WithTimeoutDisableFn(disabledFn func(*http.Request) bool) TimeoutOpt {
+	return func(opt *timeoutOpt) {
+		opt.disabledFn = disabledFn
 	}
 }

--- a/internal/roundtrippers/timeout.go
+++ b/internal/roundtrippers/timeout.go
@@ -14,8 +14,7 @@ func Timeout(timeout time.Duration) Middleware {
 
 		return RoundTripperFn(func(r *http.Request) (*http.Response, error) {
 			ctx, cancel := context.WithTimeout(r.Context(), timeout)
-			defer cancel()
-			return next.RoundTrip(r.WithContext(ctx))
+			return invokeRtWithCancel(next, r.WithContext(ctx), cancel)
 		})
 	}
 }

--- a/internal/roundtrippers/timeout_test.go
+++ b/internal/roundtrippers/timeout_test.go
@@ -1,0 +1,50 @@
+package roundtrippers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeout(t *testing.T) {
+	t.Run("timeout is applied", func(t *testing.T) {
+		timeout := 10 * time.Millisecond
+		mw := Timeout(timeout)
+
+		var ctx context.Context
+		next := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			ctx = r.Context()
+			time.Sleep(20 * time.Millisecond)
+			return nil, ctx.Err()
+		})
+
+		rt := mw(next)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		
+		_, err := rt.RoundTrip(req)
+		require.Error(t, err)
+		assert.Equal(t, context.DeadlineExceeded, err)
+	})
+
+	t.Run("timeout is not applied when 0", func(t *testing.T) {
+		mw := Timeout(0)
+
+		next := RoundTripperFn(func(r *http.Request) (*http.Response, error) {
+			_, ok := r.Context().Deadline()
+			assert.False(t, ok)
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		})
+
+		rt := mw(next)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+}

--- a/internal/roundtrippers/timeout_test.go
+++ b/internal/roundtrippers/timeout_test.go
@@ -24,8 +24,8 @@ func TestTimeout(t *testing.T) {
 		})
 
 		rt := mw(next)
-		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-		
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
+
 		_, err := rt.RoundTrip(req)
 		require.Error(t, err)
 		assert.Equal(t, context.DeadlineExceeded, err)
@@ -41,8 +41,8 @@ func TestTimeout(t *testing.T) {
 		})
 
 		rt := mw(next)
-		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-		
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
+
 		res, err := rt.RoundTrip(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)


### PR DESCRIPTION
## Problem / Task
Added unit tests for the `internal/roundtrippers` package and an integration test in `gateway/reverse_proxy_test.go` to verify correct timeout inheritance.

## Changes
- Added `internal/roundtrippers/timeout_test.go`
- Added `internal/roundtrippers/header_timeout_test.go`
- Added `internal/roundtrippers/roundtrippers_test.go`
- Added `TestTimeoutCachingBugFix` in `gateway/reverse_proxy_test.go`

## Testing
- Ran unit tests for `internal/roundtrippers`
- Verified integration test logic for `TestTimeoutCachingBugFix`

---
## Technical Solution (What was done)

1. Decoupled Timeouts from Shared Transport: 
   We stopped setting ResponseHeaderTimeout directly on the shared http.Transport. This eliminates the cache poisoning issue and ensures that the transport can be safely shared across endpoints with different timeout requirements.

2. Introduced RoundTripper Middleware Pattern (Splitting the Base RoundTripper): 
   We refactored the monolithic TykRoundTripper pipeline into a clean chain of responsibility (middlewares) using a decorator pattern. We split the timeout logic into separate middlewares:
   • Timeout Middleware: Manages the total request lifecycle timeout using context.WithTimeout.
   • HeadersTimeout Middleware: Manages the Time-To-First-Byte (TTFB) / header timeout.

   Justification (Why we did it this way): Without splitting the base RoundTripper into separate middlewares, it would be impossible to achieve local, per-request disabling of the HeaderTimeout. The standard Go http.Transport shares the ResponseHeaderTimeout across the entire connection pool. By extracting this logic into a dynamic middleware, we can now evaluate conditions on the fly without affecting other requests sharing the same transport.

3. Dynamic Middleware Disabling for Internal Loops:
   We introduced conditional execution for middlewares (e.g., WithHeadersTimeoutDisabledFn(isInternalLoop)). This dynamically disables the HeadersTimeout for Tyk's internal loopback requests (tyk:// and tyk-internal://), preventing false 500 errors caused by premature context cancellation during in-memory GraphQL queries.

4. Thread-Safe Header Timeout Tracking: 
   Implemented a headersTimeoutTracker using time.AfterFunc (instead of goroutines with select) and atomic flags. It hooks into httptrace.ClientTrace (WroteRequest, GotFirstResponseByte) to accurately measure header timeouts without leaking goroutines.

5. Safe Resource Cleanup & Streaming Support: 
   • Added proper panic recovery (invokeRtWithCancel) to prevent resource leaks.
   • Fixed premature context cancellation that broke streaming (SSE, gRPC, GraphQL) by wrapping the response body in a custom ReadWriteCloser. The context is now safely canceled only when the body is explicitly closed.

6. Final Transport as a Simple Selector:
   The original TykRoundTripper at the end of the pipeline was stripped down to its core responsibility: simply routing the request to either the standard http.Transport or h2ctransport (used for HTTP/2 Cleartext / gRPC).

7. Testing & Documentation: 
   • Added comprehensive unit tests for the new RoundTripper middlewares.
   • Added an integration test (TestTimeoutCachingBugFix) to verify that timeout inheritance works correctly and the caching bug is resolved.
   • Added inline code comments explaining why ResponseHeaderTimeout must not be set on the shared transport to prevent future regressions.


---
Requested by: U08QWRUM11Q
Slack thread: https://tyktech.slack.com/archives/D0AF7G82CSV/p1787221640049799






















<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17873" title="TT-17873" target="_blank">TT-17873</a>
</summary>

|         |    |
|---------|----|
| Status  | Ready for Testing |
| Summary | [regression] Enforced Timeout endpoint middleware not working as expected  |

Generated at: 2026-08-28 08:38:02

</details>

<!---TykTechnologies/jira-linter ends here-->





















