### PR TITLE
docs: escape MDX-breaking spans in doc comments synced to tyk-docs

### DIFF
--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -121,7 +121,7 @@ type Authentication struct {
 //
 // On non-MCP APIs only static is meaningful; mirror is a no-op.
 //
-// Deprecated: Use OAuth2PRM (under SecuritySchemes[<name>].OAuth2) instead.
+// Deprecated: Use OAuth2PRM (under `SecuritySchemes[<name>].OAuth2`) instead.
 // This type backs the legacy top-level Authentication.ProtectedResourceMetadata
 // field; the new per-scheme location is the runtime source of truth and the
 // legacy block is kept only for downgrade safety.

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -98,7 +98,7 @@ type Authentication struct {
 	// for authorization server discovery. This is used by MCP clients to discover which
 	// authorization server to use for accessing the API.
 	//
-	// Deprecated: Use SecuritySchemes[<name>].OAuth2.ProtectedResourceMetadata instead.
+	// Deprecated: Use `SecuritySchemes[<name>].OAuth2.ProtectedResourceMetadata` instead.
 	// The new per-scheme location is the runtime source of truth; this top-level
 	// field is kept for downgrade safety and will be removed in a future major version.
 	ProtectedResourceMetadata *ProtectedResourceMetadata `bson:"protectedResourceMetadata,omitempty" json:"protectedResourceMetadata,omitempty"`

--- a/apidef/oas/mcp_proxy_derive.go
+++ b/apidef/oas/mcp_proxy_derive.go
@@ -21,15 +21,15 @@ import (
 //
 // It carries everything the adapter middleware needs — method, path
 // template, where each argument lives (path / query / header / body /
-// body.<field>), and the synthesised input JSON schema that is served
+// `body.<field>`), and the synthesised input JSON schema that is served
 // back on `tools/list`.
 type DerivedTool struct {
 	// OperationID is the source REST operationId this tool calls.
 	OperationID string `json:"-"`
 
 	// SourceKey identifies the source operation even when operationId is
-	// absent. OperationId-backed tools use "operationId:<id>"; path+method
-	// fallbacks use "http:<METHOD> <PATH>".
+	// absent. OperationId-backed tools use `operationId:<id>`; path+method
+	// fallbacks use `http:<METHOD> <PATH>`.
 	SourceKey string `json:"-"`
 
 	// CanonicalName is the source-derived MCP tool name before any proxy-side
@@ -45,16 +45,16 @@ type DerivedTool struct {
 	// Method is the HTTP method (GET, POST, ...).
 	Method string `json:"-"`
 
-	// PathTemplate is the OAS path template (e.g. "/orders/{id}").
+	// PathTemplate is the OAS path template (e.g. `/orders/{id}`).
 	PathTemplate string `json:"-"`
 
 	// ParamLocations maps each argument name to its source location.
 	// Recognised values:
-	//   - "path"
-	//   - "query"
-	//   - "header"
-	//   - "body"          (the whole JSON body)
-	//   - "body.<field>"  (a single JSON body field)
+	//   - `path`
+	//   - `query`
+	//   - `header`
+	//   - `body`          (the whole JSON body)
+	//   - `body.<field>`  (a single JSON body field)
 	// Locations are used internally by the REST-as-MCP adapter.
 	ParamLocations map[string]string `json:"-"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -263,7 +263,7 @@ type NormalisedURLConfig struct {
 	// * `/ca761232-ed42-11ce-BAcd-00aa0057b223/search`
 	// * `/ca761232-ed42-11ce-BAcd-00aa0057b223/search`
 
-	// Each UUID will be replaced with a placeholder {uuid}
+	// Each UUID will be replaced with a placeholder `{uuid}`
 	NormaliseUUIDs bool `json:"normalise_uuids"`
 
 	// Set this to true to have Tyk automatically clean up ULIDs. It will match the following style:
@@ -272,7 +272,7 @@ type NormalisedURLConfig struct {
 	// * `/posts/01g9hhnkwgbhcqx7vg3jksz055/comments`
 	// * `/posts/01g9HHNKwgbhcqx7vg3JKSZ055/comments`
 
-	// Each ULID will be replaced with a placeholder {ulid}
+	// Each ULID will be replaced with a placeholder `{ulid}`
 	NormaliseULIDs bool `json:"normalise_ulids"`
 
 	// Set this to true to have Tyk automatically match for numeric IDs, it will match with a preceding slash so as not to capture actual numbers:


### PR DESCRIPTION
These Go doc-comments are synced into `TykTechnologies/tyk-docs` as `snippets/x-tyk-gateway.mdx` and `snippets/gateway-config.mdx`. Literal `{...}` and `<...>` text in them is valid Go but breaks MDX, in two different ways:

- **Hard build failure.** `<field>`, `<id>`, `<METHOD>`, `<PATH>` and `<name>` parse as unclosed JSX tags. The MDX parse fails, Mintlify drops the whole snippet, and the page still returns HTTP 200 with most of its content missing.
- **Silent content loss.** `{uuid}`, `{ulid}` and `{id}` parse as JS expressions, evaluate to undefined, and render as nothing. The sentence loses its point.

Fix throughout: wrap the span in backticks so MDX treats it as inline code. Comment-only, no behaviour change.

## Files

**`apidef/oas/authentication.go`** - 2 occurrences of `SecuritySchemes[<name>]`.

**`apidef/oas/mcp_proxy_derive.go`** (`DerivedTool`) - `body.<field>`, `operationId:<id>`, `http:<METHOD> <PATH>`, `/orders/{id}`, and the `ParamLocations` list.

**`config/config.go`** (`NormalisedURLConfig`) - `{uuid}` and `{ulid}`.

Where a span was already in double quotes, the quotes are dropped: backticks already mark it as a literal.

## Impact if this does not merge

The `x-tyk-gateway.mdx` failures currently hide the entire Tyk vendor extension reference from `/api-management/gateway-config-tyk-oas`, taking the page from 165 headings down to 7.

TykTechnologies/tyk-docs#2872 patches the generated `.mdx` files directly as a stopgap. That patch is overwritten by the next sync, so this PR is what actually keeps the fix.

## Not covered here

`internal/otel/config.go` produces a third break in `gateway-config.mdx` (the trace-context default). That comment is **already** correctly backtick-wrapped at source, so the backticks are being stripped somewhere in the sync pipeline. That needs whoever owns the generator, not a source change.
