### PR TITLE
[TT-14404] regression-gateway-always-generates-detailed-records-for-graphql-udg-requests

### DIFF
--- a/gateway/analytics_helper.go
+++ b/gateway/analytics_helper.go
@@ -91,5 +91,5 @@ func recordDetailUnsafe(r *http.Request, spec *APISpec) bool {
 	}
 
 	// no org session found, use global config
-	return spec.GraphQL.Enabled || spec.GlobalConfig.AnalyticsConfig.EnableDetailedRecording
+	return spec.GlobalConfig.AnalyticsConfig.EnableDetailedRecording
 }

--- a/gateway/analytics_helper_test.go
+++ b/gateway/analytics_helper_test.go
@@ -271,6 +271,13 @@ func TestRecordDetail(t *testing.T) {
 			spec: testAPISpec(func(spec *APISpec) {
 				spec.GraphQL.Enabled = true
 			}),
+			expect: false,
+		},
+		{
+			title: "request with detailed recording enabled",
+			spec: testAPISpec(func(spec *APISpec) {
+				spec.GlobalConfig.AnalyticsConfig.EnableDetailedRecording = true
+			}),
 			expect: true,
 		},
 	}

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -391,7 +391,12 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 	addVersionHeader(w, r, s.Spec.GlobalConfig)
 
 	t1 := time.Now()
-	resp := s.Proxy.ServeHTTP(w, r)
+	var resp ProxyResponse
+	if s.Spec.GraphQL.Enabled {
+		resp = s.Proxy.ServeHTTPForCache(w, r)
+	} else {
+		resp = s.Proxy.ServeHTTP(w, r)
+	}
 
 	t2 := time.Now()
 	proxyDuration := t2.Sub(t1)

--- a/gateway/handler_success_test.go
+++ b/gateway/handler_success_test.go
@@ -2,9 +2,12 @@ package gateway
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -561,6 +564,76 @@ func TestSuccessHandler_classifyUpstreamError(t *testing.T) {
 			} else {
 				assert.Nil(t, errClass, "expected no error classification")
 			}
+		})
+	}
+}
+
+type mockReturningHttpHandler struct {
+	serveHTTPCalled         bool
+	serveHTTPForCacheCalled bool
+}
+
+func (m *mockReturningHttpHandler) ServeHTTP(_ http.ResponseWriter, _ *http.Request) ProxyResponse {
+	m.serveHTTPCalled = true
+	return ProxyResponse{}
+}
+
+func (m *mockReturningHttpHandler) ServeHTTPForCache(_ http.ResponseWriter, _ *http.Request) ProxyResponse {
+	m.serveHTTPForCacheCalled = true
+	return ProxyResponse{}
+}
+
+func (m *mockReturningHttpHandler) CopyResponse(_ io.Writer, _ io.Reader, _ time.Duration) error {
+	return nil
+}
+
+func TestSuccessHandler_ServeHTTP_Branching(t *testing.T) {
+	tests := []struct {
+		name                    string
+		graphqlEnabled          bool
+		expectServeHTTP         bool
+		expectServeHTTPForCache bool
+	}{
+		{
+			name:                    "GraphQL disabled calls ServeHTTP",
+			graphqlEnabled:          false,
+			expectServeHTTP:         true,
+			expectServeHTTPForCache: false,
+		},
+		{
+			name:                    "GraphQL enabled calls ServeHTTPForCache",
+			graphqlEnabled:          true,
+			expectServeHTTP:         false,
+			expectServeHTTPForCache: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockProxy := &mockReturningHttpHandler{}
+
+			spec := &APISpec{
+				APIDefinition: &apidef.APIDefinition{
+					GraphQL: apidef.GraphQLConfig{
+						Enabled: tt.graphqlEnabled,
+					},
+				},
+			}
+
+			handler := &SuccessHandler{
+				BaseMiddleware: &BaseMiddleware{
+					Spec:  spec,
+					Proxy: mockProxy,
+				},
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectServeHTTP, mockProxy.serveHTTPCalled)
+			assert.Equal(t, tt.expectServeHTTPForCache, mockProxy.serveHTTPForCacheCalled)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

1. Removed the forced detailed recording for GraphQL in recordDetailUnsafe to prevent unnecessary logging of full payloads.
2. Used ServeHTTPForCache for GraphQL requests to ensure the response body is still buffered, which is required for extracting GraphQL analytics stats and errors.

## Description

1. Removed the forced detailed recording for GraphQL in recordDetailUnsafe to prevent unnecessary logging of full payloads.
2. Used ServeHTTPForCache for GraphQL requests to ensure the response body is still buffered, which is required for extracting GraphQL analytics stats and errors.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

Set enable_detailed_recording in the Gateway configuration to either true or false.
Create a GraphQL/UDG API.
Ensure that detailed recording is either enabled or disabled, depending on the test scenario.
Set up Tyk Pump using the default configuration.
Log in to MongoDB Compass or the MongoDB shell and monitor the tyk_analytics collection.
Make a request to the configured GraphQL API.
Check the tyk_analytics collection in MongoDB and verify the raw_request and raw_response fields:
If raw_request and/or raw_response are present and contain data, detailed analytics have been recorded.
If raw_request and raw_response are missing or empty, detailed analytics have not been recorded.
The result should match the configured enable_detailed_recording value.

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why








<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-14404" title="TT-14404" target="_blank">TT-14404</a>
</summary>

|         |    |
|---------|----|
| Status  | In Test |
| Summary | [regression] Gateway always generates detailed records for Graphql/UDG requests |

Generated at: 2026-09-14 08:03:10

</details>

<!---TykTechnologies/jira-linter ends here-->







