### PR TITLE
[TT-14684] The listen path recorded in analytics changes when an API response comes from cache

### DIFF
--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -237,7 +237,14 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	// Without this guard, each VEM continuation step produces a non-MCP
 	// analytics record that leaks internal routing paths into the endpoints table.
 	if copiedResponse != nil && !d.Spec.IsMCP() {
-		d.sh.RecordHit(r, analytics.Latency{Total: int64(ms), Upstream: 0, Gateway: int64(ms)}, copiedResponse.StatusCode, copiedResponse, false)
+		logRequest := d.Spec.PrepareRequestToLogShallowClone(r)
+		d.sh.RecordHit(
+			logRequest,
+			analytics.Latency{Total: int64(ms), Upstream: 0, Gateway: int64(ms)},
+			copiedResponse.StatusCode,
+			copiedResponse,
+			false,
+		)
 	}
 
 	return copiedResponse, nil


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-14684" title="TT-14684" target="_blank">TT-14684</a>
</summary>

|         |    |
|---------|----|
| Status  | In Test |
| Summary | The listen path recorded in analytics changes when an API response comes from cache |

Generated at: 2026-09-15 20:21:18

</details>

<!---TykTechnologies/jira-linter ends here-->

