### PR TITLE
[TT-17927] Restore verbose TLS and policy-id doc comments (5.13)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -611,10 +611,10 @@ type HttpServerOptionsConfig struct {
 	// Start your Gateway HTTP server on specific server name
 	ServerName string `json:"server_name"`
 
-	// Minimum TLS version. Possible values: https://tyk.io/docs/api-management/certificates#supported-tls-versions
+	// Minimum TLS version. For details see: https://tyk.io/docs/api-management/implement-tls#controlling-tls-version-and-cipher-suites
 	MinVersion uint16 `json:"min_version"`
 
-	// Maximum TLS version.
+	// Maximum TLS version. For details see: https://tyk.io/docs/api-management/implement-tls#controlling-tls-version-and-cipher-suites
 	MaxVersion uint16 `json:"max_version"`
 
 	// When mTLS enabled, this option allows to skip client CA announcement in the TLS handshake.
@@ -1424,7 +1424,9 @@ type Config struct {
 	// JWKS holds the configuration for Tyk JWKS functionalities
 	JWKS JWKSConfig `json:"jwks"`
 
-	// AllowUnsafePolicyIds allows unsafe policy identifiers
+	// AllowUnsafePolicyIds allows the use of non-standard characters in policy identifiers (default: false).
+	// The standard characters are alphanumeric characters plus underscore (_), hyphen (-), dot (.) and tilde (~).
+	// The use of other characters in IDs can cause unpredictable behavior and is not recommended.
 	AllowUnsafePolicyIds bool `json:"allow_unsafe_policy_ids"`
 }
 


### PR DESCRIPTION
## Description

Comment-only change to `config/config.go`. Restores the wording requested in the
tyk-docs #2822 review:

- `http_server_options.min_version` / `max_version` comments now link to the
  implement-tls docs page instead of the terse "Possible values" wording
- `AllowUnsafePolicyIds` gets its detailed three-line explanation back
  (standard characters, risk of unpredictable behavior)

These struct comments are the source that `tyk-config-info-generator` uses to
generate `snippets/gateway-config.mdx` in tyk-docs, so accepting the review
suggestions in the docs PR alone would be overwritten by the next sync — the
fix has to live here.

## Related Issue

https://tyktech.atlassian.net/browse/TT-17927

## Motivation and Context

Review feedback on https://github.com/TykTechnologies/tyk-docs/pull/2822: the
regenerated 5.13 docs lost the more informative TLS and policy-id descriptions
because the source comments had been shortened. No behaviour change.

## How This Has Been Tested

Comment-only; `gofmt` clean. Will be verified by re-running the Tyk Docs sync
workflow against release-5.13.2 and confirming the regenerated
gateway-config.mdx matches the requested wording.

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17927" title="TT-17927" target="_blank">TT-17927</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | [Release 4 prep]  Update API and config docs |

Generated at: 2026-09-01 08:10:40

</details>

<!---TykTechnologies/jira-linter ends here-->
