### PR TITLE
fix: don't mark successful plugin responses as span errors

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -82,7 +82,7 @@ func (tr TraceMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request,
 
 			span := otel.SpanFromContext(r.Context())
 			err, i := tr.TykMiddleware.ProcessRequest(w, r, conf)
-			if err != nil && span != nil {
+			if err != nil && span != nil && !errors.Is(err, ErrResponseSucceed) {
 				span.SetStatus(otel.SPAN_STATUS_ERROR, err.Error())
 			}
 

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +17,9 @@ import (
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/mock/gomock"
 
 	"github.com/TykTechnologies/opentelemetry/metric/metrictest"
@@ -51,6 +55,20 @@ type requestConditionalMiddleware struct {
 	calls int
 }
 
+type traceStatusMiddleware struct {
+	*BaseMiddleware
+	err error
+}
+
+func (m *traceStatusMiddleware) Name() string {
+	return "traceStatusMiddleware"
+}
+
+//nolint:staticcheck // ST1008: middleware interface requires (error, int).
+func (m *traceStatusMiddleware) ProcessRequest(http.ResponseWriter, *http.Request, interface{}) (error, int) {
+	return m.err, http.StatusOK
+}
+
 func (m *requestConditionalMiddleware) Name() string {
 	return "requestConditionalMiddleware"
 }
@@ -59,6 +77,63 @@ func (m *requestConditionalMiddleware) Name() string {
 func (m *requestConditionalMiddleware) ProcessRequest(http.ResponseWriter, *http.Request, interface{}) (error, int) {
 	m.calls++
 	return nil, http.StatusOK
+}
+
+func TestTraceMiddlewareProcessRequestSpanStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus codes.Code
+	}{
+		{
+			name:       "successful response sentinel",
+			err:        ErrResponseSucceed,
+			wantStatus: codes.Unset,
+		},
+		{
+			name:       "wrapped successful response sentinel",
+			err:        fmt.Errorf("plugin response: %w", ErrResponseSucceed),
+			wantStatus: codes.Unset,
+		},
+		{
+			name:       "plugin error response sentinel",
+			err:        fmt.Errorf("%w: status 400", ErrResponseErrorSent),
+			wantStatus: codes.Error,
+		},
+		{
+			name:       "regular error",
+			err:        errors.New("middleware failed"),
+			wantStatus: codes.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+			t.Cleanup(func() {
+				require.NoError(t, tracerProvider.Shutdown(context.Background()))
+			})
+
+			ctx, span := tracerProvider.Tracer("test").Start(t.Context(), "request")
+			conf := config.Config{}
+			conf.OpenTelemetry.Enabled = true
+			gw := NewGateway(conf, t.Context())
+			mw := TraceMiddleware{TykMiddleware: &traceStatusMiddleware{
+				BaseMiddleware: &BaseMiddleware{Gw: gw},
+				err:            tt.err,
+			}}
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			gotErr, _ := mw.ProcessRequest(httptest.NewRecorder(), req, nil)
+			require.ErrorIs(t, gotErr, tt.err)
+			span.End()
+
+			ended := recorder.Ended()
+			require.Len(t, ended, 1)
+			assert.Equal(t, tt.wantStatus, ended[0].Status().Code)
+		})
+	}
 }
 
 func (m mockStore) SessionDetail(orgID string, keyName string, hashed bool) (user.SessionState, bool) {


### PR DESCRIPTION
## Description

Stops `TraceMiddleware.ProcessRequest` from setting the OpenTelemetry span status to `Error` when middleware returns `ErrResponseSucceed`.

`ErrResponseSucceed` means a Go plugin successfully wrote the response and intentionally terminated the middleware chain. The check uses `errors.Is`, so wrapped sentinels are handled too. Real failures—including `ErrResponseErrorSent` for plugin-written 4xx/5xx responses—remain span errors.

## Related Issue

Fixes #8684

## Motivation and Context

Successful plugin-served 2xx responses currently record the correct HTTP status but an OpenTelemetry status of `Error` with the description `response succeed`, inflating tracing error rates.

## How This Has Been Tested

Run in `golang:1.26-bookworm`:

- `go test ./gateway -run '^TestTraceMiddlewareProcessRequestSpanStatus$' -count=1`
- `go test -race ./gateway -run '^TestTraceMiddlewareProcessRequestSpanStatus$' -count=1`
- `go vet ./gateway`

The regression test was first run against the unmodified implementation and failed for direct and wrapped `ErrResponseSucceed`; it passes after the fix.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why