### PR TITLE
[TT-18136] Tolerate stale MCP selectors on catalogue reads

### DIFF
--- a/apidef/oas/mcp_proxy_derive.go
+++ b/apidef/oas/mcp_proxy_derive.go
@@ -1207,6 +1207,17 @@ func buildMCPToolViewWithMode(canonical []DerivedTool, config *TykMCPServer, str
 // ExpandMCPServerConfig builds a full configurable primitive catalogue from a
 // source REST OAS and a compact proxy-side x-tyk-mcp-server extension.
 func ExpandMCPServerConfig(srcOAS *OAS, config *TykMCPServer) (*TykMCPServer, []DeriveWarning, error) {
+	return expandMCPServerConfig(srcOAS, config, true)
+}
+
+// ExpandMCPServerConfigTolerant builds a full configurable primitive catalogue
+// while skipping configured primitive sources that are no longer present in the
+// source catalogue. It is intended for derived views of saved proxy definitions.
+func ExpandMCPServerConfigTolerant(srcOAS *OAS, config *TykMCPServer) (*TykMCPServer, []DeriveWarning, error) {
+	return expandMCPServerConfig(srcOAS, config, false)
+}
+
+func expandMCPServerConfig(srcOAS *OAS, config *TykMCPServer, strict bool) (*TykMCPServer, []DeriveWarning, error) {
 	primitives, warnings, err := DeriveSourcePrimitives(srcOAS)
 	if err != nil {
 		return nil, warnings, err
@@ -1214,7 +1225,7 @@ func ExpandMCPServerConfig(srcOAS *OAS, config *TykMCPServer) (*TykMCPServer, []
 
 	tools := ToolPrimitives(primitives)
 	catalogue := newMCPToolViewCatalogue(tools)
-	selection, viewWarnings, err := buildMCPToolViewSelection(config, catalogue, true)
+	selection, viewWarnings, err := buildMCPToolViewSelection(config, catalogue, strict)
 	warnings = append(warnings, viewWarnings...)
 	if err != nil {
 		return nil, warnings, err

--- a/apidef/oas/mcp_server_test.go
+++ b/apidef/oas/mcp_server_test.go
@@ -573,6 +573,68 @@ func TestExpandMCPServerConfig_PartialSelectionIncludesUnselectedPrimitives(t *t
 	assert.False(t, *deleteOrder.Allow)
 }
 
+func TestExpandMCPServerConfigTolerant_StalePrimitiveSource(t *testing.T) {
+	t.Parallel()
+
+	src := newDeriveTestOAS(openapi3.NewPaths(
+		openapi3.WithPath("/orders", &openapi3.PathItem{
+			Get:  &openapi3.Operation{OperationID: "list_orders"},
+			Post: &openapi3.Operation{OperationID: "create_order"},
+		}),
+	))
+	config := &TykMCPServer{
+		Primitives: []TykMCPServerPrimitive{
+			{Source: TykMCPServerSource{OperationID: "list_orders"}, Name: "orders", Allow: boolPtr(true)},
+			{Source: TykMCPServerSource{OperationID: "deleted_order"}, Name: "stale_orders", Allow: boolPtr(true)},
+		},
+	}
+
+	expanded, warnings, err := ExpandMCPServerConfigTolerant(src, config)
+
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "operationId:deleted_order", warnings[0].Source)
+	assert.Equal(t, "stale_orders", warnings[0].ToolName)
+	assert.Equal(t, warningMCPServerStaleSource, warnings[0].Reason)
+	require.Len(t, expanded.Primitives, 2)
+
+	orders := primitiveByName(expanded.Primitives, "orders")
+	require.NotNil(t, orders)
+	require.NotNil(t, orders.Allow)
+	assert.True(t, *orders.Allow)
+
+	createOrder := primitiveByName(expanded.Primitives, "create_order")
+	require.NotNil(t, createOrder)
+	require.NotNil(t, createOrder.Allow)
+	assert.False(t, *createOrder.Allow)
+
+	_, _, err = ExpandMCPServerConfig(src, config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "operationId:deleted_order")
+}
+
+func TestExpandMCPServerConfigTolerant_AllSelectedPrimitivesAreStale(t *testing.T) {
+	t.Parallel()
+
+	src := newDeriveTestOAS(openapi3.NewPaths(
+		openapi3.WithPath("/orders", &openapi3.PathItem{
+			Get: &openapi3.Operation{OperationID: "list_orders"},
+		}),
+	))
+
+	expanded, warnings, err := ExpandMCPServerConfigTolerant(src, &TykMCPServer{
+		Primitives: []TykMCPServerPrimitive{
+			{Source: TykMCPServerSource{OperationID: "deleted_order"}, Allow: boolPtr(true)},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	require.Len(t, expanded.Primitives, 1)
+	require.NotNil(t, expanded.Primitives[0].Allow)
+	assert.False(t, *expanded.Primitives[0].Allow)
+}
+
 func TestExpandMCPServerConfig_MethodPathOperationWithoutOperationID(t *testing.T) {
 	t.Parallel()
 

--- a/gateway/mcp_api.go
+++ b/gateway/mcp_api.go
@@ -433,7 +433,7 @@ func (gw *Gateway) handleGetMCPWithExpand(apiID string, expand bool) (interface{
 		return obj, code
 	}
 
-	expanded, err := gw.expandMCPProxyDefinition(oasObj)
+	expanded, err := gw.expandSavedMCPProxyDefinition(oasObj)
 	if err != nil {
 		return apiError(err.Error()), http.StatusBadRequest
 	}
@@ -474,6 +474,16 @@ func boolQueryParam(r *http.Request, name string) (bool, error) {
 }
 
 func (gw *Gateway) expandMCPProxyDefinition(proxyOAS *oas.OAS) (*oas.OAS, error) {
+	return gw.expandMCPProxyDefinitionWith(proxyOAS, oas.ExpandMCPServerConfig)
+}
+
+func (gw *Gateway) expandSavedMCPProxyDefinition(proxyOAS *oas.OAS) (*oas.OAS, error) {
+	return gw.expandMCPProxyDefinitionWith(proxyOAS, oas.ExpandMCPServerConfigTolerant)
+}
+
+type mcpServerConfigExpander func(*oas.OAS, *oas.TykMCPServer) (*oas.TykMCPServer, []oas.DeriveWarning, error)
+
+func (gw *Gateway) expandMCPProxyDefinitionWith(proxyOAS *oas.OAS, expandConfig mcpServerConfigExpander) (*oas.OAS, error) {
 	if proxyOAS == nil {
 		return nil, fmt.Errorf("MCP Proxy OAS is nil")
 	}
@@ -496,7 +506,7 @@ func (gw *Gateway) expandMCPProxyDefinition(proxyOAS *oas.OAS) (*oas.OAS, error)
 		return nil, err
 	}
 
-	mcpServer, warnings, err := oas.ExpandMCPServerConfig(&rest.OAS, expanded.GetTykMCPServerExtension())
+	mcpServer, warnings, err := expandConfig(&rest.OAS, expanded.GetTykMCPServerExtension())
 	logMCPDeriveWarnings(proxyDef.APIID, restAPIID, warnings)
 	if err != nil {
 		return nil, err

--- a/gateway/mcp_api_test.go
+++ b/gateway/mcp_api_test.go
@@ -911,6 +911,40 @@ func TestHandleGetMCPWithExpand_ReturnsExpandedCatalogueForSavedProxy(t *testing
 	assert.Nil(t, storedExt.Primitives[0].InputSchema)
 }
 
+func TestHandleGetMCPWithExpand_SkipsStaleSavedPrimitive(t *testing.T) {
+	gw := newMCPTestGateway(t)
+	rest := restSourceSpec("rest-1", "org-1", true)
+	rest.OAS.Paths = openapi3.NewPaths(
+		openapi3.WithPath("/orders", &openapi3.PathItem{
+			Get: &openapi3.Operation{OperationID: "list_orders", Summary: "list orders"},
+		}),
+	)
+	gw.apisByID["rest-1"] = rest
+	gw.apisByID["proxy-1"] = pairedMCPProxySpec("proxy-1", "org-1", "rest-1", &oas.TykMCPServer{
+		Primitives: []oas.TykMCPServerPrimitive{
+			{Source: oas.TykMCPServerSource{OperationID: "create_order"}, Allow: boolPtr(true)},
+			{Source: oas.TykMCPServerSource{OperationID: "list_orders"}, Allow: boolPtr(true)},
+		},
+	})
+
+	obj, code := gw.handleGetMCPWithExpand("proxy-1", true)
+
+	require.Equal(t, http.StatusOK, code)
+	expanded, ok := obj.(*oas.OAS)
+	require.True(t, ok)
+	ext := expanded.GetTykMCPServerExtension()
+	require.NotNil(t, ext)
+	require.Len(t, ext.Primitives, 1)
+	assert.Equal(t, "list_orders", ext.Primitives[0].Name)
+	require.NotNil(t, ext.Primitives[0].Allow)
+	assert.True(t, *ext.Primitives[0].Allow)
+
+	storedExt := gw.apisByID["proxy-1"].OAS.GetTykMCPServerExtension()
+	require.NotNil(t, storedExt)
+	require.Len(t, storedExt.Primitives, 2)
+	assert.Equal(t, "create_order", storedExt.Primitives[0].Source.OperationID)
+}
+
 func TestHandleGetMCPWithExpand_NormalReadReturnsStoredShape(t *testing.T) {
 	gw := newMCPTestGateway(t)
 	gw.apisByID["rest-1"] = restSourceSpec("rest-1", "org-1", true)


### PR DESCRIPTION
## Description

Adds an explicit tolerant MCP catalogue expansion path for saved proxy reads. Stale primitive selectors are skipped with the existing derivation warning, while surviving tools remain available.

Gateway saved `GET /tyk/mcps/{apiID}?expand=true` reads use tolerant expansion. Dry-run and write validation retain the existing strict expansion behavior.

## Related Issue

TT-18136

## Motivation and Context

When a paired REST operation is deleted after an MCP proxy is saved, runtime tool derivation already skips that stale selector. The management expanded-read path remained strict, returned 400, and prevented Dashboard tool mapping from loading even though surviving tools were usable at runtime.

The strict/tolerant boundary is kept explicit so invalid selectors are still rejected for new configurations.

## How This Has Been Tested

- `go test ./apidef/oas -run "Test(ExpandMCPServerConfig|DeriveMCPToolView_Stale)" -count=1`
- `go test ./gateway -run "Test(HandleGetMCPWithExpand|HandleAddMCP_DryRunExpand|ValidatePairedMCPAdapterUpstream)" -count=1`
- Full `go test ./apidef/oas -count=1`
- Live Gateway validation: stale saved proxy exposes only the surviving `get_order` tool through `tools/list`

A full Gateway package run was also attempted. It reached unrelated existing environment/flaky failures in Python coprocess, polling/looping, rate-limit timing, and RPC reload tests; the focused MCP suites above pass.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date (no documentation changes required)
- [x] I explained why this PR updates go.mod in detail with reasoning why it is required (go.mod is not changed)
- [ ] I would like a code coverage CI quality gate exception and have explained why



<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-18136" title="TT-18136" target="_blank">TT-18136</a>
</summary>

|         |    |
|---------|----|
| Status  | In Refinement |
| Summary | MCP Proxy can't load tool mapping |

Generated at: 2026-08-27 10:35:01

</details>

<!---TykTechnologies/jira-linter ends here-->




## Companion PR

Dashboard integration: https://github.com/TykTechnologies/tyk-analytics/pull/6171
