### PR TITLE
docs: escape {uuid} and {ulid} placeholders in NormalisedURLConfig comments

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -236,7 +236,7 @@ type NormalisedURLConfig struct {
 	// * `/ca761232-ed42-11ce-BAcd-00aa0057b223/search`
 	// * `/ca761232-ed42-11ce-BAcd-00aa0057b223/search`
 
-	// Each UUID will be replaced with a placeholder {uuid}
+	// Each UUID will be replaced with a placeholder `{uuid}`
 	NormaliseUUIDs bool `json:"normalise_uuids"`
 
 	// Set this to true to have Tyk automatically clean up ULIDs. It will match the following style:
@@ -245,7 +245,7 @@ type NormalisedURLConfig struct {
 	// * `/posts/01g9hhnkwgbhcqx7vg3jksz055/comments`
 	// * `/posts/01g9HHNKwgbhcqx7vg3JKSZ055/comments`
 
-	// Each ULID will be replaced with a placeholder {ulid}
+	// Each ULID will be replaced with a placeholder `{ulid}`
 	NormaliseULIDs bool `json:"normalise_ulids"`
 
 	// Set this to true to have Tyk automatically match for numeric IDs, it will match with a preceding slash so as not to capture actual numbers:


### PR DESCRIPTION
Backport of the `config/config.go` half of #8669 to the 5.13 LTS line.

These doc-comments sync into `TykTechnologies/tyk-docs` as `snippets/gateway-config.mdx`. MDX reads `{uuid}` and `{ulid}` as JS expressions rather than literal text. They are valid JS identifiers, so the build succeeds, but they evaluate to undefined and render as nothing. Both sentences on `/tyk-oss-gateway/configuration` therefore lose the one word they exist to convey:

> Each UUID will be replaced with a placeholder
> Each ULID will be replaced with a placeholder

Fix: wrap both in backticks so MDX treats them as inline code. Comment-only, no behaviour change, `gofmt` clean.

## Why this branch

5.13 is LTS, so its docs are still regenerated from this branch. The docs side is already fixed at TykTechnologies/tyk-docs#2898, but that is a patch to a generated file and the next sync overwrites it. This PR is what makes the fix survive.

## Scope

Only `config/config.go` applies here. The other files covered by #8669 (`apidef/oas/authentication.go` and `apidef/oas/mcp_proxy_derive.go`) carry 5.15-only MCP and OAuth2 content that does not exist on this branch.
