### PR TITLE
feat: add GetOASConfigData helper function

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -179,6 +179,22 @@ func GetOASDefinition(r *http.Request) *oas.OAS {
 	return nil
 }
 
+// GetOASConfigData returns the config data of the OAS API definition valid for the request.
+// It does not deep copy the whole API definition, making it faster than GetOASDefinition.
+func GetOASConfigData(r *http.Request) (map[string]interface{}, error) {
+	oasDef, ok := r.Context().Value(OASDefinition).(*oas.OAS)
+	if !ok || oasDef == nil {
+		return nil, errors.New("OAS definition not found in request context")
+	}
+
+	mw := oasDef.GetTykMiddleware()
+	if mw == nil || mw.Global == nil || mw.Global.PluginConfig == nil || mw.Global.PluginConfig.Data == nil {
+		return nil, errors.New("config data is nil")
+	}
+
+	return mw.Global.PluginConfig.Data.Value, nil
+}
+
 // SetErrorClassification sets the error classification for the request context.
 // This is used to store structured error information for access logs.
 func SetErrorClassification(r *http.Request, ec *errors.ErrorClassification) {

--- a/ctx/ctx_test.go
+++ b/ctx/ctx_test.go
@@ -49,6 +49,45 @@ func TestGetOASDefinition(t *testing.T) {
 	assert.Equal(t, oasDef, cloned)
 }
 
+func TestGetOASConfigData(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	// Test when OAS definition is not in context
+	configData, err := ctx.GetOASConfigData(req)
+	assert.Nil(t, configData)
+	assert.Error(t, err)
+	assert.Equal(t, "OAS definition not found in request context", err.Error())
+
+	// Test when OAS definition is in context but no config data
+	oasDef := &oas.OAS{}
+	ctx.SetOASDefinition(req, oasDef)
+	configData, err = ctx.GetOASConfigData(req)
+	assert.Nil(t, configData)
+	assert.Error(t, err)
+	assert.Equal(t, "config data is nil", err.Error())
+
+	// Test when config data is present
+	expectedConfigData := map[string]any{
+		"key": "value",
+	}
+	oasDefWithConfig := &oas.OAS{}
+	oasDefWithConfig.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Global: &oas.Global{
+				PluginConfig: &oas.PluginConfig{
+					Data: &oas.PluginConfigData{
+						Value: expectedConfigData,
+					},
+				},
+			},
+		},
+	})
+	ctx.SetOASDefinition(req, oasDefWithConfig)
+	configData, err = ctx.GetOASConfigData(req)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedConfigData, configData)
+}
+
 // Benchmark for GetDefinition
 func BenchmarkGetDefinition(b *testing.B) {
 	apiDef := &apidef.APIDefinition{
@@ -60,7 +99,7 @@ func BenchmarkGetDefinition(b *testing.B) {
 	ctx.SetDefinition(req, apiDef)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		cloned := ctx.GetDefinition(req)
 		assert.Equal(b, apiDef, cloned)
 	}
@@ -79,9 +118,38 @@ func BenchmarkGetOASDefinition(b *testing.B) {
 	ctx.SetOASDefinition(req, oasDef)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		cloned := ctx.GetOASDefinition(req)
 		assert.Equal(b, oasDef, cloned)
+	}
+}
+
+// Benchmark for GetOASConfigData
+func BenchmarkGetOASConfigData(b *testing.B) {
+	expectedConfigData := map[string]interface{}{
+		"key": "value",
+	}
+	oasDefWithConfig := &oas.OAS{}
+	oasDefWithConfig.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Global: &oas.Global{
+				PluginConfig: &oas.PluginConfig{
+					Data: &oas.PluginConfigData{
+						Value: expectedConfigData,
+					},
+				},
+			},
+		},
+	})
+
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+	ctx.SetOASDefinition(req, oasDefWithConfig)
+
+	b.ResetTimer()
+	for b.Loop() {
+		configData, err := ctx.GetOASConfigData(req)
+		assert.NoError(b, err)
+		assert.Equal(b, expectedConfigData, configData)
 	}
 }
 

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -562,6 +562,167 @@ func TestGoPlugin_AccessingOASAPIDef(t *testing.T) {
 	}...)
 }
 
+func TestGoPlugin_AccessingOASConfigData(t *testing.T) {
+	ts := gateway.StartTest(nil)
+	defer ts.Close()
+
+	const (
+		oasDocTitle      = "My OAS Documentation ConfigData"
+		pluginConfigData = "my-plugin-config"
+	)
+
+	t.Run("pre plugin reads config_data via ctx.GetOASConfigData", func(t *testing.T) {
+		oasDoc := oas.OAS{}
+		oasDoc.OpenAPI = "3.0.3"
+		oasDoc.Info = &openapi3.Info{
+			Version: "1",
+			Title:   oasDocTitle,
+		}
+		oasDoc.Paths = openapi3.NewPaths()
+
+		oasDoc.SetTykExtension(&oas.XTykAPIGateway{
+			Middleware: &oas.Middleware{
+				Global: &oas.Global{
+					PluginConfig: &oas.PluginConfig{
+						Data: &oas.PluginConfigData{
+							Value: map[string]interface{}{
+								"my-context-data": pluginConfigData,
+							},
+						},
+					},
+				},
+			},
+		})
+
+		err := oasDoc.Validate(context.Background())
+		assert.NoError(t, err)
+
+		ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
+			spec.IsOAS = true
+			spec.OAS = oasDoc
+			spec.Proxy.ListenPath = "/oas-goplugin-config-data/"
+			spec.UseKeylessAccess = true
+			spec.UseStandardAuth = false
+			spec.CustomMiddleware = apidef.MiddlewareSection{
+				Driver: apidef.GoPluginDriver,
+				Pre: []apidef.MiddlewareDefinition{
+					{
+						Name: "MyPluginAccessingOASConfigData",
+						Path: goPluginFilename(),
+					},
+				},
+			}
+		})
+
+		ts.Run(t, []test.TestCase{
+			{
+				Path: "/oas-goplugin-config-data/get",
+				Code: http.StatusOK,
+				HeadersMatch: map[string]string{
+					"X-Plugin-Config-Data": pluginConfigData,
+				},
+			},
+		}...)
+	})
+
+	t.Run("pre plugin gets error when config_data is not set", func(t *testing.T) {
+		oasDoc := oas.OAS{}
+		oasDoc.OpenAPI = "3.0.3"
+		oasDoc.Info = &openapi3.Info{
+			Version: "1",
+			Title:   oasDocTitle,
+		}
+		oasDoc.Paths = openapi3.NewPaths()
+
+		oasDoc.SetTykExtension(&oas.XTykAPIGateway{})
+
+		err := oasDoc.Validate(context.Background())
+		assert.NoError(t, err)
+
+		ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
+			spec.IsOAS = true
+			spec.OAS = oasDoc
+			spec.Proxy.ListenPath = "/oas-goplugin-no-config-data/"
+			spec.UseKeylessAccess = true
+			spec.UseStandardAuth = false
+			spec.CustomMiddleware = apidef.MiddlewareSection{
+				Driver: apidef.GoPluginDriver,
+				Pre: []apidef.MiddlewareDefinition{
+					{
+						Name: "MyPluginAccessingOASConfigData",
+						Path: goPluginFilename(),
+					},
+				},
+			}
+		})
+
+		ts.Run(t, []test.TestCase{
+			{
+				Path: "/oas-goplugin-no-config-data/get",
+				Code: http.StatusOK,
+				HeadersMatch: map[string]string{
+					"X-Plugin-Config-Data-Error": "config data is nil",
+				},
+			},
+		}...)
+	})
+
+	t.Run("response plugin reads config_data via ctx.GetOASConfigData", func(t *testing.T) {
+		oasDoc := oas.OAS{}
+		oasDoc.OpenAPI = "3.0.3"
+		oasDoc.Info = &openapi3.Info{
+			Version: "1",
+			Title:   oasDocTitle,
+		}
+		oasDoc.Paths = openapi3.NewPaths()
+
+		oasDoc.SetTykExtension(&oas.XTykAPIGateway{
+			Middleware: &oas.Middleware{
+				Global: &oas.Global{
+					PluginConfig: &oas.PluginConfig{
+						Data: &oas.PluginConfigData{
+							Value: map[string]interface{}{
+								"my-context-data": pluginConfigData,
+							},
+						},
+					},
+				},
+			},
+		})
+
+		err := oasDoc.Validate(context.Background())
+		assert.NoError(t, err)
+
+		ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
+			spec.IsOAS = true
+			spec.OAS = oasDoc
+			spec.Proxy.ListenPath = "/oas-goplugin-config-data-resp/"
+			spec.UseKeylessAccess = true
+			spec.UseStandardAuth = false
+			spec.UseGoPluginAuth = false
+			spec.CustomMiddleware = apidef.MiddlewareSection{
+				Driver: apidef.GoPluginDriver,
+				Response: []apidef.MiddlewareDefinition{
+					{
+						Name: "MyResponsePluginAccessingOASConfigData",
+						Path: goPluginFilename(),
+					},
+				},
+			}
+		})
+
+		ts.Run(t, []test.TestCase{
+			{
+				Path: "/oas-goplugin-config-data-resp/get",
+				Code: http.StatusOK,
+				HeadersMatch: map[string]string{
+					"X-Plugin-Config-Data": pluginConfigData,
+				},
+			},
+		}...)
+	})
+}
+
 func TestGoPlugin_MyResponsePluginAccessingOASAPI(t *testing.T) {
 	ts := gateway.StartTest(nil)
 	defer ts.Close()

--- a/test/goplugins/test_goplugin.go
+++ b/test/goplugins/test_goplugin.go
@@ -269,3 +269,39 @@ func MyAnalyticsPluginAddTag(record *analytics.AnalyticsRecord) {
 	_ = resp.Write(&bNew)
 	record.RawResponse = base64.StdEncoding.EncodeToString(bNew.Bytes())
 }
+
+// MyPluginAccessingOASConfigData reads the API's config_data from the OAS
+// definition using ctx.GetOASConfigData (no deep copy of the whole OAS doc,
+func MyPluginAccessingOASConfigData(rw http.ResponseWriter, r *http.Request) {
+	configData, err := ctx.GetOASConfigData(r)
+	if err != nil {
+		// e.g. "config data is nil" when the API has no plugin config data
+		rw.Header().Add("X-Plugin-Config-Data-Error", err.Error())
+		return
+	}
+
+	pluginConfig, ok := configData["my-context-data"].(string)
+	if !ok || pluginConfig == "" {
+		rw.Header().Add("X-Plugin-Config-Data", "null")
+		return
+	}
+
+	rw.Header().Add("X-Plugin-Config-Data", pluginConfig)
+}
+
+// MyResponsePluginAccessingOASConfigData is the response-middleware variant.
+func MyResponsePluginAccessingOASConfigData(rw http.ResponseWriter, _ *http.Response, req *http.Request) {
+	configData, err := ctx.GetOASConfigData(req)
+	if err != nil {
+		rw.Header().Add("X-Plugin-Config-Data-Error", err.Error())
+		return
+	}
+
+	pluginConfig, ok := configData["my-context-data"].(string)
+	if !ok || pluginConfig == "" {
+		rw.Header().Add("X-Plugin-Config-Data", "null")
+		return
+	}
+
+	rw.Header().Add("X-Plugin-Config-Data", pluginConfig)
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

1. added **ctx.GetOASConfigData(r)**: A high-performance alternative introduced to solve the performance bottleneck. It safely retrieves only the config_data map from the OAS definition without performing a deep copy.
2. added unit and benchmark tests 

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

introducing a new, high-performance helper function called GetOASConfigData in ctx/ctx.go. This function safely retrieves OAS configuration data for Go plugins without performing an expensive deep copy of the entire OAS definition (which was the bottleneck in the existing GetOASDefinition method). Benchmark tests confirmed this reduced the operation time from ~1405 ns/op to ~300 ns/op.

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why




<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16007" title="TT-16007" target="_blank">TT-16007</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | Helper function to retrieve the context_data from Tyk OAS APIs for Go plugins |

Generated at: 2026-09-02 14:10:37

</details>

<!---TykTechnologies/jira-linter ends here-->



