### PR TITLE
TT-17927: escape config literal that breaks generated docs

### DIFF
--- a/internal/otel/mcp_trace_context.go
+++ b/internal/otel/mcp_trace_context.go
@@ -84,7 +84,7 @@ type MCPTraceSource struct {
 type MCPTraceContextConfig struct {
 	// ReadSources is an ordered, first-match-wins list of places to look for
 	// the inbound trace context. When omitted, it defaults to
-	// [{header}, {body, path: params._meta}].
+	// `[{header}, {body, path: params._meta}]`.
 	ReadSources []MCPTraceSource `json:"read_sources,omitempty"`
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
```
gateway-config.mdx is generated from these comments; MDX parses the
unescaped {…} literal as a JSX expression and fails. The sibling
comment in internal/otel/config.go was already escaped by TT-17415.
```

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why

<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17927" title="TT-17927" target="_blank">TT-17927</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | [Release 4 prep]  Update API and config docs |

Generated at: 2026-08-31 12:43:11

</details>

<!---TykTechnologies/jira-linter ends here-->
