### PR TITLE
[TT-17981] docs: add a testing section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Compile from Source
 git clone https://github.com/TykTechnologies/tyk
 go build
 ```
-Go version 1.22 is required to build `master`, the current development version. Tyk is officially supported on `Linux/amd64`, `Linux/i386` and `Linux/arm64`.
+Go version 1.26 is required to build `master`, the current development version. Tyk is officially supported on `Linux/amd64`, `Linux/i386` and `Linux/arm64`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -183,13 +183,85 @@ go build
 ```
 Go version 1.22 is required to build `master`, the current development version. Tyk is officially supported on `Linux/amd64`, `Linux/i386` and `Linux/arm64`.
 
-To run tests locally use the following command:
-```console
-go test ./...
-```
-Note that tests require Redis to be running on the same machine (default port).
+## Testing
 
-To write your own test please use this guide [https://github.com/TykTechnologies/tyk/blob/master/TESTING.md](https://github.com/TykTechnologies/tyk/blob/master/TESTING.md)
+### Prerequisites
+
+The test suite needs a Redis instance and an HTTP echo server. The repository ships a Compose file that provides both:
+
+```console
+docker compose up -d redis httpbin
+```
+
+Compose creates the required network, publishes Redis on port 6379 and httpbin on port 3123. If either port is already in use, stop the conflicting service before you start the containers.
+
+Tear the services down when you finish:
+
+```console
+docker compose down
+```
+
+### Running the tests
+
+If you have [Task](https://taskfile.dev/) installed, run the whole suite with:
+
+```console
+task test:integration
+```
+
+Task starts and stops the services for you, detects your local Python version, and applies the flags described below.
+
+To run the tests directly with `go` instead:
+
+```console
+CI=true go test -count=1 -p 1 ./...
+```
+
+| Setting | Why you need it |
+| --- | --- |
+| `CI=true` | Skips tests that the codebase marks as unreliable outside CI. |
+| `-count=1` | Disables the test cache. Without it, Go reports cached results from earlier runs and only changed packages actually execute. |
+| `-p 1` | Runs one package at a time. Each package starts its own gateway against the same Redis, and running them concurrently can exhaust the connection pool. |
+
+### Python plugin tests
+
+The `dlpython` and `coprocess/python` packages load the Python C API at runtime, so they need a `python3-config` binary on your `PATH`. On most systems this comes from your Python development package.
+
+The `dlpython` tests look for Python 3.5 unless you tell them otherwise, and fail with `Couldn't find Python 3.5` on newer installations. Set `PYTHON_VERSION` to the version you have:
+
+```console
+PYTHON_VERSION=3.12 CI=true go test -count=1 ./dlpython/...
+```
+
+`task test:integration` sets this for you from your local `python3`.
+
+The `coprocess/python` package runs Python middleware end to end, so it needs a working Python plugin environment rather than just a matching version. Set the version the gateway uses through the `python_version` config field.
+
+### Troubleshooting
+
+**`panic: can't connect to redis, timeout`**
+
+The gateway allows two seconds to reach Redis. Running many packages at once, or a Redis that blocks on disk writes, can exceed that. Run with `-p 1` first.
+
+If the panic continues, disable append-only persistence on the test Redis. Test data is disposable, so you lose nothing by trading durability for steadier connections. Create a `docker-compose.override.yml` file:
+
+```yaml
+services:
+  redis:
+    command: redis-server --appendonly no
+```
+
+**The suite finishes far faster than expected**
+
+Go is serving cached results. Add `-count=1`.
+
+**`Bind for 0.0.0.0:6379 failed: port is already allocated`**
+
+Another Redis already holds the port. Stop it, or remove the leftover container with `docker rm -f <name>`.
+
+### Writing tests
+
+To write your own tests, see the [testing guide](https://github.com/TykTechnologies/tyk/blob/master/TESTING.md).
 
 ## Contributing
 


### PR DESCRIPTION
## What

The README currently covers running tests in two lines, tucked inside the compiling section:

> To run tests locally use the following command: `go test ./...`
> Note that tests require Redis to be running on the same machine (default port).

That is not enough to get a clean run. Following it produces failures that look like real test failures but are actually setup gaps. This PR moves testing into its own `## Testing` section and fills in what was missing.

## Why

Running the suite from the README as written, the following bite you and none of them are documented:

- **Go's test cache hides most of the run.** Without `-count=1`, the majority of packages report cached results and never execute. It looks like a full pass.
- **`-p 1` matters.** Each package starts its own gateway against the same Redis. Run them concurrently and you can blow the gateway's two-second connect timeout, which surfaces as `panic: can't connect to redis, timeout` rather than anything test-related.
- **`dlpython` looks for Python 3.5.** On any modern Python it fails with `Couldn't find Python 3.5`. `PYTHON_VERSION` fixes it, but that is not mentioned anywhere.
- **httpbin is needed too**, not just Redis.
- **`task test:integration` already does all of this** and is only mentioned in CONTRIBUTING.md.

## Notes

- Uses Docker Compose throughout rather than raw `docker run`, so the instructions work the same on any platform and Compose handles the network.
- The AOF workaround is written as a troubleshooting step rather than blanket advice. The committed `redis.yml` uses `--appendonly yes` and CI passes with it, so this looks specific to local disks under load.
- Kept the existing link to TESTING.md for writing tests.

## Out of scope

The compiling section still says Go 1.22 is required. `go.mod` is on 1.26.5. Left alone here to keep this diff to the testing content, but worth a follow-up.



<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17981" title="TT-17981" target="_blank">TT-17981</a>
</summary>

|         |    |
|---------|----|
| Status  | Closed |
| Summary | Update README.md / docs about testing our Open Source Core Components |

Generated at: 2026-09-02 06:14:50

</details>

<!---TykTechnologies/jira-linter ends here-->



